### PR TITLE
ENH add option to launch a debugger on error

### DIFF
--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -77,9 +77,16 @@ def main(ctx, prog_name='benchopt', version=False):
 @click.option('--no-plot',
               is_flag=True,
               help="If this flag is set, do not plot the results.")
+@click.option('--pdb',
+              is_flag=True,
+              help="Launch a debugger if there is an Error.")
+@click.option('--env-name', '-e', 'env_name', metavar="<env_name>", type=str,
+              help="Specify the environment in which the benchmark need to run"
+              " if it is not local.")
 def run(benchmark, solver_names, forced_solvers, dataset_names,
         objective_filters, max_runs, n_repetitions, timeout,
-        recreate=False, local=True, no_plot=False):
+        recreate=False, local=True, no_plot=False, pdb=False,
+        env_name=None):
     """Run a benchmark in a separate conda env where the deps will be installed
     """
 
@@ -90,15 +97,16 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
     if local:
         run_benchmark(
             benchmark, solver_names, forced_solvers,
-
-            dataset_names=dataset_names, objective_filters=objective_filters,
-            max_runs=max_runs, n_repetitions=n_repetitions, timeout=timeout,
-            plot_result=not no_plot
+            dataset_names=dataset_names,
+            objective_filters=objective_filters,
+            max_runs=max_runs, n_repetitions=n_repetitions,
+            timeout=timeout, plot_result=not no_plot, pdb=pdb
         )
         return
 
-    benchmark_name = Path(benchmark).resolve().name
-    env_name = f"benchopt_{benchmark_name}"
+    if env_name is None:
+        benchmark_name = Path(benchmark).resolve().name
+        env_name = f"benchopt_{benchmark_name}"
     create_conda_env(env_name, recreate=recreate)
 
     # installed required datasets
@@ -121,6 +129,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
         rf"{solvers_option} {forced_solvers_option} "
         rf"{datasets_option} {objective_option} "
         rf"{'--no-plot' if no_plot else ''} "
+        rf"{'--pdb' if pdb else ''} "
         .replace('\\', '\\\\')
     )
     raise SystemExit(_run_shell_in_conda_env(

--- a/benchopt/utils/colorify.py
+++ b/benchopt/utils/colorify.py
@@ -1,0 +1,20 @@
+"Helper function for colored terminal outputs"
+
+
+BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(30, 38)
+
+
+def colorify(message, color=BLUE):
+    """Change color of the standard output.
+
+    Parameters
+    ----------
+    message : str
+        The message to color.
+
+    Returns
+    -------
+    color_message : str
+        The colored message to be displayed in terminal.
+    """
+    return ("\033[1;%dm" % color) + message + "\033[0m"

--- a/benchopt/utils/pdb_helpers.py
+++ b/benchopt/utils/pdb_helpers.py
@@ -1,0 +1,42 @@
+"A context manager to handle exception with option to open a debugger."
+from contextlib import contextmanager
+
+
+from .colorify import colorify, RED
+from ..config import get_global_setting
+
+try:
+    from ipdb import post_mortem
+except ImportError:
+    from pdb import post_mortem
+
+
+# Get config values
+DEBUG = get_global_setting('debug')
+
+
+@contextmanager
+def exception_handler(tag=None, pdb=False):
+    """Context manager to handle exception with option to open a debugger.
+
+    Parameter
+    ---------
+    tag: str
+        Name to display before outputing error in red.
+    pdb: bool
+        If set to True, open a debugger if an error is raised.
+    """
+    try:
+        yield
+    except BaseException:
+        status = colorify("error", RED)
+        print(f"{tag} {status}".ljust(80))
+
+        if pdb:
+            post_mortem()
+
+        if DEBUG:
+            raise
+        else:
+            import traceback
+            traceback.print_exc()


### PR DESCRIPTION
add a `--pdb` option to the `run` command so a debugger (`ipdb` if present else `pdb`) is open on error for the solver.
This should prove helpful to develop new solvers.