### PR TITLE
Enh clean config

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -4,13 +4,12 @@ import warnings
 from pathlib import Path
 from joblib import Memory
 
+from .config import get_setting
 from .base import BaseSolver, BaseDataset
 from .utils.colorify import colorify, YELLOW
 from .utils.dynamic_modules import _load_class_from_module
 from .utils.parametrized_name_mixin import product_param
 from .utils.parametrized_name_mixin import _list_all_names
-
-from .config import get_benchmark_setting
 
 
 CACHE_DIR = '__cache__'
@@ -37,7 +36,8 @@ class Benchmark:
 
         # Get the config file and read it
         config_file = self.get_config_file()
-        return get_benchmark_setting(config_file, self.name, setting_name)
+        return get_setting(name=setting_name, config_file=config_file,
+                           benchmark_name=self.name)
 
     def get_benchmark_objective(self):
         """Load the objective function defined in the given benchmark.
@@ -101,14 +101,18 @@ class Benchmark:
         "Get the location for the cache of the benchmark."
         return self.benchmark_dir / CACHE_DIR
 
+    def get_config_file(self):
+        "Get the location for the config file of the benchmark."
+        return self.benchmark_dir / 'config.ini'
+
     def get_output_folder(self):
-        "Create or get the folder to store the output of the benchmark."
+        """Get the folder to store the output of the benchmark.
+
+        If it does not exists, create it.
+        """
         output_dir = self.benchmark_dir / "outputs"
         output_dir.mkdir(exist_ok=True)
         return output_dir
-
-    def get_config_file(self):
-        return self.benchmark_dir / 'config.ini'
 
     def get_result_file(self, filename=None):
         """Get a result file from the benchmark.
@@ -116,7 +120,8 @@ class Benchmark:
         Parameters
         ----------
         filename : str
-            Select a specific file from the benchmark.
+            Select a specific file from the benchmark. If None, this will
+            select the most recent CSV file in the benchmark output folder.
         """
         # List all result files
         output_folder = self.get_output_folder()
@@ -149,7 +154,7 @@ class Benchmark:
 
     def _install_required_classes(self, classes, include_patterns,
                                   force_patterns=None, env_name=None):
-        """Install all classes that are required for the run."""
+        "Install all classes that are required for the run."
         # Merge force install and install patterns.
         include_patterns = _check_name_lists(include_patterns, force_patterns)
 
@@ -180,7 +185,7 @@ class Benchmark:
 
     def install_required_solvers(self, solver_names, forced_solvers=None,
                                  env_name=None):
-        """List all solvers and install the required ones."""
+        "List all solvers and install the required ones."
         solvers = self.list_benchmark_solvers()
         self._install_required_classes(
             solvers, solver_names, force_patterns=forced_solvers,
@@ -188,14 +193,14 @@ class Benchmark:
         )
 
     def install_required_datasets(self, dataset_names, env_name=None):
-        """List all datasets and install the required ones."""
+        "List all datasets and install the required ones."
         datasets = self.list_benchmark_datasets()
         self._install_required_classes(
             datasets, dataset_names, env_name=env_name
         )
 
     def validate_dataset_patterns(self, dataset_patterns):
-        """Check that all provided patterns match at least one dataset"""
+        "Check that all provided patterns match at least one dataset"
 
         # List all dataset strings.
         datasets = self.list_benchmark_datasets()
@@ -204,7 +209,7 @@ class Benchmark:
         _validate_patterns(all_datasets, dataset_patterns, name_type='dataset')
 
     def validate_solver_patterns(self, solver_patterns):
-        """Check that all provided patterns match at least one solver"""
+        "Check that all provided patterns match at least one solver"
 
         # List all dataset strings.
         solvers = self.list_benchmark_solvers()
@@ -214,7 +219,7 @@ class Benchmark:
 
 
 def _check_name_lists(*name_lists):
-    """Normalize name_list ot a list of lowercase str."""
+    "Normalize name_list ot a list of lowercase str."
     res = []
     for name_list in name_lists:
         if name_list is None:
@@ -239,8 +244,7 @@ def is_matched(name, include_patterns=None):
 
 
 def _validate_patterns(all_names, patterns, name_type='dataset'):
-    """Check that all provided patterns match at least one name.
-    """
+    "Check that all provided patterns match at least one name."
     if patterns is None:
         return
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -178,8 +178,8 @@ class Benchmark:
         if not success:
             warnings.warn(
                 "Some solvers were not successfully installed, and will thus "
-                "be ignored. Use 'export BENCHO_RAISE_INSTALL_ERROR=true' to "
-                "stop at any installation failure and print the traceback.",
+                "be ignored. Use 'export BENCHOPT_RAISE_INSTALL_ERROR=true' to"
+                " stop at any installation failure and print the traceback.",
                 UserWarning
             )
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -2,6 +2,7 @@ import re
 import click
 import warnings
 from pathlib import Path
+from joblib import Memory
 
 from .base import BaseSolver, BaseDataset
 from .utils.colorify import colorify, YELLOW
@@ -10,6 +11,9 @@ from .utils.parametrized_name_mixin import product_param
 from .utils.parametrized_name_mixin import _list_all_names
 
 from .config import get_benchmark_setting
+
+
+CACHE_DIR = '__cache__'
 
 
 class Benchmark:
@@ -26,20 +30,17 @@ class Benchmark:
                 "benchmark."
             )
 
+        self.mem = Memory(location=self.get_cache_location(), verbose=0)
+
     def get_setting(self, setting_name):
         "Retrieve the setting value from benchmark config."
 
         # Get the config file and read it
-        config_file = self.benchmark_dir / 'config.ini'
+        config_file = self.get_config_file()
         return get_benchmark_setting(config_file, self.name, setting_name)
 
     def get_benchmark_objective(self):
         """Load the objective function defined in the given benchmark.
-
-        Parameters
-        ----------
-        benchmark_dir : str or Path
-            The path to the folder containing the benchmark.
 
         Returns
         -------
@@ -59,8 +60,6 @@ class Benchmark:
 
         Parameters
         ----------
-        benchmark_dir : str or Path
-            The path to the folder containing the benchmark.
         base_class : class
             Base class for the classes to load.
 
@@ -98,11 +97,18 @@ class Benchmark:
         "List all available dataset classes for the benchmark."
         return self._list_benchmark_classes(BaseDataset)
 
+    def get_cache_location(self):
+        "Get the location for the cache of the benchmark."
+        return self.benchmark_dir / CACHE_DIR
+
     def get_output_folder(self):
         "Create or get the folder to store the output of the benchmark."
-        output_dir = Path(self.benchmark_dir) / "outputs"
+        output_dir = self.benchmark_dir / "outputs"
         output_dir.mkdir(exist_ok=True)
         return output_dir
