### PR TITLE
ENH install hook / JuliaSover / FIX cache

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -163,6 +163,7 @@ class DependenciesMixin:
             print(f"Installing {cls.name} in {env_name}:...",
                   end='', flush=True)
             try:
+                cls._pre_install_hook(env_name=env_name)
                 if cls.install_cmd == 'conda':
                     install_in_conda_env(*cls.requirements, env_name=env_name,
                                          force=force)
@@ -172,6 +173,7 @@ class DependenciesMixin:
                         cls.install_script
                     )
                     shell_install_in_conda_env(install_file, env_name=env_name)
+                cls._post_install_hook(env_name=env_name)
 
             except Exception as exception:
                 if RAISE_INSTALL_ERROR:
@@ -184,6 +186,16 @@ class DependenciesMixin:
                 print(" failed")
 
         return is_installed
+
+    @classmethod
+    def _pre_install_hook(cls, env_name=None):
+        """Hook called before installing dependencies with conda or pip."""
+        pass
+
+    @classmethod
+    def _post_install_hook(cls, env_name=None):
+        """Hook called after installing dependencies with conda or pip."""
+        pass
 
 
 class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -83,6 +83,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
     if local:
         run_benchmark(
             benchmark, solver_names, forced_solvers,
+
             dataset_names=dataset_names, objective_filters=objective_filters,
             max_runs=max_runs, n_repetitions=n_repetitions, timeout=timeout,
             plot_result=not no_plot

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -380,7 +380,9 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                             scale=scale
                         )
 
-                        force = is_matched(str(solver), forced_solvers)
+                        force = (forced_solvers is not None
+                                 and len(forced_solvers) > 0
+                                 and is_matched(str(solver), forced_solvers))
                         run_statistics.extend(run_one_solver(
                             benchmark=benchmark, objective=objective,
                             solver=solver, meta=meta, max_runs=max_runs,

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -95,7 +95,8 @@ def run_one_repetition(objective, solver, meta, stop_val):
 
 
 def run_one_stop_val(benchmark, objective, solver, meta, stop_val,
-                     n_repetitions, deadline, progress_str=None, force=False):
+                     n_repetitions, deadline=None, progress_str=None,
+                     force=False):
     """Run all repetitions of the solver for a value of stopping criterion.
 
     Parameters
@@ -156,7 +157,7 @@ def run_one_stop_val(benchmark, objective, solver, meta, stop_val,
         curve.append(cost)
         current_objective.append(objective_value)
 
-        if deadline < time.time():
+        if deadline is not None and deadline < time.time():
             # Reached the timeout so stop the computation here
             break
 
@@ -204,7 +205,8 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
     # Create a Memory object to cache the computations in the benchmark folder
     mem = Memory(location=benchmark, verbose=0)
     run_one_stop_val_cached = mem.cache(
-        run_one_stop_val, ignore=['deadline', 'benchmark']
+        run_one_stop_val,
+        ignore=['deadline', 'benchmark', 'force', 'progress_str']
     )
 
     # Get the solver's name

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/julia_pgd.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/julia_pgd.py
@@ -1,25 +1,23 @@
 from pathlib import Path
-from benchopt.base import BaseSolver
 from benchopt.util import safe_import_context
 
+from benchopt.utils.julia_helpers import JuliaSolver
+from benchopt.utils.julia_helpers import get_jl_interpreter
+from benchopt.utils.julia_helpers import assert_julia_installed
+
 with safe_import_context() as import_ctx:
-    from benchopt.utils.julia_helpers import get_jl_interpreter
+    assert_julia_installed()
 
 
 # File containing the function to be called from julia
 JULIA_SOLVER_FILE = str(Path(__file__).with_suffix('.jl'))
 
 
-class Solver(BaseSolver):
+class Solver(JuliaSolver):
 
     # Config of the solver
     name = 'Julia-PGD'
     stop_strategy = 'iteration'
-    support_sparse = False
-
-    # Requirements
-    install_cmd = 'conda'
-    requirements = ['julia', 'pip:julia']
 
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd

--- a/benchopt/utils/misc.py
+++ b/benchopt/utils/misc.py
@@ -1,0 +1,23 @@
+
+
+from pip._internal.operations.freeze import FrozenRequirement
+from pip._internal.utils.misc import get_installed_distributions
+
+
+def get_benchopt_requirement_line():
+    """Specification for pip requirement to install benchopt in conda env.
+
+    Find out how benchopt where installed so we can install the same version
+    even if it was installed in develop mode. This requires pip version >= 20.1
+    """
+
+    # If benchopt is installed in editable mode, get the module path to install
+    # it directly from the folder. Else, install it correctly even if it is
+    # installed with an url.
+    dist = [t for t in get_installed_distributions()
+            if t.project_name == 'benchopt'][0]
+    req = FrozenRequirement.from_dist(dist)
+    if req.editable:
+        return f'-e {dist.module_path}'
+
+    return str(req)

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -18,11 +18,3 @@ python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "from joblib import cpu_count; print('%d CPUs' % cpu_count())"
 pip list
 pip install -e .
-
-
-# There is an ungoing issue with compat between libgit2 and julia which makes
-# the auto install of julia solver fails when cloning the General repository
-# from julia. To avoid this, we clone this on the system directly.
-# See https://github.com/JuliaLang/julia/issues/33111
-git clone https://github.com/JuliaRegistries/General.git \
-        $HOME/.julia/registries/General


### PR DESCRIPTION
Add pre/post install hook and use them to make sure julia is correctly installed.

This is to avoid having to clone manually `.julia/registries/General` in every repo, as the failures in benchopt/benchmark_logreg_l2#1 .
This requires changing a bit the API for Julia solver as it should now derive from `JuliaSolver` and the proper preamble is now:

```python
from benchopt.utils.julia_helpers import JuliaSolver
from benchopt.utils.julia_helpers import get_jl_interpreter
from benchopt.utils.julia_helpers import assert_julia_installed

with safe_import_context() as import_ctx:
    assert_julia_installed()
```