### PR TITLE
CLN update Lasso:Baseline solver for a better doc

### DIFF
--- a/benchmarks/lasso/solvers/baseline.py
+++ b/benchmarks/lasso/solvers/baseline.py
@@ -5,33 +5,34 @@ from benchopt.base import BaseSolver
 
 
 class Solver(BaseSolver):
-    name = 'Baseline'
+    name = 'Baseline'  # proximal gradient, eventually accelerated
 
+    # any parameter defined here is accessible as a class attribute
     parameters = {'use_acceleration': [False, True]}
 
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 
-        self.L = np.linalg.norm(self.X.dot(self.X.T), ord=2)
+        self.L = np.linalg.norm(self.X, ord=2) ** 2
 
     def run(self, n_iter):
         n_features = self.X.shape[1]
-        z_hat = np.zeros(n_features)
+        w = np.zeros(n_features)
         t_new = 1
         for _ in range(n_iter):
             if self.use_acceleration:
                 t_old = t_new
                 t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2
-                z_old = z_hat.copy()
-            grad = self.X.T.dot(self.X.dot(z_hat) - self.y)
-            z_hat -= 1 / self.L * grad
-            z_hat = self.st(z_hat, 1 / self.L * self.lmbd)
+                w_old = w.copy()
+            grad = self.X.T.dot(self.X.dot(w) - self.y)
+            w -= 1 / self.L * grad
+            w = self.st(w, 1 / self.L * self.lmbd)
             if self.use_acceleration:
-                z_hat = z_hat + (t_old - 1.) / t_new * (z_hat - z_old)
-        self.z_hat = z_hat
+                w = w + (t_old - 1.) / t_new * (w - w_old)
+        self.w = w
 
-    def st(self, z, mu):
-        return np.sign(z) * np.maximum(0, np.abs(z) - mu)
+    def st(self, w, mu):
+        return np.sign(w) * np.maximum(0, np.abs(w) - mu)
 
     def get_result(self):
-        return self.z_hat
+        return self.w

--- a/benchmarks/lasso/solvers/baseline.py
+++ b/benchmarks/lasso/solvers/baseline.py
@@ -32,7 +32,8 @@ class Solver(BaseSolver):
         self.w = w
 
     def st(self, w, mu):
-        return np.sign(w) * np.maximum(0, np.abs(w) - mu)
+        w -= np.clip(w, -mu, mu)
+        return w
 
     def get_result(self):
         return self.w

--- a/benchmarks/lasso/solvers/baseline.py
+++ b/benchmarks/lasso/solvers/baseline.py
@@ -13,9 +13,9 @@ class Solver(BaseSolver):
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 
-        self.L = np.linalg.norm(self.X, ord=2) ** 2
-
     def run(self, n_iter):
+        L = np.linalg.norm(self.X, ord=2) ** 2
+
         n_features = self.X.shape[1]
         w = np.zeros(n_features)
         t_new = 1
@@ -25,10 +25,10 @@ class Solver(BaseSolver):
                 t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2
                 w_old = w.copy()
             grad = self.X.T.dot(self.X.dot(w) - self.y)
-            w -= 1 / self.L * grad
-            w = self.st(w, 1 / self.L * self.lmbd)
+            w -= grad / L
+            w = self.st(w, self.lmbd / L)
             if self.use_acceleration:
-                w = w + (t_old - 1.) / t_new * (w - w_old)
+                w += (t_old - 1.) / t_new * (w - w_old)
         self.w = w
 
     def st(self, w, mu):

--- a/doc/how.rst
+++ b/doc/how.rst
@@ -61,7 +61,7 @@ from the union of the data and the objective parameters.
 
 You can define your custom solver.
 
-Example of hand written solver
+Example of hand written and parametrized solver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using a hand written solver:

--- a/doc/how.rst
+++ b/doc/how.rst
@@ -62,7 +62,7 @@ from the union of the data and the objective parameters.
 You can define your custom solver.
 
 Example of hand written and parametrized solver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Using a hand written solver:
 


### PR DESCRIPTION
-  added a comment to mention that parameters defined in `parameters` can be accessed without being set in an init.
-  replaced z by w
- avoided computation of X.T @ X for Lipschitz constant (costly) 