+
+    def get_config_file(self):
+        return self.benchmark_dir / 'config.ini'
 
     def get_result_file(self, filename=None):
         """Get a result file from the benchmark.

--- a/benchopt/cli.py
+++ b/benchopt/cli.py
@@ -208,21 +208,6 @@ def publish(benchmark, token=None, filename=None):
 
 
 @main.command(
-    help="Check that a given solver or dataset is correctly installed.\n\n"
-    "The class to be checked is specified with the absolute path of the file "
-    "in which it is defined MODULE_FILENAME and the name of the base "
-    "class BASE_CLASS_NAME."
-)
-@click.argument('module_filename', nargs=1, type=Path)
-@click.argument('base_class_name', nargs=1, type=str)
-def check_install(module_filename, base_class_name):
-
-    # Get class to check
-    klass = _load_class_from_module(module_filename, base_class_name)
-    klass.is_installed(raise_on_not_installed=True)
-
-
-@main.command(
     help="Test a benchmark in BENCHMARK_DIR.",
     context_settings=dict(ignore_unknown_options=True)
 )
@@ -254,6 +239,26 @@ def test(benchmark_dir, env_name, pytest_args):
     raise SystemExit(_run_shell_in_conda_env(
         cmd, env_name=env_name, capture_stdout=False
     ) != 0)
+
+
+############################################################################
+# Private sub-commands - not part of the public CLI
+# These are helpers used in the other commands.
+
+@main.command(
+    help="Check that a given solver or dataset is correctly installed.\n\n"
+    "The class to be checked is specified with the absolute path of the file "
+    "in which it is defined MODULE_FILENAME and the name of the base "
+    "class BASE_CLASS_NAME.",
+    hidden=True
+)
+@click.argument('module_filename', nargs=1, type=Path)
+@click.argument('base_class_name', nargs=1, type=str)
+def check_install(module_filename, base_class_name):
+
+    # Get class to check
+    klass = _load_class_from_module(module_filename, base_class_name)
+    klass.is_installed(raise_on_not_installed=True)
 
 
 if __name__ == '__main__':

--- a/benchopt/cli/__init__.py
+++ b/benchopt/cli/__init__.py
@@ -1,0 +1,28 @@
+import click
+
+from benchopt import __version__
+
+from benchopt.cli.main import main
+from benchopt.cli.helpers import helpers
+from benchopt.cli.process_results import process_results
+
+
+SOURCES = [main, process_results, helpers]
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+@click.command(name='benchopt', cls=click.CommandCollection, sources=SOURCES,
+               context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
+@click.option('--version', '-v', is_flag=True, help='Print version')
+@click.pass_context
+def benchopt(ctx, version=False):
+    """Command-line interface to benchOpt"""
+    if version:
+        print(__version__)
+        raise SystemExit(0)
+    if ctx.invoked_subcommand is None:
+        print(benchopt.get_help(ctx))
+
+
+if __name__ == '__main__':
+    benchopt()

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -12,7 +12,7 @@ from benchopt.utils.dynamic_modules import _load_class_from_module
 
 @click.group(name='HELPERS')
 def helpers(ctx):
-    "Private commands for benchopt."
+    "Helpers to clean and config ``benchopt``."
     pass
 
 
@@ -37,7 +37,8 @@ def clean(benchmark, token=None, filename=None):
 
 
 @helpers.group(
-    help="Configuration helper for benchopt.",
+    help="Configuration helper for benchopt. The configuration of benchopt "
+    "is detailed in :ref:`config_doc`.",
     invoke_without_command=True
 )
 @click.option('--benchmark', '-b', metavar='<benchmark>',
@@ -58,10 +59,13 @@ def config(ctx, benchmark, token=None, filename=None):
     ctx.obj['benchmark_name'] = benchmark.name if benchmark else None
 
 
-@config.command(help="Set config value.")
+@config.command(help="Set value of setting <name> to <val>.\n\n"
+                "Multiple values can be provided as separate arguments. "
+                "This will generate a list of values in the config file.")
 @click.option('--append', '-a', is_flag=True,
-              help='Append values to others')
-@click.argument("name", type=str)
+              help="Can be used to append values to the existing ones for "
+              "settings that takes list of values.")
+@click.argument("name", metavar='<name>', type=str)
 @click.argument("values", metavar='<val>', type=str,
                 nargs=-1, required=True)
 @click.pass_context
@@ -91,8 +95,8 @@ def set(ctx, name, values, append=False):
                 benchmark_name=benchmark_name)
 
 
-@config.command(help="Get config value.")
-@click.argument("name", type=str)
+@config.command(help="Get config value for setting <name>.")
+@click.argument("name", metavar='<name>', type=str)
 @click.pass_context
 def get(ctx, name):
     config = ctx.obj['config']

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -10,10 +10,10 @@ from benchopt.config import get_global_config_file
 from benchopt.utils.dynamic_modules import _load_class_from_module
 
 
-@click.group(name='HELPERS')
-def helpers(ctx):
-    "Helpers to clean and config ``benchopt``."
-    pass
+helpers = click.Group(
+    name='helpers',
+    help="Helpers to clean and config ``benchopt``."
+)
 
 
 @helpers.command(

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -11,7 +11,7 @@ from benchopt.utils.dynamic_modules import _load_class_from_module
 
 
 helpers = click.Group(
-    name='helpers',
+    name='Helpers',
     help="Helpers to clean and config ``benchopt``."
 )
 

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -1,0 +1,73 @@
+import click
+from pathlib import Path
+
+from benchopt.benchmark import Benchmark
+from benchopt.utils.files import rm_folder
+from benchopt.config import get_global_config_file
+from benchopt.utils.dynamic_modules import _load_class_from_module
+
+
+@click.group(name='HELPERS')
+def helpers(ctx):
+    "Private commands for benchopt."
+    pass
+
+
+@helpers.command(
+    help="Clean the cache and the outputs from a benchmark.",
+    options_metavar=''
+)
+@click.argument('benchmark', type=click.Path(exists=True))
+def clean(benchmark, token=None, filename=None):
+
+    benchmark = Benchmark(benchmark)
+
+    # Delete result files
+    output_folder = benchmark.get_output_folder()
+    print(f"rm -rf {output_folder}")
+    rm_folder(output_folder)
+
+    # Delete cache files
+    cache_folder = benchmark.get_cache_location()
+    print(f"rm -rf {cache_folder}")
+    rm_folder(cache_folder)
+
+
+@helpers.command(
+    help="Configuration helper for benchopt."
+)
+@click.option('--benchmark', '-b', metavar='<benchmark>',
+              type=click.Path(exists=True), default=None)
+def config(benchmark, token=None, filename=None):
+
+    if benchmark is None:
+        global_config = get_global_config_file()
+        print(f"Global config for benchopt is: {global_config.resolve()}")
+    else:
+        benchmark = Benchmark(benchmark)
+        bench_config = benchmark.get_config_file()
+        if not bench_config.exists():
+            bench_config = get_global_config_file()
+        print(
+            f"Config File for benchmark {benchmark.name}: {bench_config}"
+        )
+
+
+############################################################################
+# Private sub-commands - not part of the public CLI
+# These are helpers used in the other commands.
+
+@helpers.command(
+    help="Check that a given solver or dataset is correctly installed.\n\n"
+    "The class to be checked is specified with the absolute path of the file "
+    "in which it is defined MODULE_FILENAME and the name of the base "
+    "class BASE_CLASS_NAME.",
+    hidden=True
+)
+@click.argument('module_filename', nargs=1, type=Path)
+@click.argument('base_class_name', nargs=1, type=str)
+def check_install(module_filename, base_class_name):
+
+    # Get class to check
+    klass = _load_class_from_module(module_filename, base_class_name)
+    klass.is_installed(raise_on_not_installed=True)

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -11,7 +11,10 @@ from benchopt.tests import __file__ as _bench_test_module
 BENCHMARK_TEST_FILE = Path(_bench_test_module).parent / "test_benchmarks.py"
 
 
-main = click.Group()
+main = click.Group(
+    name='main',
+    help="Principal commands that are used in ``benchopt``."
+)
 
 
 @main.command(

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -12,7 +12,7 @@ BENCHMARK_TEST_FILE = Path(_bench_test_module).parent / "test_benchmarks.py"
 
 
 main = click.Group(
-    name='main',
+    name='Principal Commands',
     help="Principal commands that are used in ``benchopt``."
 )
 

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -8,10 +8,10 @@ from benchopt.plotting import plot_benchmark
 from benchopt.utils.github import publish_result_file
 
 
-@click.group()
-def process_results(ctx):
-    "Utilities to process benchmark outputs produced by benchOpt."
-    pass
+process_results = click.Group(
+    name='process_results',
+    help="Utilities to process benchmark outputs produced by benchOpt."
+)
 
 
 @process_results.command(

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -1,0 +1,79 @@
+import click
+import pandas as pd
+
+from benchopt.benchmark import Benchmark
+from benchopt.plotting import PLOT_KINDS
+from benchopt.plotting import plot_benchmark
+from benchopt.config import get_global_setting
+from benchopt.utils.github import publish_result_file
+
+
+@click.group()
+def process_results(ctx):
+    "Utilities to process benchmark outputs produced by benchOpt."
+    pass
+
+
+@process_results.command(
+    help="Plot the result from a previously run benchmark."
+)
+@click.argument('benchmark', type=click.Path(exists=True))
+@click.option('--filename', '-f', type=str, default=None,
+              help="Specify the file to select in the benchmark. If it is "
+              "not specified, take the latest on in the benchmark output "
+              "folder.")
+@click.option('--kind', '-k', 'kinds',
+              multiple=True, show_default=True, type=str,
+              help="Specify the type of figure to plot:\n\n* " +
+              "\n\n* ".join([f"``{name}``: {func.__doc__.splitlines()[0]}"
+                             for name, func in PLOT_KINDS.items()]))
+@click.option('--display/--no-display', default=True,
+              help="Whether or not to display the plot on the screen.")
+@click.option('--plotly', is_flag=True,
+              help="If this flag is set, generate figure as HTML with plotly. "
+              "This option does not work with all plot kinds and requires "
+              "to have installed `plotly`.")
+def plot(benchmark, filename=None, kinds=('suboptimality_curve',),
+         display=True, plotly=False):
+
+    # Get the result file
+    benchmark = Benchmark(benchmark)
+    result_filename = benchmark.get_result_file(filename)
+
+    # Plot the results.
+    df = pd.read_csv(result_filename)
+    plot_benchmark(df, benchmark, kinds=kinds, display=display, plotly=plotly)
+
+
+@process_results.command(
+    help="Publish the result from a previously run benchmark.\n\n"
+    "See the :ref:`publish` documentation for more info on how to use this "
+    "command."
+)
+@click.argument('benchmark', type=click.Path(exists=True))
+@click.option('--token', '-t', type=str, default=None,
+              help="Github token to access the result repo.")
+@click.option('--filename', '-f',
+              type=str, default=None,
+              help="Specify the file to publish in the benchmark. If it is "
+              "not specified, take the latest on in the benchmark output "
+              "folder.")
+def publish(benchmark, token=None, filename=None):
+
+    if token is None:
+        token = get_global_setting('github_token')
+    if token is None:
+        raise RuntimeError(
+            "Could not find the token value to connect to GitHub.\n\n"
+            "Please go to https://github.com/settings/tokens to generate a "
+            "personal token $TOKEN.\nThen, either provide it with option `-t` "
+            "or put it in a config file ./benchopt.ini\nunder section "
+            "[benchopt] as `github_token = $TOKEN`."
+        )
+
+    # Get the result file
+    benchmark = Benchmark(benchmark)
+    result_filename = benchmark.get_result_file(filename)
+
+    # Publish the result.
+    publish_result_file(benchmark.name, result_filename, token)

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -9,7 +9,7 @@ from benchopt.utils.github import publish_result_file
 
 
 process_results = click.Group(
-    name='process_results',
+    name='Process Results',
     help="Utilities to process benchmark outputs produced by benchOpt."
 )
 

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -47,8 +47,8 @@ def plot(benchmark, filename=None, kinds=('suboptimality_curve',),
 
 @process_results.command(
     help="Publish the result from a previously run benchmark.\n\n"
-    "See the :ref:`publish` documentation for more info on how to use this "
-    "command."
+    "See the :ref:`publish_doc` documentation for more info on how to use "
+    "this command."
 )
 @click.argument('benchmark', type=click.Path(exists=True))
 @click.option('--token', '-t', type=str, default=None,

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -1,10 +1,10 @@
 import click
 import pandas as pd
 
+from benchopt.config import get_setting
 from benchopt.benchmark import Benchmark
 from benchopt.plotting import PLOT_KINDS
 from benchopt.plotting import plot_benchmark
-from benchopt.config import get_global_setting
 from benchopt.utils.github import publish_result_file
 
 
@@ -61,7 +61,7 @@ def plot(benchmark, filename=None, kinds=('suboptimality_curve',),
 def publish(benchmark, token=None, filename=None):
 
     if token is None:
-        token = get_global_setting('github_token')
+        token = get_setting('github_token')
     if token is None:
         raise RuntimeError(
             "Could not find the token value to connect to GitHub.\n\n"

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -17,10 +17,34 @@ DEFAULT_GLOBAL_CONFIG = {
     'conda_cmd': 'conda',
     'shell': os.environ.get('SHELL', 'bash')
 }
+"""
+* ``debug``: If set to true, enable debug logs.
+* ``allow_install``, *boolean*: Install in current env are disabled by
+  default. If set to true, enable installing in the current env.
+* ``raise_install_error``, *boolean*: If set to true, raise error when
+  install fails.
+* ``github_token``, *str*: token to publish results on ``benchopt/results``
+  via github.
+* ``conda_cmd``, *str*: can be used to give the path to ``conda`` if it is
+  not directly installed on ``$PATH``.
+* ``shell``, *str*: can be used to specify the shell to use. Default to
+  `SHELL` from env if it exists and ``'bash'`` otherwise.
+"""
 
 DEFAULT_BENCHMARK_CONFIG = {
     'plots': ["suboptimality_curve"],
 }
+"""
+* ``plots``, *list*: Select the plots to display for the benchmark. Should be
+  valid plot kinds. The list can simply be one item by line, with each item
+  indented, as:
+
+  .. code-block:: ini
+
+    plots =
+        suboptimality_curve
+        histogram
+"""
 
 
 def get_global_config_file():

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -1,9 +1,10 @@
 import os
-import re
 import warnings
 import configparser
 from pathlib import Path
+from collections import Iterable
 
+BOOLEAN_STATES = configparser.ConfigParser.BOOLEAN_STATES
 CONFIG_FILE_NAME = 'benchopt.ini'
 CONFIG_FILE_LOCATION = os.environ.get('BENCHO_CONFIG', './benchopt.ini')
 
@@ -18,19 +19,18 @@ DEFAULT_GLOBAL_CONFIG = {
 }
 
 DEFAULT_BENCHMARK_CONFIG = {
-    'plots': "'suboptimality_curve'",
-    'name': None
+    'plots': ["suboptimality_curve"],
 }
 
 
 def get_global_config_file():
     "Return the global config file."
 
-    config_file = os.environ.get('BENCHO_CONFIG', None)
+    config_file = os.environ.get('BENCHOPT_CONFIG', None)
     if config_file is not None:
         config_file = Path(config_file)
         assert config_file.exists(), (
-            f"BENCHO_CONFIG is set but file {config_file} does not exists."
+            f"BENCHOPT_CONFIG is set but file {config_file} does not exists."
         )
         return config_file
     config_file = Path('.') / CONFIG_FILE_NAME
@@ -39,61 +39,107 @@ def get_global_config_file():
     return config_file
 
 
-def get_global_setting(name):
-    assert name in DEFAULT_GLOBAL_CONFIG, f"Unknown config key {name}"
+def set_setting(name, value, config_file=None, benchmark_name=None):
+    if config_file is None:
+        config_file = get_global_config_file()
 
-    # Get the name of the environment variable associated to this setting
-    env_var_name = f"BENCHO_{name.upper()}"
+    # Get default value
+    default_config = DEFAULT_BENCHMARK_CONFIG
+    if benchmark_name is None:
+        benchmark_name = 'benchopt'
+        default_config = DEFAULT_GLOBAL_CONFIG
+
+    if name not in default_config:
+        print(
+            f'ERROR: {name} is not a setting for {benchmark_name}. Possible '
+            'settings are:\n  - ' + '\n  - '.join(default_config)
+        )
+        raise SystemExit(1)
+    default_value = default_config[name]
 
     # Get global config file
-    global_config = configparser.ConfigParser()
-    global_config.read(get_global_config_file())
-
-    if isinstance(DEFAULT_GLOBAL_CONFIG[name], bool):
-        file_setting = global_config.getboolean(
-            'benchopt', name, fallback=DEFAULT_GLOBAL_CONFIG[name]
-        )
-        setting = os.environ.get(env_var_name, file_setting)
-        # convert string 0/1/true/false/yes/no/on/off to boolean
-        if isinstance(setting, str):
-            setting = setting.lower()
-            try:
-                setting = configparser.ConfigParser.BOOLEAN_STATES[setting]
-            except KeyError:
-                warnings.warn(
-                    f'env variable {env_var_name} could not be parsed as a '
-                    'boolean. Should be one of '
-                    f'{list(configparser.ConfigParser.BOOLEAN_STATES.keys())}'
-                )
-                setting = file_setting
-    else:
-        # TODO: get the correct type from DEFAULT_GLOBAL_CONFIG for other types
-        setting = global_config.get(
-            'benchopt', name, fallback=DEFAULT_GLOBAL_CONFIG[name]
-        )
-        setting = os.environ.get(env_var_name, setting)
-
-    return setting
-
-
-def get_benchmark_setting(config_file, benchmark_name, setting_name):
-    if not config_file.exists():
-        config_file = get_global_config_file()
     config = configparser.ConfigParser()
     config.read(config_file)
 
-    # retrieve the setting value from the file or fallback to default.
-    setting = config.get(
-        benchmark_name, setting_name,
-        fallback=DEFAULT_BENCHMARK_CONFIG[setting_name]
-    )
+    if benchmark_name not in config:
+        config[benchmark_name] = {}
 
-    # Parse the setting depending on it name.
-    if setting_name in ['plots']:
-        setting = re.findall("[\"']([^']+)[\"']", setting)
-    elif setting_name == 'name' and setting is None:
-        setting = benchmark_name
-    return setting
+    config[benchmark_name][name] = reverse_parse(default_value, value)
+    with config_file.open('w') as f:
+        config.write(f)
+
+
+def get_setting(name, config_file=None, benchmark_name=None):
+    if config_file is None:
+        config_file = get_global_config_file()
+
+    # Get default value
+    default_config = DEFAULT_BENCHMARK_CONFIG
+    if benchmark_name is None:
+        benchmark_name = 'benchopt'
+        default_config = DEFAULT_GLOBAL_CONFIG
+    assert name in default_config, f"Unknown config key {name}"
+    default_value = default_config[name]
+
+    # Get config file
+    config = configparser.ConfigParser()
+    config.read(config_file)
+
+    # Get the name of the environment variable associated to this setting
+    env_var_name = f"BENCHOPT_{name.upper()}"
+
+    # Get setting with order: 1. env var / 2. config file / 3. default value
+    value = config.get(benchmark_name, name, fallback=default_value)
+    value = os.environ.get(env_var_name, value)
+
+    # Parse the value to the correct type
+    value = parse_value(default_value, value)
+
+    return value
+
+
+def parse_value(default_value, value):
+    if isinstance(default_value, bool):
+        # convert string 0/1/true/false/yes/no/on/off to boolean
+        if isinstance(value, str):
+            value = value.lower()
+            try:
+                value = BOOLEAN_STATES[value]
+            except KeyError:
+                warnings.warn(
+                    f'setting {value} could not be parsed as a '
+                    'boolean. Should be one of '
+                    f'{list(BOOLEAN_STATES.keys())}'
+                )
+                value = default_value
+        assert isinstance(value, bool)
+    elif isinstance(default_value, list):
+        # parse multiline statements as list with separators '\n' and ','
+        if isinstance(value, str):
+            values = value.split()
+            values = [v.strip() for value in values
+                      for v in value.split(',') if v != '']
+            value = values
+        assert isinstance(value, list)
+
+    return value
+
+
+def reverse_parse(default_value, value):
+    if isinstance(value, bool) or isinstance(default_value, bool):
+        if isinstance(value, bool):
+            assert isinstance(default_value, bool)
+            value = 'true' if value else 'false'
+        else:
+            assert value.lower() in BOOLEAN_STATES, (
+                "boolean setting should have value in "
+                f"{list(BOOLEAN_STATES.keys())}"
+            )
+    elif isinstance(value, Iterable) and not isinstance(value, str):
+        assert isinstance(default_value, list)
+        value = '\n' + '\n'.join(value)
+
+    return value
 
 
 # Make sure we load the lattest value of the config parameter, even if it is
@@ -103,7 +149,7 @@ class BooleanFlag(object):
         self.name = name
 
     def __bool__(self):
-        return get_global_setting(self.name)
+        return get_setting(self.name)
 
 
 DEBUG = BooleanFlag('debug')

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from .utils import product_param
 from .benchmark import is_matched
 from .plotting import plot_benchmark
-from .config import get_global_setting
 from .benchmark import _check_name_lists
 from .utils.pdb_helpers import exception_handler
 
@@ -15,8 +14,8 @@ from .utils.colorify import LINE_LENGTH, RED, GREEN, YELLOW
 
 
 # Get config values
-DEBUG = get_global_setting('debug')
-RAISE_INSTALL_ERROR = get_global_setting('raise_install_error')
+from .config import DEBUG
+from .config import RAISE_INSTALL_ERROR
 
 
 # Define some constants

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -5,13 +5,17 @@ import click
 import pytest
 
 from benchopt.plotting import PLOT_KINDS
-from benchopt.cli import run, plot, check_install
 from benchopt.utils.stream_redirection import SuppressStd
 
 
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
 from benchopt.tests import DUMMY_BENCHMARK_PATH
+
+
+from benchopt.cli.main import run
+from benchopt.cli.process_results import plot
+from benchopt.cli.helpers import check_install
 
 
 class TestCheckInstallCmd:
@@ -161,7 +165,7 @@ class TestPlotCmd:
         out = SuppressStd()
         with out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
-                 '-s', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-p', '0.1',
+                 '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-p', '0.1',
                  '--no-plot'], 'benchopt', standalone_mode=False)
         result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
         assert len(result_files) == 1, out.output

--- a/benchopt/tests/test_config.py
+++ b/benchopt/tests/test_config.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+from pathlib import Path
+from contextlib import contextmanager
+
+from benchopt.config import get_global_config_file
+
+
+@contextmanager
+def set_config_file(permission='600'):
+    permission = int(f"100{permission}", base=8)
+    config_file = Path() / 'test_config_file.ini'
+    config_file.touch(mode=permission, exist_ok=False)
+    old_config_file = os.environ.get('BENCHOPT_CONFIG', None)
+    os.environ['BENCHOPT_CONFIG'] = str(config_file)
+    try:
+        yield config_file
+    finally:
+        if old_config_file is not None:
+            os.environ['BENCHOPT_CONFIG'] = old_config_file
+        else:
+            os.unsetenv('BENCHOPT_CONFIG')
+        config_file.unlink()
+
+
+@pytest.mark.parametrize("permission", ["644", "655", "240"])
+def test_config_file_permission_warn(permission):
+    with set_config_file(permission) as config_file:
+        msg = f"{config_file} is with mode {permission}"
+        with pytest.warns(UserWarning, match=msg):
+            global_config_file = get_global_config_file()
+        assert str(global_config_file) == str(config_file)
+
+
+def test_config_file_permission_no_warning():
+    with set_config_file() as config_file:
+        with pytest.warns(None) as record:
+            global_config_file = get_global_config_file()
+        assert str(global_config_file) == str(config_file)
+        assert len(record) == 0, (
+            "A warning was issued while it should not have.\n"
+            f"Warning is: {record[0]}"
+        )

--- a/benchopt/tests/test_config.py
+++ b/benchopt/tests/test_config.py
@@ -19,7 +19,7 @@ def set_config_file(permission='600'):
         if old_config_file is not None:
             os.environ['BENCHOPT_CONFIG'] = old_config_file
         else:
-            os.unsetenv('BENCHOPT_CONFIG')
+            del os.environ['BENCHOPT_CONFIG']
         config_file.unlink()
 
 

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -16,7 +16,7 @@ def test_skip_api(capsys):
     solver = TEST_SOLVER.get_instance()
 
     res = run_one_solver(
-        benchmark_dir=benchmark.benchmark_dir,
+        benchmark=benchmark,
         objective=objective, solver=solver, meta={},
         max_runs=1, n_repetitions=1,
         timeout=10000, show_progress=False,
@@ -30,7 +30,7 @@ def test_skip_api(capsys):
     objective = TEST_OBJECTIVE.get_instance(reg=1)
     objective.set_dataset(dataset)
     res = run_one_solver(
-        benchmark_dir=benchmark.benchmark_dir,
+        benchmark=benchmark,
         objective=objective, solver=solver, meta={},
         max_runs=1, n_repetitions=1,
         timeout=10000, show_progress=False,

--- a/benchopt/utils/files.py
+++ b/benchopt/utils/files.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def rm_folder(folder):
+    "Recursively delete a folder and its content."
+    folder = Path(folder)
+    for f in folder.iterdir():
+        if f.is_dir():
+            rm_folder(f)
+        else:
+            f.unlink()
+    folder.rmdir()

--- a/benchopt/utils/pdb_helpers.py
+++ b/benchopt/utils/pdb_helpers.py
@@ -1,14 +1,12 @@
 "A context manager to handle exception with option to open a debugger."
 from contextlib import contextmanager
 
-from ..config import get_global_setting
-
 from .colorify import colorify
 from .colorify import LINE_LENGTH, RED, YELLOW
 
 
 # Get config values
-DEBUG = get_global_setting('debug')
+from ..config import DEBUG
 
 
 @contextmanager

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -229,7 +229,7 @@ def install_in_conda_env(*packages, env_name=None, force=False):
     if env_name is None and not ALLOW_INSTALL:
         raise ValueError("Trying to install solver not in a conda env "
                          "managed by benchopt. To allow this, "
-                         "set BENCHO_ALLOW_INSTALL=True.")
+                         "set BENCHOPT_ALLOW_INSTALL=True.")
 
     pip_packages = [pkg[4:] for pkg in packages if pkg.startswith('pip:')]
     conda_packages = [pkg for pkg in packages if not pkg.startswith('pip:')]
@@ -257,7 +257,7 @@ def shell_install_in_conda_env(script, env_name=None):
     """Run a shell install script in the given environment"""
     if env_name is None and not ALLOW_INSTALL:
         raise ValueError("Trying to install solver not in a conda env. "
-                         "To allow this, set BENCHO_ALLOW_INSTALL=True.")
+                         "To allow this, set BENCHOPT_ALLOW_INSTALL=True.")
 
     cmd = f"{SHELL} {script} $CONDA_PREFIX"
     _run_shell_in_conda_env(cmd, env_name=env_name,

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -4,13 +4,13 @@ import warnings
 import subprocess
 
 import benchopt
-from ..config import get_global_setting
+from ..config import get_setting
 from ..config import DEBUG, ALLOW_INSTALL
 from .misc import get_benchopt_requirement_line
 
 
-SHELL = get_global_setting('shell')
-CONDA_CMD = get_global_setting('conda_cmd')
+SHELL = get_setting('shell')
+CONDA_CMD = get_setting('conda_cmd')
 
 BENCHOPT_INSTALL = get_benchopt_requirement_line()
 

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -4,6 +4,21 @@
 Command Line Interface (CLI) Documentation
 ==========================================
 
+.. click:: benchopt.cli:benchopt
+   :prog: benchopt
+   :nested: none
+
 .. click:: benchopt.cli:main
+   :semantic-group: Principal commands
+   :prog: benchopt
+   :nested: full
+
+.. click:: benchopt.cli:process_results
+   :semantic-group: Process Results
+   :prog: benchopt
+   :nested: full
+
+.. click:: benchopt.cli:helpers
+   :semantic-group: Helpers
    :prog: benchopt
    :nested: full

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -6,19 +6,19 @@ Command Line Interface (CLI) Documentation
 
 .. click:: benchopt.cli:benchopt
    :prog: benchopt
-   :nested: none
-
-.. click:: benchopt.cli:main
-   :semantic-group: Principal commands
-   :prog: benchopt
    :nested: full
 
-.. click:: benchopt.cli:process_results
-   :semantic-group: Process Results
-   :prog: benchopt
-   :nested: full
+.. .. click:: benchopt.cli:main
+..    :semantic-group: Principal commands
+..    :prog: benchopt
+..    :nested: full
 
-.. click:: benchopt.cli:helpers
-   :semantic-group: Helpers
-   :prog: benchopt
-   :nested: full
+.. .. click:: benchopt.cli:process_results
+..    :semantic-group: Process Results
+..    :prog: benchopt
+..    :nested: full
+
+.. .. click:: benchopt.cli:helpers
+..    :semantic-group: Helpers
+..    :prog: benchopt
+..    :nested: full

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -8,17 +8,3 @@ Command Line Interface (CLI) Documentation
    :prog: benchopt
    :nested: full
 
-.. .. click:: benchopt.cli:main
-..    :semantic-group: Principal commands
-..    :prog: benchopt
-..    :nested: full
-
-.. .. click:: benchopt.cli:process_results
-..    :semantic-group: Process Results
-..    :prog: benchopt
-..    :nested: full
-
-.. .. click:: benchopt.cli:helpers
-..    :semantic-group: Helpers
-..    :prog: benchopt
-..    :nested: full

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -6,4 +6,4 @@ Command Line Interface (CLI) Documentation
 
 .. click:: benchopt.cli:main
    :prog: benchopt
-   :show-nested:
+   :nested: full

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
-    'sphinx_click.ext',
+    'sphinx_click_semantic_group',
     'sphinx_gallery.gen_gallery',
     'numpydoc',
     'gh_substitutions',  # custom ext, see ./sphinxext/gh_substitutions.py

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -5,9 +5,9 @@ BenchOpt configuration
 
 BenchOpt can be configured using setting files. These files can either be created directly or generated and modified using ``benchopt config``.
 
-There are two configuration levels. The first level is the global config for the ``benchopt`` client. It contains the system specific tweaks, the user info such as the *<GitHub token>* and the output levels. The second level is the configuration of the benchmarks. Each benchmark can have its own config for the kind of plots is displays by default and other display tweaks.
+There are two configuration levels. The first level is the global config for the ``benchopt`` client. It contains the system specific tweaks, the user info such as the *<GitHub token>* and the output levels. The second level is the configuration of the benchmarks. Each benchmark can have its own config for the kind of plots it displays by default and other display tweaks.
 
-To get the benchopt global config file used by the benchopt command, you can run ``benchopt config``. Using the option ``--benchmark,-b <benchmark>`` allows to display the config file for a specific benchmark. See :ref:`config_file` for more details on how the config file path is resolved.
+To get the BenchOpt global config file used by the ``benchopt`` command, you can run ``benchopt config``. Using the option ``--benchmark,-b <benchmark>`` allows to display the config file for a specific benchmark. See :ref:`config_file` for more details on how the config file path is resolved.
 
 The structure of the files follows the Microsoft Windows INI files structure and is described in :ref:`config_structure`. The available settings are listed in :ref:`config_settings`.
 

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -1,0 +1,73 @@
+.. _config_doc:
+
+BenchOpt configuration
+======================
+
+BenchOpt can be configured using setting files. These files can either be created directly or generated and modified using ``benchopt config``.
+
+There are two configuration levels. The first level is the global config for the ``benchopt`` client. It contains the system specific tweaks, the user info such as the *<GitHub token>* and the output levels. The second level is the configuration of the benchmarks. Each benchmark can have its own config for the kind of plots is displays by default and other display tweaks.
+
+To get the benchopt global config file used by the benchopt command, you can run ``benchopt config``. Using the option ``--benchmark,-b <benchmark>`` allows to display the config file for a specific benchmark. See :ref:`config_file` for more details on how the config file path is resolved.
+
+The structure of the files follows the Microsoft Windows INI files structure and is described in :ref:`config_structure`. The available settings are listed in :ref:`config_settings`.
+
+The value of each setting can be accessed with the CLI using ``benchopt config [-b <benchmark>] get <name>``. Similarly, the setting value can be set using ``benchopt config [-b <benchmark>] set <name> <value>``.
+
+.. _config_file:
+
+Config File Location
+--------------------
+
+For global config file, the resolution order is the following:
+
+1. The environment variable ``BENCHOPT_CONFIG`` is set to an existing file,
+2. A file ``benchopt.ini`` in the current directory,
+3. The default file is ``$HOME/.config/benchopt.ini``.
+
+For benchmark config files, they are usually located in the benchmark folder with name ``benchopt.ini``. If it does not exists, the default is to use the global config file.
+
+.. _config_structure:
+
+Config File Structure
+---------------------
+
+The config files for benchOpt follow the Microsoft Windows INI files structure. The global setting are grouped in a ``[benchopt]`` section:
+
+.. code-block:: ini
+
+    [benchopt]
+    debug = true  # Activate or not debug logs
+    raise_install_error = no  # Raise/ignore install error. Default is ignore.
+    github_token = 0...0  # Token used to publish results on benchopt/results
+
+For benchmark settings, they are grouped in a section with the same name as the benchmark. For a benchmark named ``benchmark_bench``, the config structure is:
+
+.. code-block:: ini
+
+    [benchmark_bench]
+    plots =
+        suboptimality_curve
+        histogram
+        objective_curve
+
+
+.. _config_settings:
+
+Config Settings
+---------------
+
+This section lists the available settings.
+
+
+Global settings
+~~~~~~~~~~~~~~~
+
+.. autodata:: benchopt.config.DEFAULT_GLOBAL_CONFIG
+
+
+
+Benchmark settings
+~~~~~~~~~~~~~~~~~~~
+
+.. autodata:: benchopt.config.DEFAULT_BENCHMARK_CONFIG
+

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx-bootstrap-theme
-# sphinx-click
+sphinx-click
 sphinx_gallery
 pillow
 scikit-learn

--- a/doc/doc-requirements.txt
+++ b/doc/doc-requirements.txt
@@ -1,6 +1,6 @@
 numpydoc
 sphinx-bootstrap-theme
-sphinx-click
+# sphinx-click
 sphinx_gallery
 pillow
 scikit-learn

--- a/doc/how.rst
+++ b/doc/how.rst
@@ -93,7 +93,7 @@ Sometimes one wants to test the solvers for variants of the same dataset.
 For example, one may want to change the dataset size, the noise level, etc.
 To be able to specify parameters to get a dataset, you can use a class
 attribute called ``parameters``. This parameter must be a dictionary
-whose keys can be passed to the ``__init__`` of the class. Then benchopt
+whose keys can be passed to the ``__init__`` of the class. Then BenchOpt
 will automatically allow you to test all combinations of parameters.
 
 .. literalinclude:: ../benchopt/tests/test_benchmarks/dummy_benchmark/datasets/simulated.py
@@ -133,7 +133,7 @@ This ``stop_strategy`` can be:
       the running time. The parameter is called ``tol`` and should be
       a positive float.
 
-benchopt supports different types of solvers:
+BenchOpt supports different types of solvers:
 
    - :ref:`python_solvers`
    - :ref:`r_solvers`
@@ -153,7 +153,7 @@ with no other dependencies. Here is an example:
 .. literalinclude:: ../benchopt/tests/test_benchmarks/dummy_benchmark/solvers/python_pgd.py
 
 If your Python solver requires some packages such as `Numba <https://numba.pydata.org/>`_,
-benchopt allows you to list some requirements. The necessary packages should be available
+BenchOpt allows you to list some requirements. The necessary packages should be available
 via `conda <https://docs.conda.io/en/latest/>`_ or
 `pip <https://packaging.python.org/guides/tool-recommendations/>`_.
 
@@ -173,7 +173,7 @@ not `conda-forge <https://conda-forge.org/>`_. See example:
 
 .. note::
 
-    Specifying the dependencies is necessary if you let benchopt
+    Specifying the dependencies is necessary if you let BenchOpt
     manage the creation of a dedicated environment. If you want to
     use your local environment the list of dependencies is
     not relevant. See :ref:`cli_documentation`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -127,7 +127,7 @@ Contents
    publish
    config
    whats_new
-   Fork benchopt on Github <https://github.com/benchopt/benchopt>
+   Fork BenchOpt on Github <https://github.com/benchopt/benchopt>
 
 .. |Build Status| image:: https://dev.azure.com/benchopt/benchopt/_apis/build/status/benchopt.benchOpt?branchName=master
    :target: https://dev.azure.com/benchopt/benchopt/_build/latest?definitionId=1&branchName=master

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -113,7 +113,7 @@ Benchmark results
 
 All the public benchmark results are available at `BenchOpt Benchmarks results <https://benchopt.github.io/results/>`_.
 
-**Publish results**: You can directly publish the result of a run of ``benchopt`` on `BenchOpt Benchmarks results <https://benchopt.github.io/results/>`_. You can have a look at this page to :ref:`publish`.
+**Publish results**: You can directly publish the result of a run of ``benchopt`` on `BenchOpt Benchmarks results <https://benchopt.github.io/results/>`_. You can have a look at this page to :ref:`publish_doc`.
 
 Contents
 ========
@@ -125,6 +125,7 @@ Contents
    api
    how
    publish
+   config
    whats_new
    Fork benchopt on Github <https://github.com/benchopt/benchopt>
 

--- a/doc/publish.rst
+++ b/doc/publish.rst
@@ -48,4 +48,6 @@ Then create a token named ``benchopt``, ticking the **repo** box as shown below:
    :align: center
 
 Then click on ``generate token`` and copy this token of 40 characters in a
-secure location. Note that the token can be stored in a config file for benchopt using ``benchopt config set github_token <TOKEN>``. More info on config files can be found in :ref:`config_doc`.
+secure location. Note that the token can be stored in a config file for BenchOpt
+using ``benchopt config set github_token <TOKEN>``. More info on config files can
+be found in :ref:`config_doc`.

--- a/doc/publish.rst
+++ b/doc/publish.rst
@@ -1,4 +1,4 @@
-.. _publish:
+.. _publish_doc:
 
 Publish benchmark results
 =========================
@@ -47,5 +47,5 @@ Then create a token named ``benchopt``, ticking the **repo** box as shown below:
    :target: https://github.com/settings/tokens
    :align: center
 
-Then click on ``generate token`` and copy this token of 40 characters in a secure
-location.
+Then click on ``generate token`` and copy this token of 40 characters in a
+secure location. Note that the token can be stored in a config file for benchopt using ``benchopt config set github_token <TOKEN>``. More info on config files can be found in :ref:`config_doc`.

--- a/doc/sphinxext/sphinx_click_semantic_group.py
+++ b/doc/sphinxext/sphinx_click_semantic_group.py
@@ -1,418 +1,27 @@
-import traceback
-import warnings
-
 import click
 from docutils import nodes
-from docutils.parsers import rst
 from docutils.parsers.rst import directives
 from docutils import statemachine
 from sphinx.util import logging
 from sphinx.util import nodes as sphinx_nodes
 
+from sphinx_click.ext import ClickDirective as _ClickDirective
+from sphinx_click.ext import _format_command
+from sphinx_click.ext import _format_description
+from sphinx_click.ext import _filter_commands
+from sphinx_click.ext import NESTED_FULL
+
+
 LOG = logging.getLogger(__name__)
 CLICK_VERSION = tuple(int(x) for x in click.__version__.split('.')[0:2])
 
-NESTED_FULL = 'full'
-NESTED_SHORT = 'short'
-NESTED_NONE = 'none'
 
+class ClickDirective(_ClickDirective):
 
-def _indent(text, level=1):
-    prefix = ' ' * (4 * level)
-
-    def prefixed_lines():
-        for line in text.splitlines(True):
-            yield (prefix + line if line.strip() else line)
-
-    return ''.join(prefixed_lines())
-
-
-def _get_usage(ctx):
-    """Alternative, non-prefixed version of 'get_usage'."""
-    formatter = ctx.make_formatter()
-    pieces = ctx.command.collect_usage_pieces(ctx)
-    formatter.write_usage(ctx.command_path, ' '.join(pieces), prefix='')
-    return formatter.getvalue().rstrip('\n')
-
-
-def _get_help_record(opt):
-    """Re-implementation of click.Opt.get_help_record.
-
-    The variant of 'get_help_record' found in Click makes uses of slashes to
-    separate multiple opts, and formats option arguments using upper case. This
-    is not compatible with Sphinx's 'option' directive, which expects
-    comma-separated opts and option arguments surrounded by angle brackets [1].
-
-    [1] http://www.sphinx-doc.org/en/stable/domains.html#directive-option
-    """
-
-    def _write_opts(opts):
-        rv, _ = click.formatting.join_options(opts)
-        if not opt.is_flag and not opt.count:
-            name = opt.name
-            if opt.metavar:
-                name = opt.metavar.lstrip('<[{($').rstrip('>]})$')
-            rv += ' <{}>'.format(name)
-        return rv
-
-    rv = [_write_opts(opt.opts)]
-    if opt.secondary_opts:
-        rv.append(_write_opts(opt.secondary_opts))
-
-    out = []
-    if opt.help:
-        if opt.required:
-            out.append('**Required** %s' % opt.help)
-        else:
-            out.append(opt.help)
-    else:
-        if opt.required:
-            out.append('**Required**')
-
-    extras = []
-
-    if opt.default is not None and opt.show_default:
-        if isinstance(opt.show_default, str):
-            # Starting from Click 7.0 this can be a string as well. This is
-            # mostly useful when the default is not a constant and
-            # documentation thus needs a manually written string.
-            extras.append(':default: %s' % opt.show_default)
-        else:
-            extras.append(
-                ':default: %s'
-                % (
-                    ', '.join('%s' % d for d in opt.default)
-                    if isinstance(opt.default, (list, tuple))
-                    else opt.default,
-                )
-            )
-
-    if isinstance(opt.type, click.Choice):
-        extras.append(':options: %s' % ' | '.join(opt.type.choices))
-
-    if extras:
-        if out:
-            out.append('')
-
-        out.extend(extras)
-
-    return ', '.join(rv), '\n'.join(out)
-
-
-def _format_description(ctx):
-    """Format the description for a given `click.Command`.
-
-    We parse this as reStructuredText, allowing users to embed rich
-    information in their help messages if they so choose.
-    """
-    help_string = ctx.command.help or ctx.command.short_help
-    if not help_string:
-        return
-
-    bar_enabled = False
-    for line in statemachine.string2lines(
-        help_string, tab_width=4, convert_whitespace=True
-    ):
-        if line == '\b':
-            bar_enabled = True
-            continue
-        if line == '':
-            bar_enabled = False
-        line = '| ' + line if bar_enabled else line
-        yield line
-    yield ''
-
-
-def _format_usage(ctx):
-    """Format the usage for a `click.Command`."""
-    yield '.. code-block:: shell'
-    yield ''
-    for line in _get_usage(ctx).splitlines():
-        yield _indent(line)
-    yield ''
-
-
-def _format_option(opt):
-    """Format the output for a `click.Option`."""
-    opt = _get_help_record(opt)
-
-    yield '.. option:: {}'.format(opt[0])
-    if opt[1]:
-        yield ''
-        for line in statemachine.string2lines(
-            opt[1], tab_width=4, convert_whitespace=True
-        ):
-            yield _indent(line)
-
-
-def _format_options(ctx):
-    """Format all `click.Option` for a `click.Command`."""
-    # the hidden attribute is part of click 7.x only hence use of getattr
-    params = [
-        param
-        for param in ctx.command.params
-        if (isinstance(param, click.Option)
-            and not getattr(param, 'hidden', False))
-    ]
-
-    for param in params:
-        for line in _format_option(param):
-            yield line
-        yield ''
-
-
-def _format_argument(arg):
-    """Format the output of a `click.Argument`."""
-    yield '.. option:: {}'.format(arg.human_readable_name)
-    yield ''
-    yield _indent(
-        '{} argument{}'.format(
-            'Required' if arg.required
-            else 'Optional', '(s)' if arg.nargs != 1 else ''
-        )
-    )
-
-
-def _format_arguments(ctx):
-    """Format all `click.Argument` for a `click.Command`."""
-    params = [x for x in ctx.command.params if isinstance(x, click.Argument)]
-
-    for param in params:
-        for line in _format_argument(param):
-            yield line
-        yield ''
-
-
-def _format_envvar(param):
-    """Format the envvars of a `click.Option` or `click.Argument`."""
-    yield '.. envvar:: {}'.format(param.envvar)
-    yield '   :noindex:'
-    yield ''
-    if isinstance(param, click.Argument):
-        param_ref = param.human_readable_name
-    else:
-        # if a user has defined an opt with multiple "aliases", always use the
-        # first. For example, if '--foo' or '-f' are possible, use '--foo'.
-        param_ref = param.opts[0]
-
-    yield _indent('Provide a default for :option:`{}`'.format(param_ref))
-
-
-def _format_envvars(ctx):
-    """Format all envvars for a `click.Command`."""
-    params = [x for x in ctx.command.params if getattr(x, 'envvar')]
-
-    for param in params:
-        yield '.. _{command_name}-{param_name}-{envvar}:'.format(
-            command_name=ctx.command_path.replace(' ', '-'),
-            param_name=param.name,
-            envvar=param.envvar,
-        )
-        yield ''
-        for line in _format_envvar(param):
-            yield line
-        yield ''
-
-
-def _format_subcommand(command):
-    """Format a sub-command of a `click.Command` or `click.Group`."""
-    yield '.. object:: {}'.format(command.name)
-
-    # click 7.0 stopped setting short_help by default
-    if CLICK_VERSION < (7, 0):
-        short_help = command.short_help
-    else:
-        short_help = command.get_short_help_str()
-
-    if short_help:
-        yield ''
-        for line in statemachine.string2lines(
-            short_help, tab_width=4, convert_whitespace=True
-        ):
-            yield _indent(line)
-
-
-def _format_epilog(ctx):
-    """Format the epilog for a given `click.Command`.
-
-    We parse this as reStructuredText, allowing users to embed rich
-    information in their help messages if they so choose.
-    """
-    epilog_string = ctx.command.epilog
-    if not epilog_string:
-        return
-
-    for line in statemachine.string2lines(
-        epilog_string, tab_width=4, convert_whitespace=True
-    ):
-        yield line
-    yield ''
-
-
-def _get_lazyload_commands(multicommand):
-    commands = {}
-    for command in multicommand.list_commands(multicommand):
-        commands[command] = multicommand.get_command(multicommand, command)
-
-    return commands
-
-
-def _filter_commands(ctx, commands=None):
-    """Return list of used commands."""
-    lookup = getattr(ctx.command, 'commands', {})
-    if not lookup and isinstance(ctx.command, click.MultiCommand):
-        lookup = _get_lazyload_commands(ctx.command)
-
-    if commands is None:
-        return sorted(lookup.values(), key=lambda item: item.name)
-
-    names = [name.strip() for name in commands.split(',')]
-    return [lookup[name] for name in names if name in lookup]
-
-
-def _format_command(ctx, nested, commands=None):
-    """Format the output of `click.Command`."""
-    if CLICK_VERSION >= (7, 0) and ctx.command.hidden:
-        return
-
-    # description
-
-    for line in _format_description(ctx):
-        yield line
-
-    yield '.. program:: {}'.format(ctx.command_path)
-
-    # usage
-
-    for line in _format_usage(ctx):
-        yield line
-
-    # options
-
-    lines = list(_format_options(ctx))
-    if lines:
-        # we use rubric to provide some separation without exploding the table
-        # of contents
-        yield '.. rubric:: Options'
-        yield ''
-
-    for line in lines:
-        yield line
-
-    # arguments
-
-    lines = list(_format_arguments(ctx))
-    if lines:
-        yield '.. rubric:: Arguments'
-        yield ''
-
-    for line in lines:
-        yield line
-
-    # environment variables
-
-    lines = list(_format_envvars(ctx))
-    if lines:
-        yield '.. rubric:: Environment variables'
-        yield ''
-
-    for line in lines:
-        yield line
-
-    # description
-
-    for line in _format_epilog(ctx):
-        yield line
-
-    # if we're nesting commands, we need to do this slightly differently
-    if nested in (NESTED_FULL, NESTED_NONE):
-        return
-
-    commands = _filter_commands(ctx, commands)
-
-    if commands:
-        yield '.. rubric:: Commands'
-        yield ''
-
-    for command in commands:
-        # Don't show hidden subcommands
-        if CLICK_VERSION >= (7, 0) and command.hidden:
-            continue
-
-        for line in _format_subcommand(command):
-            yield line
-        yield ''
-
-
-def nested(argument):
-    values = (NESTED_FULL, NESTED_SHORT, NESTED_NONE)
-    if not argument:
-        return None
-
-    if argument not in values:
-        raise ValueError(
-            "%s is not a valid value for ':nested:'; allowed values: %s"
-            % directives.format_values(values)
-        )
-
-    return argument
-
-
-class ClickDirective(rst.Directive):
-
-    has_content = False
-    required_arguments = 1
     option_spec = {
-        'prog': directives.unchanged_required,
-        'nested': nested,
-        'commands': directives.unchanged,
-        'show-nested': directives.flag,
+        **_ClickDirective.option_spec,
         'semantic-group': directives.unchanged,
     }
-
-    def _load_module(self, module_path):
-        """Load the module."""
-        # __import__ will fail on unicode,
-        # so we ensure module path is a string here.
-        module_path = str(module_path)
-
-        try:
-            module_name, attr_name = module_path.split(':', 1)
-        except ValueError:  # noqa
-            raise self.error(
-                '"{}" is not of format "module:parser"'.format(module_path)
-            )
-
-        try:
-            mod = __import__(module_name, globals(), locals(), [attr_name])
-        except (Exception, SystemExit) as exc:  # noqa
-            err_msg = (
-                'Failed to import "{}" from "{}". '
-                .format(attr_name, module_name)
-            )
-            if isinstance(exc, SystemExit):
-                err_msg += 'The module appeared to call sys.exit()'
-            else:
-                err_msg += 'The following exception was raised:\n{}'.format(
-                    traceback.format_exc()
-                )
-
-            raise self.error(err_msg)
-
-        if not hasattr(mod, attr_name):
-            raise self.error(
-                'Module "{}" has no attribute "{}"'
-                .format(module_name, attr_name)
-            )
-
-        parser = getattr(mod, attr_name)
-
-        if not isinstance(parser, click.BaseCommand):
-            raise self.error(
-                '"{}" of type "{}" is not derived from '
-                '"click.BaseCommand"'.format(type(parser), module_path)
-            )
-        return parser
 
     def _generate_nodes(self, name, command, parent, nested, commands=None,
                         semantic_group=None):
@@ -426,6 +35,8 @@ class ClickDirective(rst.Directive):
         :param nested: The granularity of subcommand details.
         :param commands: Display only listed commands or skip the section if
             empty
+        :param semantic_group: Display this as title with the command
+            description.
         :returns: A list of nested docutil nodes
         """
         ctx = click.Context(command, info_name=name, parent=parent)
