### PR TITLE
temporary install instruction while PyPI version is not up-to-date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,11 +43,17 @@ Learn how to `write a benchmark on our documentation <https://benchopt.github.io
 Install
 --------
 
-This package can be installed through `pip` using:
+This package can be installed through `pip`. To get the **last release**, use:
 
 .. code-block::
 
     $ pip install benchopt
+
+And to get the **latest development version**, you can use:
+
+.. code-block::
+
+    $ pip install -U https://github.com/benchopt/benchOpt/archive/master.zip
 
 This will install the command line tool to run the benchmark. Then, existing
 benchmarks can be retrieved from git or created locally. For instance, the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,8 @@ This package can be installed through `pip` using:
 
 .. code-block::
 
-    $ pip install benchopt
+    $ git clone https://github.com/benchopt/benchOpt
+    $ pip install -e benchOpt
 
 This will install the command line tool to run the benchmark. Then, existing
 benchmarks can be retrieved from git or created locally. To discover which

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -35,12 +35,21 @@ Learn how to :ref:`how`.
 Install
 --------
 
-This package can be installed through `pip` using:
+This package can be installed through `pip`. To get the **last release**, use:
 
 .. code-block::
 
-    $ git clone https://github.com/benchopt/benchOpt
-    $ pip install -e benchOpt
+    $ pip install benchopt
+
+And to get the **latest development version**, you can use:
+
+.. code-block::
+
+    $ pip install -U https://github.com/benchopt/benchOpt/archive/master.zip
+
+**Note:** due to major API modifications, the last ``benchopt`` release does
+not correspond to the latest version of the documentation at the moment.
+Until further notice, it is recommended to use the development version.
 
 This will install the command line tool to run the benchmark. Then, existing
 benchmarks can be retrieved from git or created locally. To discover which


### PR DESCRIPTION
Temporary update of installation instruction:
```
$ git clone https://github.com/benchopt/benchOpt
$ pip install -e benchOpt
```
to replace `pip install benchopt` while PyPI version is 1.0.0 and thus not compatible with current version of the doc (c.f. #130)