### PR TITLE
ENH add benchopt publish command

### DIFF
--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -165,7 +165,7 @@ def plot(benchmark, filename=None, kinds=('suboptimality_curve',),
     benchmark = Benchmark(benchmark)
     result_filename = benchmark.get_result_file(filename)
 
-    # Plot he results.
+    # Plot the results.
     df = pd.read_csv(result_filename)
     plot_benchmark(df, benchmark, kinds=kinds, display=not no_display)
 

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -10,29 +10,30 @@ config = configparser.ConfigParser()
 config.read(CONFIG_FILE_LOCATION)
 
 
-DEFAULT_GLOBAL = {
+DEFAULT_GLOBAL_CONFIG = {
     'debug': False,
     'allow_install': False,
     'raise_install_error': False,
+    'github_token': None,
     'data_dir': './data/',
     'shell': os.environ.get('SHELL', 'bash')
 }
 
-DEFAULT_BENCHMARK = {
+DEFAULT_BENCHMARK_CONFIG = {
     'plots': "'suboptimality_curve'",
     'name': None
 }
 
 
 def get_global_setting(name):
-    assert name in DEFAULT_GLOBAL, f"Unknown config key {name}"
+    assert name in DEFAULT_GLOBAL_CONFIG, f"Unknown config key {name}"
 
     # Get the name of the environment variable associated to this setting
     env_var_name = f"BENCHO_{name.upper()}"
 
-    if isinstance(DEFAULT_GLOBAL[name], bool):
+    if isinstance(DEFAULT_GLOBAL_CONFIG[name], bool):
         file_setting = config.getboolean('benchopt', name,
-                                         fallback=DEFAULT_GLOBAL[name])
+                                         fallback=DEFAULT_GLOBAL_CONFIG[name])
         setting = os.environ.get(env_var_name, file_setting)
         # convert string 0/1/true/false/yes/no/on/off to boolean
         if isinstance(setting, str):
@@ -47,20 +48,32 @@ def get_global_setting(name):
                 )
                 setting = file_setting
     else:
-        # TODO: get the correct type from DEFAULT_GLOBAL for other types
-        setting = config.get('benchopt', name, fallback=DEFAULT_GLOBAL[name])
+        # TODO: get the correct type from DEFAULT_GLOBAL_CONFIG for other types
+        setting = config.get(
+            'benchopt', name, fallback=DEFAULT_GLOBAL_CONFIG[name]
+        )
         setting = os.environ.get(env_var_name, setting)
 
     return setting
 
 
-def get_benchmark_setting(benchmark, setting_name):
-    setting = config.get(benchmark, setting_name,
-                         fallback=DEFAULT_BENCHMARK[setting_name])
+def get_benchmark_setting(config_file, benchmark_name, setting_name):
+    if not config_file.exists():
+        config_file = CONFIG_FILE_LOCATION
+    config = configparser.ConfigParser()
+    config.read(config_file)
+
+    # retrieve the setting value from the file or fallback to default.
+    setting = config.get(
+        benchmark_name, setting_name,
+        fallback=DEFAULT_BENCHMARK_CONFIG[setting_name]
+    )
+
+    # Parse the setting depending on it name.
     if setting_name in ['plots']:
         setting = re.findall("[\"']([^']+)[\"']", setting)
     elif setting_name == 'name' and setting is None:
-        setting = benchmark
+        setting = benchmark_name
     return setting
 
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -9,7 +9,6 @@ from .utils import product_param
 from .benchmark import is_matched
 from .config import get_global_setting
 from .benchmark import _check_name_lists
-from .utils.files import _get_output_folder
 from .utils.pdb_helpers import exception_handler
 
 from .utils.colorify import colorify
@@ -382,7 +381,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
 
     # Save output in CSV file in the benchmark folder
     timestamp = datetime.now().strftime('%Y-%m-%d_%Hh%Mm%S')
-    output_dir = _get_output_folder(benchmark.benchmark_dir)
+    output_dir = benchmark.get_output_folder()
     save_file = output_dir / f'benchopt_run_{timestamp}.csv'
     df.to_csv(save_file)
     print(colorify(f'Saving result in: {save_file}', GREEN))

--- a/benchopt/tests/conftest.py
+++ b/benchopt/tests/conftest.py
@@ -2,15 +2,15 @@ import uuid
 import pytest
 
 from benchopt.benchmark import Benchmark
-from benchopt.config import DEFAULT_GLOBAL
+from benchopt.config import DEFAULT_GLOBAL_CONFIG
 from benchopt.utils.shell_cmd import delete_conda_env
 from benchopt.utils.shell_cmd import create_conda_env
 
 from benchopt.tests import TEST_BENCHMARK_DIR
 
 
-DEFAULT_GLOBAL['debug'] = True
-DEFAULT_GLOBAL['raise_install_error'] = True
+DEFAULT_GLOBAL_CONFIG['debug'] = True
+DEFAULT_GLOBAL_CONFIG['raise_install_error'] = True
 
 _TEST_ENV_NAME = None
 

--- a/benchopt/utils/files.py
+++ b/benchopt/utils/files.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-
-
-def _get_output_folder(benchmark):
-    output_dir = Path(benchmark) / "outputs"
-    output_dir.mkdir(exist_ok=True)
-    return output_dir

--- a/benchopt/utils/github.py
+++ b/benchopt/utils/github.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from github import Github
+
+
+BENCHOPT_RESULT_REPO = 'benchopt/results'
+
+
+def list_all_files(repo):
+    "List all existing files in a github repo."
+    all_files = []
+    contents = repo.get_contents('')
+    while contents:
+        file_content = contents.pop(0)
+        if file_content.type == "dir":
+            contents.extend(repo.get_contents(file_content.path))
+        else:
+            all_files.append(file_content.path)
+    return all_files
+
+
+def publish_result_file(benchmark_name, file_path, token):
+    "Upload a result file to github for a given benchmark."
+
+    file_to_upload = Path(file_path)
+    if not file_to_upload.exists():
+        raise FileNotFoundError(
+            f"Could not upload file {file_to_upload}."
+        )
+
+    g = Github(login_or_token=token)
+    repo = g.get_repo(BENCHOPT_RESULT_REPO)
+
+    with file_to_upload.open('r') as f:
+        file_content = f.read()
+
+    git_dir = f'outputs/{benchmark_name}'
+    git_path = f'{git_dir}/{file_to_upload.name}'
+    all_files = list_all_files(repo)
+
+    if git_path in all_files:
+        prev_content = repo.get_contents(git_path)
+        if prev_content.decoded_content.decode('utf-8') == file_content:
+            print(f"File {git_path} is already uploaded.")
+            return
+        repo.update_file(git_path, f"RESULT update {git_path}",
+                         file_content, sha=prev_content.sha,
+                         branch="main")
+    else:
+        repo.create_file(git_path, f"RESULT upload {git_path}",
+                         file_content, branch="main")
+    print(f"Uploaded file {file_to_upload.name} in benchopt/results")

--- a/benchopt/utils/pdb_helpers.py
+++ b/benchopt/utils/pdb_helpers.py
@@ -6,12 +6,6 @@ from ..config import get_global_setting
 from .colorify import colorify
 from .colorify import LINE_LENGTH, RED, YELLOW
 
-# Use ipdb if it is available and default to pdb otherwise.
-try:
-    from ipdb import post_mortem
-except ImportError:
-    from pdb import post_mortem
-
 
 # Get config values
 DEBUG = get_global_setting('debug')
@@ -39,6 +33,11 @@ def exception_handler(tag=None, pdb=False):
         print(f"{tag} {status}".ljust(LINE_LENGTH))
 
         if pdb:
+            # Use ipdb if it is available and default to pdb otherwise.
+            try:
+                from ipdb import post_mortem
+            except ImportError:
+                from pdb import post_mortem
             post_mortem()
 
         if DEBUG:

--- a/benchopt/viz/__init__.py
+++ b/benchopt/viz/__init__.py
@@ -50,7 +50,7 @@ def plot_benchmark(df, benchmark, kinds=None, display=True):
         for objective_name in objective_names:
             df_obj = df_data[df_data['objective_name'] == objective_name]
 
-            plot_id = get_plot_id(benchmark, df_obj)
+            plot_id = get_plot_id(benchmark.name, df_obj)
 
             for k in kinds:
                 if k not in PLOT_KINDS:

--- a/benchopt/viz/__init__.py
+++ b/benchopt/viz/__init__.py
@@ -1,8 +1,5 @@
 import matplotlib.pyplot as plt
 
-from ..config import get_benchmark_setting
-from ..utils.files import _get_output_folder
-
 from .helpers import get_plot_id
 from .plot_histogram import plot_histogram
 from .plot_suboptimality_curve import plot_suboptimality_curve
@@ -39,11 +36,11 @@ def plot_benchmark(df, benchmark, kinds=None, display=True):
         The matplotlib figures for convergence curve and histogram
         for each dataset.
     """
-    config_kinds = get_benchmark_setting(benchmark, 'plots')
+    config_kinds = benchmark.get_setting('plots')
     if kinds is None or len(kinds) == 0:
         kinds = config_kinds
 
-    output_dir = _get_output_folder(benchmark)
+    output_dir = benchmark.get_output_folder()
 
     datasets = df['data_name'].unique()
     figs = []

--- a/examples/plot_run_benchmark.py
+++ b/examples/plot_run_benchmark.py
@@ -33,5 +33,5 @@ except RuntimeError:
 
 
 kinds = list(PLOT_KINDS.keys())
-figs = plot_benchmark(df, benchmark=str(BENCHMARK_PATH), kinds=kinds)
+figs = plot_benchmark(df, benchmark=Benchmark(BENCHMARK_PATH), kinds=kinds)
 plt.show()

--- a/examples/plot_run_benchmark_python_R_julia.py
+++ b/examples/plot_run_benchmark_python_R_julia.py
@@ -34,5 +34,5 @@ except RuntimeError:
     )
 
 kinds = list(PLOT_KINDS.keys())
-figs = plot_benchmark(df, benchmark=str(BENCHMARK_PATH), kinds=kinds)
+figs = plot_benchmark(df, benchmark=Benchmark(BENCHMARK_PATH), kinds=kinds)
 plt.show()

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     },
     packages=find_packages(),
     install_requires=['numpy', 'pandas', 'matplotlib',
-                      'click', 'joblib'],
+                      'click', 'joblib', 'pygithub'],
     entry_points={
         'console_scripts': ['benchopt = benchopt.cli:main']
     }


### PR DESCRIPTION
Add a `benchopt publish` command to upload the benchmark results to [`benchopt/results`](https://github.com/benchopt/results).

The command is based on `pygithub` and upload the file when given a token. The token can be set either directly with `-t TOKEN`, with an environment variable `BENCHO_GITHUB_TOKEN` or in the config file.