@@ -434,13 +45,17 @@ class ClickDirective(rst.Directive):
             return []
 
         # Title
-        label = name if semantic_group is None else semantic_group
+        label = name
+        base_id = ctx.command_path
+        if semantic_group is not None:
+            label = semantic_group
+            base_id = f'{base_id}-{semantic_group}'
 
         section = nodes.section(
             '',
             nodes.title(text=label),
-            ids=[nodes.make_id(ctx.command_path)],
-            names=[nodes.fully_normalize_name(ctx.command_path)],
+            ids=[nodes.make_id(base_id)],
+            names=[nodes.fully_normalize_name(base_id)],
         )
 
         # Summary
@@ -478,20 +93,11 @@ class ClickDirective(rst.Directive):
             raise self.error(':prog: must be specified')
 
         prog_name = self.options.get('prog')
-        show_nested = 'show-nested' in self.options
         nested = self.options.get('nested')
 
+        show_nested = 'show-nested' in self.options
         if show_nested:
-            if nested:
-                raise self.error(
-                    "':nested:' and ':show-nested:' are mutually exclusive"
-                )
-            else:
-                warnings.warn(
-                    "':show-nested:' is deprecated; use ':nested: full'",
-                    DeprecationWarning,
-                )
-                nested = NESTED_FULL if show_nested else NESTED_SHORT
+            raise self.error("':show-nested:' has been removed")
 
         commands = self.options.get('commands')
         semantic_group = self.options.get('semantic-group')

