### PR TITLE
FIX clean up some left-over from setting --local as default

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -2,6 +2,9 @@
 
 - Add a `--version` option in benchopt and check that the version installed
   in conda subenv match the one in the calling process (#83)
+- Change default mode to local run. Can call a run in an environment with
+  option `--env` for a dedicated conda env or `--env-name ENV_NAME` to specify
+  the env to use. (#94)
 
 
 ### 1.0 - 2020-09-25 - Release highlights

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ be **as simple as doing**:
 .. code-block::
 
     $ git clone https://github.com/benchopt/benchmark_logreg_l2
-    $ benchopt run ./benchmark_logreg_l2
+    $ benchopt run --env ./benchmark_logreg_l2
 
 Running this command will give you a benchmark plot on l2-regularized
 logistic regression:
@@ -65,7 +65,7 @@ To run the Lasso benchmark on all datasets and with all solvers, run:
 
 .. code-block::
 
-    $ benchopt run ./benchmark_lasso
+    $ benchopt run --env ./benchmark_lasso
 
 Use
 

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -128,7 +128,8 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
     datasets_option = ' '.join(['-d ' + d for d in dataset_names])
     objective_option = ' '.join(['-p ' + p for p in objective_filters])
     cmd = (
-        rf"benchopt run {benchmark} --local --n-repetitions {n_repetitions} "
+        rf"benchopt run --local {benchmark.benchmark_dir} "
+        rf"--n-repetitions {n_repetitions} "
         rf"--max-runs {max_runs} --timeout {timeout} "
         rf"{solvers_option} {forced_solvers_option} "
         rf"{datasets_option} {objective_option} "

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -74,11 +74,11 @@ def main(ctx, prog_name='benchopt', version=False):
               help="Launch a debugger if there is an error. This will launch "
               "ipdb if it is installed and default to pdb otherwise.")
 @click.option('--local', '-l', 'env_name',
-              flag_value=False, default=True,
+              flag_value='False', default=True,
               help="Run the benchmark in the local env. Must have all solvers "
               "and dataset dependencies installed.")
 @click.option('--env', '-e', 'env_name',
-              flag_value=True,
+              flag_value='True',
               help="Run the benchmark in a conda env for the benchmark. The "
               "env is named benchopt_<BENCHMARK> and all solver dependencies "
               "are installed in it.")
@@ -98,7 +98,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
 
     # If env_name is False, the flag `--local` has been used (default) so
     # run in the current environement.
-    if env_name is False:
+    if env_name == 'False':
         run_benchmark(
             benchmark, solver_names, forced_solvers,
             dataset_names=dataset_names,
@@ -110,7 +110,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
 
     # If env_name is True, the flag `--env` has been used. Create a conda env
     # specific to the benchmark. Else, use the <env_name> value.
-    if env_name is True:
+    if env_name == 'True':
         env_name = f"benchopt_{benchmark.name}"
     create_conda_env(env_name, recreate=recreate)
 

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -105,6 +105,22 @@ class TestRunCmd:
         # Make sure the results were saved in a result file
         assert len(out.result_files) == 1, out.output
 
+    def test_benchopt_run_in_env(self, test_env_name):
+        with CaptureRunOutput() as out:
+            with pytest.raises(SystemExit, match='False'):
+                run([str(DUMMY_BENCHMARK), '--env-name', test_env_name,
+                     '-d', SELECT_ONE_SIMULATED,
+                     '-f', 'pgd*False', '-n', '1', '-r', '1', '-p', '0.1',
+                     '--no-plot'], 'benchopt', standalone_mode=False)
+
+        out.check_output(f'conda activate {test_env_name}', repetition=6)
+        out.check_output('Dummy Sparse Regression', repetition=1)
+        out.check_output(r'Python-PGD\[use_acceleration=False\]', repetition=2)
+        out.check_output(r'Python-PGD\[use_acceleration=True\]', repetition=0)
+
+        # Make sure the results were saved in a result file
+        assert len(out.result_files) == 1, out.output
+
     def test_benchopt_caching(self):
 
         n_rep = 2

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -113,7 +113,8 @@ class TestRunCmd:
                      '-f', 'pgd*False', '-n', '1', '-r', '1', '-p', '0.1',
                      '--no-plot'], 'benchopt', standalone_mode=False)
 
-        out.check_output(f'conda activate {test_env_name}', repetition=6)
+        out.check_output(f'conda activate {test_env_name}')
+        out.check_output('Simulated', repetition=1)
         out.check_output('Dummy Sparse Regression', repetition=1)
         out.check_output(r'Python-PGD\[use_acceleration=False\]', repetition=2)
         out.check_output(r'Python-PGD\[use_acceleration=True\]', repetition=0)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,7 +21,7 @@ optimization benchmark should be **as simple as doing**:
 .. code-block::
 
     $ git clone https://github.com/benchopt/benchmark_logreg_l2
-    $ benchopt run ./benchmark_logreg_l2
+    $ benchopt run --env ./benchmark_logreg_l2
 
 Running these commands will fetch the benchmark files and give you a benchmark plot on l2-regularized logistic regression:
 
@@ -59,7 +59,7 @@ To run Lasso benchmarks on all datasets and with all solvers, run:
 
 .. code-block::
 
-    $ benchopt run benchmark_lasso
+    $ benchopt run --env benchmark_lasso
 
 Use
 


### PR DESCRIPTION
- Update the doc to call `benchopt run --env` for the first benchmarks (no install required).
- Make the `--env-name` option working.