### PR TITLE
ENH add statsmodels solver for lasso

### DIFF
--- a/benchmarks/lasso/solvers/statsmodels.py
+++ b/benchmarks/lasso/solvers/statsmodels.py
@@ -1,0 +1,30 @@
+from benchopt.base import BaseSolver
+from benchopt.util import safe_import
+
+
+with safe_import() as solver_import:
+    import statsmodels.api as sm
+
+
+class Solver(BaseSolver):
+    name = 'statsmodels'
+
+    install_cmd = 'pip'
+    requirements = ['statsmodels']
+    requirements_import = ['statsmodels']
+
+    def set_objective(self, X, y, lmbd):
+        self.X, self.y, self.lmbd = X, y, lmbd
+        self.n_samples = self.X.shape[0]
+        self.clf = sm.GLS(y, X, hasconst=False)
+
+    def run(self, n_iter):
+
+        self.results = self.clf.fit_regularized(alpha=self.lmbd / self.n_samples,
+                                                method='elastic_net',
+                                                L1_wt=1, maxiter=n_iter,
+                                                cnvrg_tol=1e-14,
+                                                zero_tol=1e-14)
+
+    def get_result(self):
+        return self.results.params.flatten()

--- a/benchmarks/lasso/solvers/statsmodels.py
+++ b/benchmarks/lasso/solvers/statsmodels.py
@@ -11,7 +11,6 @@ class Solver(BaseSolver):
 
     install_cmd = 'pip'
     requirements = ['statsmodels']
-    requirements_import = ['statsmodels']
 
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd


### PR DESCRIPTION
I have added a comparison with `statsmodels` (now having lasso, enet, etc.) for versions 0.11.1
Results are in favor of `sklearn`. 

![sklearn_vs_statsmodels_boston_lasso](https://user-images.githubusercontent.com/4193992/80927061-948df500-8d9b-11ea-8cc5-bdd92ef08b23.png)