--- a/doc/sphinxext/sphinx_click_semantic_group.py
+++ b/doc/sphinxext/sphinx_click_semantic_group.py
@@ -1,6 +1,5 @@
 import click
 from docutils import nodes
-from docutils.parsers.rst import directives
 from docutils import statemachine
 from sphinx.util import logging
 from sphinx.util import nodes as sphinx_nodes
@@ -18,13 +17,8 @@ CLICK_VERSION = tuple(int(x) for x in click.__version__.split('.')[0:2])
 
 class ClickDirective(_ClickDirective):
 
-    option_spec = {
-        **_ClickDirective.option_spec,
-        'semantic-group': directives.unchanged,
-    }
-
     def _generate_nodes(self, name, command, parent, nested, commands=None,
-                        semantic_group=None):
+                        semantic_group=False):
         """Generate the relevant Sphinx nodes.
 
         Format a `click.Group` or `click.Command`.
@@ -35,8 +29,8 @@ class ClickDirective(_ClickDirective):
         :param nested: The granularity of subcommand details.
         :param commands: Display only listed commands or skip the section if
             empty
-        :param semantic_group: Display this as title with the command
-            description.
+        :param semantic_group: Display command as title and description for
+            CommandCollection.
         :returns: A list of nested docutil nodes
         """
         ctx = click.Context(command, info_name=name, parent=parent)
