### PR TITLE
Enable autocompletion for BENCHMARK argument

### DIFF
--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -32,8 +32,10 @@ def get_datasets(ctx, args, incomplete):
 
 def get_benchmark(ctx, args, incomplete):
     skip_import()
-    benchmarks = [b.path for b in os.scandir('.') if b.is_dir()]
-    return [os.curdir] + [b for b in benchmarks if incomplete in b]
+    benchmarks = [os.curdir] + [b.path for b in os.scandir('.') if b.is_dir()]
+    benchmarks = [b for b in benchmarks
+                    if os.path.isfile(os.path.join(b, "objective.py"))]
+    return [b for b in benchmarks if incomplete in b]
 
 
 @main.command(

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -33,7 +33,7 @@ def get_datasets(ctx, args, incomplete):
 def get_benchmark(ctx, args, incomplete):
     skip_import()
     benchmarks = [b.path for b in os.scandir('.') if b.is_dir()]
-    return [b for b in benchmarks if incomplete in b]
+    return [os.curdir] + [b for b in benchmarks if incomplete in b]
 
 
 @main.command(

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -1,3 +1,4 @@
+import os
 import click
 from pathlib import Path
 
@@ -29,10 +30,17 @@ def get_datasets(ctx, args, incomplete):
     return [d for d in datasets if incomplete.lower() in d]
 
 
+def get_benchmark(ctx, args, incomplete):
+    skip_import()
+    benchmarks = [b.path for b in os.scandir('.') if b.is_dir()]
+    return [b for b in benchmarks if incomplete in b]
+
+
 @main.command(
     help="Run a benchmark with benchopt."
 )
-@click.argument('benchmark', type=click.Path(exists=True))
+@click.argument('benchmark', type=click.Path(exists=True),
+                autocompletion=get_benchmark)
 @click.option('--recreate',
               is_flag=True,
               help="If this flag is set, start with a fresh conda env.")

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -34,7 +34,7 @@ def get_benchmark(ctx, args, incomplete):
     skip_import()
     benchmarks = [os.curdir] + [b.path for b in os.scandir('.') if b.is_dir()]
     benchmarks = [b for b in benchmarks
-                    if os.path.isfile(os.path.join(b, "objective.py"))]
+                  if (Path(b) / "objective.py").exists()]
     return [b for b in benchmarks if incomplete in b]
 
 


### PR DESCRIPTION
When click autocompletion is activated, `benchopt run` suggests the list of sub-directories in current directory for the BENCHMARK argument.