### PR TITLE
ENH add FISTA solver for Lasso benchmark

### DIFF
--- a/benchmarks/lasso/solvers/baseline.py
+++ b/benchmarks/lasso/solvers/baseline.py
@@ -7,6 +7,12 @@ from benchopt.base import BaseSolver
 class Solver(BaseSolver):
     name = 'Baseline'
 
+    parameters = {'use_acceleration': [False, True]}
+
+    def __init__(self, use_acceleration):
+        self.use_acceleration = use_acceleration
+        super().__init__()
+
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 
@@ -15,14 +21,21 @@ class Solver(BaseSolver):
     def run(self, n_iter):
         n_features = self.X.shape[1]
         z_hat = np.zeros(n_features)
-        for i in range(n_iter):
+        t_new = 1
+        for _ in range(n_iter):
+            if self.use_acceleration:
+                t_old = t_new
+                t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2
+                z_old = z_hat.copy()
             grad = self.X.T.dot(self.X.dot(z_hat) - self.y)
             z_hat -= 1 / self.L * grad
             z_hat = self.st(z_hat, 1 / self.L * self.lmbd)
+            if self.use_acceleration:
+                z_hat = z_hat + (t_old - 1.) / t_new * (z_hat - z_old)
         self.z_hat = z_hat
 
     def st(self, z, mu):
-        return np.sign(z) * np.maximum(0, abs(z) - mu)
+        return np.sign(z) * np.maximum(0, np.abs(z) - mu)
 
     def get_result(self):
         return self.z_hat

--- a/benchmarks/lasso/solvers/baseline.py
+++ b/benchmarks/lasso/solvers/baseline.py
@@ -9,10 +9,6 @@ class Solver(BaseSolver):
 
     parameters = {'use_acceleration': [False, True]}
 
-    def __init__(self, use_acceleration):
-        self.use_acceleration = use_acceleration
-        super().__init__()
-
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 


### PR DESCRIPTION
I am doing something wrong since use_acceleration is never set to True:
```
(base) ➜  benchOpt git:(add_fista) ✗ benchopt run lasso -s baseline -n 1 -d boston
Boston
|--Lasso regression(reg=0.05)
|----Baseline(use_acceleration=false): done               
|----Baseline(use_acceleration=false): done               
|--Lasso regression(reg=0.1)
|----Baseline(use_acceleration=false): done               
|----Baseline(use_acceleration=false): done               
|--Lasso regression(reg=0.5)
|----Baseline(use_acceleration=false): done               
|----Baseline(use_acceleration=false): done    
```

We can also discuss the naming, I would go for `w` instead of  `z_hat`
 (same as in sklearn),  and I'm not very satisfied with `use_acceleration` either