@@ -45,27 +39,21 @@ class ClickDirective(_ClickDirective):
             return []
 
         # Title
-        label = name
-        base_id = ctx.command_path
-        if semantic_group is not None:
-            label = semantic_group
-            base_id = f'{base_id}-{semantic_group}'
-
         section = nodes.section(
             '',
-            nodes.title(text=label),
-            ids=[nodes.make_id(base_id)],
-            names=[nodes.fully_normalize_name(base_id)],
+            nodes.title(text=name),
+            ids=[nodes.make_id(ctx.command_path)],
+            names=[nodes.fully_normalize_name(ctx.command_path)],
         )
 
         # Summary
         source_name = ctx.command_path
         result = statemachine.ViewList()
 
-        if semantic_group is None:
-            lines = _format_command(ctx, nested, commands)
-        else:
+        if semantic_group:
             lines = _format_description(ctx)
+        else:
+            lines = _format_command(ctx, nested, commands)
 
         for line in lines:
             LOG.debug(line)
@@ -76,35 +64,22 @@ class ClickDirective(_ClickDirective):
         # Subcommands
 
         if nested == NESTED_FULL:
-            commands = _filter_commands(ctx, commands)
-            for command in commands:
-                section.extend(
-                    self._generate_nodes(command.name, command, ctx, nested)
-                )
+            if isinstance(command, click.CommandCollection):
+                for source in command.sources:
+                    section.extend(
+                        self._generate_nodes(source.name, source, ctx, nested,
+                                             semantic_group=True)
+                    )
+            else:
+                commands = _filter_commands(ctx, commands)
+                for command in commands:
+                    parent = ctx if not semantic_group else ctx.parent
+                    section.extend(
+                        self._generate_nodes(command.name, command, parent,
+                                             nested)
+                    )
 
         return [section]
