### PR TITLE
FIX install link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install
 This package can be install through `pip` using
 
 ```
-$ pip install https://github.com/benchopt/benchopt
+$ pip install git+https://github.com/benchopt/benchopt
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install
 This package can be install through `pip` using
 
 ```
-$ pip install git+https://github.com/benchopt/benchopt
+$ pip install -U https://api.github.com/repos/benchopt/benchOpt/zipball/master
 ```
 
 Usage


### PR DESCRIPTION
Simple fix, otherwise you get:
```
$ pip install https://github.com/benchopt/benchopt                                                                               ~
Collecting https://github.com/benchopt/benchopt
  Downloading https://github.com/benchopt/benchopt
     - 105 kB 1.4 MB/s
  ERROR: Cannot unpack file /tmp/pip-unpack-75wvkp8v/benchopt (downloaded from /tmp/pip-req-build-9m5j3we2, content-type: text/html; charset=utf-8); cannot detect archive format
ERROR: Cannot determine archive format of /tmp/pip-req-build-9m5j3we2
```