### PR TITLE
ENH Add install and import failure message

### DIFF
--- a/benchmarks/logreg/solvers/liblinear.py
+++ b/benchmarks/logreg/solvers/liblinear.py
@@ -1,5 +1,9 @@
 import pandas as pd
 from benchopt.base import CommandLineSolver
+from benchopt.util import safe_import
+
+with safe_import() as solver_import:
+    pass
 
 
 class Solver(CommandLineSolver):

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -9,6 +9,7 @@ from .util import bash_install_in_env
 from .util import pip_uninstall_in_env
 from .util import check_import_solver
 from .class_property import classproperty
+from .config import PRINT_INSTALL_ERROR
 
 
 # Possible sampling strategies
@@ -125,12 +126,18 @@ class DependenciesMixin:
         if force or not cls.is_installed(env_name=env_name):
             print(f"Installing {cls.name} in {env_name}:...",
                   end='', flush=True)
-            if cls.install_cmd == 'pip':
-                pip_install_in_env(*cls.requirements_install,
-                                   env_name=env_name)
-            elif cls.install_cmd == 'bash':
-                bash_install_in_env(cls.install_script, env_name=env_name)
-            print(" done")
+            try:
+                if cls.install_cmd == 'pip':
+                    pip_install_in_env(*cls.requirements_install,
+                                       env_name=env_name)
+                elif cls.install_cmd == 'bash':
+                    bash_install_in_env(cls.install_script, env_name=env_name)
+                print(" done")
+            except Exception as exception:
+                if PRINT_INSTALL_ERROR:
+                    raise exception
+                else:
+                    print(" failed")
         return cls.is_installed(env_name=env_name)
 
     @classmethod

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -123,7 +123,8 @@ class DependenciesMixin:
         if force:
             cls.uninstall(env_name=env_name)
 
-        if force or not cls.is_installed(env_name=env_name):
+        is_installed = cls.is_installed(env_name=env_name)
+        if force or not is_installed:
             print(f"Installing {cls.name} in {env_name}:...",
                   end='', flush=True)
             try:
@@ -132,13 +133,18 @@ class DependenciesMixin:
                                        env_name=env_name)
                 elif cls.install_cmd == 'bash':
                     bash_install_in_env(cls.install_script, env_name=env_name)
-                print(" done")
+
             except Exception as exception:
                 if RAISE_INSTALL_ERROR:
                     raise exception
-                else:
-                    print(" failed")
-        return cls.is_installed(env_name=env_name)
+
+            is_installed = cls.is_installed(env_name=env_name)
+            if is_installed:
+                print(" done")
+            else:
+                print(" failed")
+
+        return is_installed
 
     @classmethod
     def uninstall(cls, env_name=None):

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -9,7 +9,7 @@ from .util import bash_install_in_env
 from .util import pip_uninstall_in_env
 from .util import check_import_solver
 from .class_property import classproperty
-from .config import PRINT_INSTALL_ERROR
+from .config import RAISE_INSTALL_ERROR
 
 
 # Possible sampling strategies
@@ -134,7 +134,7 @@ class DependenciesMixin:
                     bash_install_in_env(cls.install_script, env_name=env_name)
                 print(" done")
             except Exception as exception:
