### PR TITLE
Capture stdout in scipy FORTRAN solver

### DIFF
--- a/benchmarks/nnls/solvers/nnls_scipy.py
+++ b/benchmarks/nnls/solvers/nnls_scipy.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from benchopt.base import BaseSolver
 from benchopt.util import safe_import_context
+from benchopt.utils.stream_redirection import SuppressStd
 
 with safe_import_context() as import_ctx:
     from scipy.optimize.__nnls import nnls
@@ -25,8 +26,14 @@ class Solver(BaseSolver):
         zz = np.zeros((m,))
         index = np.zeros((n,), dtype=int)
 
-        self.w, _, _ = \
-            nnls(self.X, m, n, self.y, w, zz, index, n_iter)
+        out = SuppressStd()
+        try:
+            with out:
+                self.w, _, _ = \
+                    nnls(self.X, m, n, self.y, w, zz, index, n_iter)
+        except BaseException:
+            print(out.output)
+            raise
 
     def get_result(self):
         return self.w


### PR DESCRIPTION
Uses https://github.com/benchopt/benchOpt/issues/31#issuecomment-684972791 to capture stdout in scipy FORTRAN solver.

Before:
```
Simulated[n_samples=100,n_features=10000]
|--Non negative least squares[fit_intercept=false]
|----Baseline[use_acceleration=false]: done               
|----Baseline[use_acceleration=true]: done                
|----Cd: done                                             
|----Scipy:   0.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   0.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   0.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   0.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   0.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   1.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   1.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   1.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   1.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   1.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   2.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   2.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   2.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   2.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   2.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   3.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   3.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   3.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   3.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   3.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   4.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   4.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   4.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   4.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   4.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   5.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   5.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   5.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   5.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   5.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   6.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   6.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   6.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   6.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   6.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   7.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   7.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   7.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   7.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   7.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   8.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   8.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   8.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   8.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   8.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:   9.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:   9.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:   9.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:   9.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:   9.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:  10.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:  10.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:  10.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:  10.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:  10.0% (4 / 5)
 NNLS quitting on iteration count.
|----Scipy:  11.0% (0 / 5)
 NNLS quitting on iteration count.
|----Scipy:  11.0% (1 / 5)
 NNLS quitting on iteration count.
|----Scipy:  11.0% (2 / 5)
 NNLS quitting on iteration count.
|----Scipy:  11.0% (3 / 5)
 NNLS quitting on iteration count.
|----Scipy:  11.0% (4 / 5)
 NNLS quitting on iteration count.
```

After:
```
Simulated[n_samples=100,n_features=10000]
|--Non negative least squares[fit_intercept=false]
|----Baseline[use_acceleration=false]: done               
|----Baseline[use_acceleration=true]: done                
|----Cd: done                                             
|----Scipy: done                                          
|----Sklearn: done 
```