-
-    def run(self):
-        self.env = self.state.document.settings.env
-
-        command = self._load_module(self.arguments[0])
-
-        if 'prog' not in self.options:
-            raise self.error(':prog: must be specified')
-
-        prog_name = self.options.get('prog')
-        nested = self.options.get('nested')
-
-        show_nested = 'show-nested' in self.options
-        if show_nested:
-            raise self.error("':show-nested:' has been removed")
-
-        commands = self.options.get('commands')
-        semantic_group = self.options.get('semantic-group')
-
-        return self._generate_nodes(
-            prog_name, command, None, nested, commands, semantic_group
-        )
 
 
 def setup(app):

--- a/doc/sphinxext/sphinx_click_semantic_group.py
+++ b/doc/sphinxext/sphinx_click_semantic_group.py
@@ -1,0 +1,505 @@
+import traceback
+import warnings
+
+import click
+from docutils import nodes
+from docutils.parsers import rst
+from docutils.parsers.rst import directives
+from docutils import statemachine
+from sphinx.util import logging
+from sphinx.util import nodes as sphinx_nodes
+
+LOG = logging.getLogger(__name__)
+CLICK_VERSION = tuple(int(x) for x in click.__version__.split('.')[0:2])
+
+NESTED_FULL = 'full'
+NESTED_SHORT = 'short'
+NESTED_NONE = 'none'
+
+
+def _indent(text, level=1):
+    prefix = ' ' * (4 * level)
+
+    def prefixed_lines():
+        for line in text.splitlines(True):
+            yield (prefix + line if line.strip() else line)
+
+    return ''.join(prefixed_lines())
+
+
+def _get_usage(ctx):
+    """Alternative, non-prefixed version of 'get_usage'."""
+    formatter = ctx.make_formatter()
+    pieces = ctx.command.collect_usage_pieces(ctx)
+    formatter.write_usage(ctx.command_path, ' '.join(pieces), prefix='')
+    return formatter.getvalue().rstrip('\n')
+
+
+def _get_help_record(opt):
+    """Re-implementation of click.Opt.get_help_record.
+
+    The variant of 'get_help_record' found in Click makes uses of slashes to
+    separate multiple opts, and formats option arguments using upper case. This
+    is not compatible with Sphinx's 'option' directive, which expects
+    comma-separated opts and option arguments surrounded by angle brackets [1].
+
+    [1] http://www.sphinx-doc.org/en/stable/domains.html#directive-option
+    """
+
+    def _write_opts(opts):
+        rv, _ = click.formatting.join_options(opts)
+        if not opt.is_flag and not opt.count:
+            name = opt.name
+            if opt.metavar:
+                name = opt.metavar.lstrip('<[{($').rstrip('>]})$')
+            rv += ' <{}>'.format(name)
+        return rv
+
+    rv = [_write_opts(opt.opts)]
+    if opt.secondary_opts:
+        rv.append(_write_opts(opt.secondary_opts))
+
+    out = []
+    if opt.help:
+        if opt.required:
+            out.append('**Required** %s' % opt.help)
+        else:
+            out.append(opt.help)
+    else:
+        if opt.required:
+            out.append('**Required**')
+
+    extras = []
+
+    if opt.default is not None and opt.show_default:
+        if isinstance(opt.show_default, str):
+            # Starting from Click 7.0 this can be a string as well. This is
+            # mostly useful when the default is not a constant and
+            # documentation thus needs a manually written string.
+            extras.append(':default: %s' % opt.show_default)
+        else:
+            extras.append(
+                ':default: %s'
+                % (
+                    ', '.join('%s' % d for d in opt.default)
+                    if isinstance(opt.default, (list, tuple))
+                    else opt.default,
+                )
+            )
+
+    if isinstance(opt.type, click.Choice):
+        extras.append(':options: %s' % ' | '.join(opt.type.choices))
+
+    if extras:
+        if out:
+            out.append('')
+
+        out.extend(extras)
+
+    return ', '.join(rv), '\n'.join(out)
+
+
+def _format_description(ctx):
+    """Format the description for a given `click.Command`.
+
+    We parse this as reStructuredText, allowing users to embed rich
+    information in their help messages if they so choose.
+    """
+    help_string = ctx.command.help or ctx.command.short_help
+    if not help_string:
+        return
+
+    bar_enabled = False
+    for line in statemachine.string2lines(
+        help_string, tab_width=4, convert_whitespace=True
+    ):
+        if line == '\b':
+            bar_enabled = True
+            continue
+        if line == '':
+            bar_enabled = False
+        line = '| ' + line if bar_enabled else line
+        yield line
+    yield ''
+
+
+def _format_usage(ctx):
+    """Format the usage for a `click.Command`."""
+    yield '.. code-block:: shell'
+    yield ''
+    for line in _get_usage(ctx).splitlines():
+        yield _indent(line)
+    yield ''
+
+
+def _format_option(opt):
+    """Format the output for a `click.Option`."""
+    opt = _get_help_record(opt)
+
+    yield '.. option:: {}'.format(opt[0])
+    if opt[1]:
+        yield ''
+        for line in statemachine.string2lines(
+            opt[1], tab_width=4, convert_whitespace=True
+        ):
+            yield _indent(line)
+
+
+def _format_options(ctx):
+    """Format all `click.Option` for a `click.Command`."""
+    # the hidden attribute is part of click 7.x only hence use of getattr
+    params = [
+        param
+        for param in ctx.command.params
+        if (isinstance(param, click.Option)
+            and not getattr(param, 'hidden', False))
+    ]
+
+    for param in params:
+        for line in _format_option(param):
+            yield line
+        yield ''
+
+
+def _format_argument(arg):
+    """Format the output of a `click.Argument`."""
+    yield '.. option:: {}'.format(arg.human_readable_name)
+    yield ''
+    yield _indent(
+        '{} argument{}'.format(
+            'Required' if arg.required
+            else 'Optional', '(s)' if arg.nargs != 1 else ''
+        )
+    )
+
+
+def _format_arguments(ctx):
+    """Format all `click.Argument` for a `click.Command`."""
+    params = [x for x in ctx.command.params if isinstance(x, click.Argument)]
+
+    for param in params:
+        for line in _format_argument(param):
+            yield line
+        yield ''
+
+
+def _format_envvar(param):
+    """Format the envvars of a `click.Option` or `click.Argument`."""
+    yield '.. envvar:: {}'.format(param.envvar)
+    yield '   :noindex:'
+    yield ''
+    if isinstance(param, click.Argument):
+        param_ref = param.human_readable_name
+    else:
+        # if a user has defined an opt with multiple "aliases", always use the
+        # first. For example, if '--foo' or '-f' are possible, use '--foo'.
+        param_ref = param.opts[0]
+
+    yield _indent('Provide a default for :option:`{}`'.format(param_ref))
+
+
+def _format_envvars(ctx):
+    """Format all envvars for a `click.Command`."""
+    params = [x for x in ctx.command.params if getattr(x, 'envvar')]
+
+    for param in params:
+        yield '.. _{command_name}-{param_name}-{envvar}:'.format(
+            command_name=ctx.command_path.replace(' ', '-'),
+            param_name=param.name,
+            envvar=param.envvar,
+        )
+        yield ''
+        for line in _format_envvar(param):
+            yield line
+        yield ''
+
+
+def _format_subcommand(command):
+    """Format a sub-command of a `click.Command` or `click.Group`."""
+    yield '.. object:: {}'.format(command.name)
+
+    # click 7.0 stopped setting short_help by default
+    if CLICK_VERSION < (7, 0):
+        short_help = command.short_help
+    else:
+        short_help = command.get_short_help_str()
+
+    if short_help:
+        yield ''
+        for line in statemachine.string2lines(
+            short_help, tab_width=4, convert_whitespace=True
+        ):
+            yield _indent(line)
+
+
+def _format_epilog(ctx):
+    """Format the epilog for a given `click.Command`.
+
+    We parse this as reStructuredText, allowing users to embed rich
+    information in their help messages if they so choose.
+    """
+    epilog_string = ctx.command.epilog
+    if not epilog_string:
+        return
+
+    for line in statemachine.string2lines(
+        epilog_string, tab_width=4, convert_whitespace=True
+    ):
+        yield line
+    yield ''
+
+
+def _get_lazyload_commands(multicommand):
+    commands = {}
+    for command in multicommand.list_commands(multicommand):
+        commands[command] = multicommand.get_command(multicommand, command)
+
+    return commands
+
+
+def _filter_commands(ctx, commands=None):
+    """Return list of used commands."""
+    lookup = getattr(ctx.command, 'commands', {})
+    if not lookup and isinstance(ctx.command, click.MultiCommand):
+        lookup = _get_lazyload_commands(ctx.command)
+
+    if commands is None:
+        return sorted(lookup.values(), key=lambda item: item.name)
+
+    names = [name.strip() for name in commands.split(',')]
+    return [lookup[name] for name in names if name in lookup]
+
+
+def _format_command(ctx, nested, commands=None):
+    """Format the output of `click.Command`."""
+    if CLICK_VERSION >= (7, 0) and ctx.command.hidden:
+        return
+
+    # description
+
+    for line in _format_description(ctx):
+        yield line
+
+    yield '.. program:: {}'.format(ctx.command_path)
+
+    # usage
+
+    for line in _format_usage(ctx):
+        yield line
+
+    # options
+
+    lines = list(_format_options(ctx))
+    if lines:
+        # we use rubric to provide some separation without exploding the table
+        # of contents
+        yield '.. rubric:: Options'
+        yield ''
+
+    for line in lines:
+        yield line
+
+    # arguments
+
+    lines = list(_format_arguments(ctx))
+    if lines:
+        yield '.. rubric:: Arguments'
+        yield ''
+
+    for line in lines:
+        yield line
+
+    # environment variables
+
+    lines = list(_format_envvars(ctx))
+    if lines:
+        yield '.. rubric:: Environment variables'
+        yield ''
+
+    for line in lines:
+        yield line
+
+    # description
+
+    for line in _format_epilog(ctx):
+        yield line
+
+    # if we're nesting commands, we need to do this slightly differently
+    if nested in (NESTED_FULL, NESTED_NONE):
+        return
+
+    commands = _filter_commands(ctx, commands)
+
+    if commands:
+        yield '.. rubric:: Commands'
+        yield ''
+
+    for command in commands:
+        # Don't show hidden subcommands
+        if CLICK_VERSION >= (7, 0) and command.hidden:
+            continue
+
+        for line in _format_subcommand(command):
+            yield line
+        yield ''
+
+
+def nested(argument):
+    values = (NESTED_FULL, NESTED_SHORT, NESTED_NONE)
+    if not argument:
+        return None
+
+    if argument not in values:
+        raise ValueError(
+            "%s is not a valid value for ':nested:'; allowed values: %s"
+            % directives.format_values(values)
+        )
+
+    return argument
+
+
+class ClickDirective(rst.Directive):
+
+    has_content = False
+    required_arguments = 1
+    option_spec = {
+        'prog': directives.unchanged_required,
+        'nested': nested,
+        'commands': directives.unchanged,
+        'show-nested': directives.flag,
+        'semantic-group': directives.unchanged,
+    }
+
+    def _load_module(self, module_path):
+        """Load the module."""
+        # __import__ will fail on unicode,
+        # so we ensure module path is a string here.
+        module_path = str(module_path)
+
+        try:
+            module_name, attr_name = module_path.split(':', 1)
+        except ValueError:  # noqa
+            raise self.error(
+                '"{}" is not of format "module:parser"'.format(module_path)
+            )
+
+        try:
+            mod = __import__(module_name, globals(), locals(), [attr_name])
+        except (Exception, SystemExit) as exc:  # noqa
+            err_msg = (
+                'Failed to import "{}" from "{}". '
+                .format(attr_name, module_name)
+            )
+            if isinstance(exc, SystemExit):
+                err_msg += 'The module appeared to call sys.exit()'
+            else:
+                err_msg += 'The following exception was raised:\n{}'.format(
+                    traceback.format_exc()
+                )
+
+            raise self.error(err_msg)
+
+        if not hasattr(mod, attr_name):
+            raise self.error(
+                'Module "{}" has no attribute "{}"'
+                .format(module_name, attr_name)
+            )
+
+        parser = getattr(mod, attr_name)
+
+        if not isinstance(parser, click.BaseCommand):
+            raise self.error(
+                '"{}" of type "{}" is not derived from '
+                '"click.BaseCommand"'.format(type(parser), module_path)
+            )
+        return parser
+
+    def _generate_nodes(self, name, command, parent, nested, commands=None,
+                        semantic_group=None):
+        """Generate the relevant Sphinx nodes.
+
+        Format a `click.Group` or `click.Command`.
+
+        :param name: Name of command, as used on the command line
+        :param command: Instance of `click.Group` or `click.Command`
+        :param parent: Instance of `click.Context`, or None
+        :param nested: The granularity of subcommand details.
+        :param commands: Display only listed commands or skip the section if
+            empty
+        :returns: A list of nested docutil nodes
+        """
+        ctx = click.Context(command, info_name=name, parent=parent)
+
+        if CLICK_VERSION >= (7, 0) and command.hidden:
+            return []
+
+        # Title
+        label = name if semantic_group is None else semantic_group
+
+        section = nodes.section(
+            '',
+            nodes.title(text=label),
+            ids=[nodes.make_id(ctx.command_path)],
+            names=[nodes.fully_normalize_name(ctx.command_path)],
+        )
+
+        # Summary
+        source_name = ctx.command_path
+        result = statemachine.ViewList()
+
+        if semantic_group is None:
+            lines = _format_command(ctx, nested, commands)
+        else:
+            lines = _format_description(ctx)
+
+        for line in lines:
+            LOG.debug(line)
+            result.append(line, source_name)
+
+        sphinx_nodes.nested_parse_with_titles(self.state, result, section)
+
+        # Subcommands
+
+        if nested == NESTED_FULL:
+            commands = _filter_commands(ctx, commands)
+            for command in commands:
+                section.extend(
+                    self._generate_nodes(command.name, command, ctx, nested)
+                )
+
+        return [section]
+
+    def run(self):
+        self.env = self.state.document.settings.env
+
+        command = self._load_module(self.arguments[0])
+
+        if 'prog' not in self.options:
+            raise self.error(':prog: must be specified')
+
+        prog_name = self.options.get('prog')
+        show_nested = 'show-nested' in self.options
+        nested = self.options.get('nested')
+
+        if show_nested:
+            if nested:
+                raise self.error(
+                    "':nested:' and ':show-nested:' are mutually exclusive"
+                )
+            else:
+                warnings.warn(
+                    "':show-nested:' is deprecated; use ':nested: full'",
+                    DeprecationWarning,
+                )
+                nested = NESTED_FULL if show_nested else NESTED_SHORT
+
+        commands = self.options.get('commands')
+        semantic_group = self.options.get('semantic-group')
+
+        return self._generate_nodes(
+            prog_name, command, None, nested, commands, semantic_group
+        )
+
+
+def setup(app):
+    app.add_directive('click', ClickDirective)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -46,7 +46,7 @@ CLI
 BUG
 ~~~
 
