### PR TITLE
ENH raise a warning when unmatched benchopt versions

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,10 +1,14 @@
 ### 1.1 -- in progress
 
+- Add a `--version` option in benchopt and check that the version installed
+  in conda subenv match the one in the calling process (#83)
+
 
 ### 1.0 - 2020-09-25 - Release highlights
 
-Provide a command line interface for benchmarking optimisation algorithm implementations:
-- `benchopt run` to run the benchmarks
-- `benchopt plot` to display the results
-- `benchopt test` to test that a benchmark folder is correctly structured.
+- Provide a command line interface for benchmarking optimisation algorithm
+  implementations:
+  - `benchopt run` to run the benchmarks
+  - `benchopt plot` to display the results
+  - `benchopt test` to test that a benchmark folder is correctly structured.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,4 +24,7 @@ recursive-include benchopt/tests/test_benchmarks *.R
 recursive-include benchopt/tests/test_benchmarks *.jl
 recursive-include benchopt/tests/test_benchmarks *.py
 
+# Exclude joblib folders in dummy_benchmark
+prune benchopt/tests/test_benchmarks/dummy_benchmark/joblib
+
 exclude .mailmap

--- a/benchopt/__init__.py
+++ b/benchopt/__init__.py
@@ -1,4 +1,5 @@
 from .runner import run_benchmark
 
 __version__ = '1.1.0.dev0'
-__all__ = ['run_benchmark']
+
+__all__ = ['run_benchmark', '__version__']

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -2,6 +2,7 @@ import click
 import pandas as pd
 from pathlib import Path
 
+from benchopt import __version__
 from benchopt import run_benchmark
 from benchopt.viz import plot_benchmark
 
@@ -21,10 +22,21 @@ BENCHMARK_TEST_FILE = Path(__file__).parent / 'tests' / 'test_benchmarks.py'
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.group(context_settings=CONTEXT_SETTINGS)
-def main(prog_name='benchopt'):
+@click.group(context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click.option('--version', '-v', is_flag=True, help='Print version')
+@click.pass_context
+def main(ctx, prog_name='benchopt', version=False):
     """Command-line interface to benchOpt"""
-    pass
+    if ctx.invoked_subcommand is None:
+        if not version:
+            print(main.get_help(ctx))
+        else:
+            print(__version__)
+    else:
+        if version:
+            raise click.BadOptionUsage(
+                '--version',
+                '--version should only be used without a sub-command.')
 
 
 @main.command(

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -27,17 +27,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.pass_context
 def main(ctx, prog_name='benchopt', version=False):
     """Command-line interface to benchOpt"""
+    if version:
+        print(__version__)
+        raise SystemExit(0)
     if ctx.invoked_subcommand is None:
-        if not version:
-            print(main.get_help(ctx))
-        else:
-            print(__version__)
-    else:
-        if version:
-            raise click.BadOptionUsage(
-                '--version',
-                '--version should only be used without a sub-command.'
-            )
+        print(main.get_help(ctx))
 
 
 @main.command(

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -36,7 +36,8 @@ def main(ctx, prog_name='benchopt', version=False):
         if version:
             raise click.BadOptionUsage(
                 '--version',
-                '--version should only be used without a sub-command.')
+                '--version should only be used without a sub-command.'
+            )
 
 
 @main.command(

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,10 @@ from setuptools import find_packages, setup
 with open('benchopt/__init__.py') as f:
     infos = f.readlines()
 for line in infos:
-    if "__version__" in line:
+    if "__version__ =" in line:
         match = re.search(r"__version__ = '([^']*)'", line)
         __version__ = match.groups()[0]
+        break
 
 
 DISTNAME = 'benchopt'


### PR DESCRIPTION
If the version of benchopt in a conda env is different from the one in the main process, raise a warning.

TODO:
- [x] add `--version` option in main command
- [x] check version in conda env and raise warning if discrepancy