-                if PRINT_INSTALL_ERROR:
+                if RAISE_INSTALL_ERROR:
                     raise exception
                 else:
                     print(" failed")

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -12,7 +12,7 @@ config.read(CONFIG_FILE_LOCATION)
 DEFAULT_GLOBAL = {
     'debug': False,
     'allow_install': False,
-    'print_install_error': False,
+    'raise_install_error': False,
     'venv_dir': './.venv/',
     'cache_dir': '.',
     'data_dir': './data/'
@@ -64,4 +64,4 @@ class BooleanFlag(object):
 
 DEBUG = BooleanFlag('debug')
 ALLOW_INSTALL = BooleanFlag('allow_install')
-PRINT_INSTALL_ERROR = BooleanFlag('print_install_error')
+RAISE_INSTALL_ERROR = BooleanFlag('raise_install_error')

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -51,7 +51,7 @@ def run_repetition(objective, solver_class, solver_parameters, meta, sample):
 
     # check if the module caught a failed import
     module = importlib.import_module(solver_class.__module__)
-    if module.solver_import.failed_import:
+    if hasattr(module, 'solver_import') and module.solver_import.failed_import:
         raise ImportError(
             f"Failure during import in {solver_class.__module__}.")
 
@@ -121,7 +121,7 @@ def run_one_solver(objective, solver_class, solver_parameters,
 
     # check if the module caught a failed import
     module = importlib.import_module(solver_class.__module__)
-    if module.solver_import.failed_import:
+    if hasattr(module, 'solver_import') and module.solver_import.failed_import:
         status = colorify("failed import", RED)
         print(f"{tag} {status}".ljust(80))
         return curve

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -122,7 +122,7 @@ def run_one_solver(objective, solver_class, solver_parameters,
     # check if the module caught a failed import
     module = importlib.import_module(solver_class.__module__)
     if module.solver_import.failed_import:
-        status = colorify("failed import", YELLOW)
+        status = colorify("failed import", RED)
         print(f"{tag} {status}".ljust(80))
         return curve
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,4 +1,5 @@
 import time
+import importlib
 import numpy as np
 import pandas as pd
 from joblib import Memory
@@ -47,6 +48,12 @@ def colorify(message, color=BLUE):
 ##################################
 @mem.cache
 def run_repetition(objective, solver_class, solver_parameters, meta, sample):
+
+    # check if the module catched a failed import
+    module = importlib.import_module(solver_class.__module__)
+    if module.solver_import.failed_import:
+        raise ImportError(
+            f"Failure during import in {solver_class.__module__}.")
 
     # Instantiate solver here to avoid having weird pickling errors
     solver = solver_class(**solver_parameters)
@@ -111,6 +118,13 @@ def run_one_solver(objective, solver_class, solver_parameters,
     def progress(id_sample, delta):
         return max(id_sample / max_samples,
                    np.log(max(delta, eps)) / np.log(eps))
+
+    # check if the module catched a failed import
+    module = importlib.import_module(solver_class.__module__)
+    if module.solver_import.failed_import:
+        status = colorify("failed import", YELLOW)
+        print(f"{tag} {status}".ljust(80))
+        return curve
 
     id_sample = 0
     sample = 1

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -49,7 +49,7 @@ def colorify(message, color=BLUE):
 @mem.cache
 def run_repetition(objective, solver_class, solver_parameters, meta, sample):
 
-    # check if the module catched a failed import
+    # check if the module caught a failed import
     module = importlib.import_module(solver_class.__module__)
     if module.solver_import.failed_import:
         raise ImportError(
@@ -119,7 +119,7 @@ def run_one_solver(objective, solver_class, solver_parameters,
         return max(id_sample / max_samples,
                    np.log(max(delta, eps)) / np.log(eps))
 
-    # check if the module catched a failed import
+    # check if the module caught a failed import
     module = importlib.import_module(solver_class.__module__)
     if module.solver_import.failed_import:
         status = colorify("failed import", YELLOW)

--- a/benchopt/util.py
+++ b/benchopt/util.py
@@ -316,9 +316,16 @@ def delete_venv(env_name):
 def install_solvers(solvers, forced_solvers=None, env_name=None):
     """Install the listed solvers if needed."""
 
+    successes = []
     for solver in solvers:
         force_install = solver.name.lower() in forced_solvers
-        solver.install(env_name=env_name, force=force_install)
+        success = solver.install(env_name=env_name, force=force_install)
+        successes.append(success)
+
+    if not all(successes):
+        print("Some solvers were not successfully installed, and will thus be "
+              "ignored. Use 'export BENCHOPT_RAISE_INSTALL_ERROR=true' to "
+              "stop at any installation failure and print the traceback.")
 
 
 def install_required_datasets(benchmark, dataset_names, env_name=None):

--- a/benchopt/util.py
+++ b/benchopt/util.py
@@ -10,7 +10,7 @@ import subprocess
 from importlib import import_module
 
 from .config import get_global_setting
-from .config import DEBUG, ALLOW_INSTALL, PRINT_INSTALL_ERROR
+from .config import DEBUG, ALLOW_INSTALL, RAISE_INSTALL_ERROR
 
 
 # Load global setting
@@ -338,8 +338,8 @@ class safe_import:
         self.record = warnings.catch_warnings(record=True)
 
     def __enter__(self):
-        # Catch the import warning except if install error are printed.
-        if not PRINT_INSTALL_ERROR:
+        # Catch the import warning except if install errors are raised.
+        if not RAISE_INSTALL_ERROR:
             self.record.__enter__()
         return self
 
@@ -354,7 +354,7 @@ class safe_import:
             # Prevent the error propagation
             silence_error = True
 
-        if not PRINT_INSTALL_ERROR:
+        if not RAISE_INSTALL_ERROR:
             self.record.__exit__(exc_type, exc_value, traceback)
 
         # Returning True in __exit__ prevent error propagation.

--- a/benchopt/util.py
+++ b/benchopt/util.py
@@ -324,7 +324,7 @@ def install_solvers(solvers, forced_solvers=None, env_name=None):
 
     if not all(successes):
         print("Some solvers were not successfully installed, and will thus be "
-              "ignored. Use 'export BENCHOPT_RAISE_INSTALL_ERROR=true' to "
+              "ignored. Use 'export BENCHO_RAISE_INSTALL_ERROR=true' to "
               "stop at any installation failure and print the traceback.")
 
 

--- a/benchopt/util.py
+++ b/benchopt/util.py
@@ -118,8 +118,6 @@ def pip_install_in_env(*packages, env_name=None):
                          "To allow this, set BENCHO_ALLOW_INSTALL=True.")
     cmd = PIP_INSTALL_CMD.format(packages=' '.join(packages))
     error_msg = f"Failed to pip install packages {packages}\nError:{{output}}"
-    if not PRINT_INSTALL_ERROR:
-        error_msg = None
     _run_bash_in_env(cmd, env_name=env_name,
                      raise_on_error=error_msg)
 

--- a/benchopt/util.py
+++ b/benchopt/util.py
@@ -323,9 +323,11 @@ def install_solvers(solvers, forced_solvers=None, env_name=None):
         successes.append(success)
 
     if not all(successes):
-        print("Some solvers were not successfully installed, and will thus be "
-              "ignored. Use 'export BENCHO_RAISE_INSTALL_ERROR=true' to "
-              "stop at any installation failure and print the traceback.")
+        warnings.warn(
+            "Some solvers were not successfully installed, and will thus be "
+            "ignored. Use 'export BENCHO_RAISE_INSTALL_ERROR=true' to "
+            "stop at any installation failure and print the traceback.",
+            UserWarning)
 
 
 def install_required_datasets(benchmark, dataset_names, env_name=None):

--- a/conftest.py
+++ b/conftest.py
@@ -4,7 +4,7 @@ from benchopt.config import DEFAULT_GLOBAL
 
 
 DEFAULT_GLOBAL['debug'] = True
-DEFAULT_GLOBAL['print_install_error'] = True
+DEFAULT_GLOBAL['raise_install_error'] = True
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Solves #27

Instead of not raising an error in `pip_install_in_env` when `PRINT_INSTALL_ERROR=False`, now the error is always raised, but caught in `DependenciesMixin.install`.

In a second part of this PR, in ` benchopt/runner.py`, it prevents the solver from running if the module caught an ImportError in `safe_import`.