-- Throw a warning when benchopt version in conda env does not match the one of
+- Throw a warning when BenchOpt version in conda env does not match the one of
   calling ``benchopt``, by `Thomas Moreau`_ (:gh:`83`).
 
 - Fix Lapack issue with R code, by `Tanguy Lefort`_ (:gh:`97`).

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,8 +19,8 @@ Changelog
 - Support plotly for plotting functions, by `Thomas Moreau`_,
   `Tanguy Lefort`_ and `Joseph Salmon`_ (:gh:`110`, :gh:`111`, :gh:`112`).
 
-- Add ``benchopt publish`` command to push benchmark results to GitHub,
-  by `Thomas Moreau`_ (:gh:`110`).
+- Change envrionment variable for config from `BENCHO_*` to `BENCHOPT_*`,
+  by `Thomas Moreau`_ (:gh:`128`).
 
 API
 ~~~
@@ -42,6 +42,15 @@ CLI
 - Change default run to local mode. Can call a run in a dedicated env with
   option ``--env`` or ``--env-name ENV_NAME`` to specify the env,
   by `Thomas Moreau`_ (:gh:`94`).
+
+- Add ``benchopt publish`` command to push benchmark results to GitHub,
+  by `Thomas Moreau`_ (:gh:`110`).
+
+- Add ``benchopt clean`` command to remove cached file and output files locally,
+  by `Thomas Moreau`_ (:gh:`128`).
+
+- Add ``benchopt config`` command to allow easy configuration of ``benchopt``
+  using the CLI, by `Thomas Moreau`_ (:gh:`128`).
 
 BUG
 ~~~

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     install_requires=['numpy', 'scipy', 'pandas', 'matplotlib',
                       'click', 'joblib', 'pygithub'],
     entry_points={
-        'console_scripts': ['benchopt = benchopt.cli:main']
+        'console_scripts': ['benchopt = benchopt.cli:benchopt']
     }
 )


### PR DESCRIPTION
- [x] Refactor the client to have easier to maintain structure.
- [x] Add `clean` command to solve #125 
- [x] Add `config` command to make it easier to configurate `benchopt`. In particular, storing token, passing conda prefix if it is not in `PATH`, ...
- [x] Narrative doc for config.
- [x] Set permission for config file to user read/write only. Warn if it is not the case.