### PR TITLE
[NOMRG] ENH remove I/O overhead for cmd line based solvers

### DIFF
--- a/benchmarks/logreg/datasets/simulated.py
+++ b/benchmarks/logreg/datasets/simulated.py
@@ -10,7 +10,8 @@ class Dataset(BaseDataset):
     parameters = {
         'n_samples, n_features': [
             (100, 5000),
-            (100, 10000)]
+            (100, 10000)
+        ]
     }
 
     def __init__(self, n_samples=100, n_features=5000, random_state=42):

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -52,7 +52,7 @@ def run_one_repetition(objective, solver_class, solver_parameters,
     solver = solver_class(**solver_parameters)
     solver.set_objective(**objective.to_dict())
 
-    delta_t = solver._time_run(sample)
+    delta_t = solver._timed_run(sample)
     beta_hat_i = solver.get_result()
     objective_value = objective(beta=beta_hat_i)
 


### PR DESCRIPTION
Tentative to solve #3 

Proposes to resort to `/usr/bin/time` to estimate subprocess time. This could probably be done directly using https://docs.python.org/3.7/library/resource.html#resource.getrusage but I did not investigate it yet.