### PR TITLE
DBG fail in benchopt test due to sys.path modification

### DIFF
--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -176,7 +176,7 @@ def test(benchmark, env_name, pytest_args):
 
     cmd = (
         f'pytest {pytest_args} {BENCHMARK_TEST_FILE} '
-        f'--benchmark {benchmark} {env_option}'
+        f'--benchmark {benchmark} {env_option} '
         # Make sure to not modify sys.path to add test file from current env
         # in sub conda env as there might be different python versions.
         '--import-mode importlib'

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -177,6 +177,9 @@ def test(benchmark, env_name, pytest_args):
     cmd = (
         f'pytest {pytest_args} {BENCHMARK_TEST_FILE} '
         f'--benchmark {benchmark} {env_option}'
+        # Make sure to not modify sys.path to add test file from current env
+        # in sub conda env as there might be different python versions.
+        '--import-mode importlib'
     )
 
     raise SystemExit(_run_shell_in_conda_env(

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -5,7 +5,7 @@ import subprocess
 from shutil import which
 from pathlib import Path
 
-from benchopt.utils.stream_redirection import SuppressStd
+from .stream_redirection import SuppressStd
 
 
 def _get_processor_name():
@@ -38,7 +38,7 @@ def _get_cuda_version():
 def _get_numpy_libs():
     "Return info on 'Blas/Lapack' lib linked to numpy."
 
-    # Import are nested to avoid long import time.
+    # Import is nested to avoid long import time.
     import numpy as np
 
     with SuppressStd() as capture:

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -5,10 +5,6 @@ import subprocess
 from shutil import which
 from pathlib import Path
 
-import scipy
-import numpy as np
-from joblib import cpu_count
-
 from .stream_redirection import SuppressStd
 
 
@@ -41,6 +37,10 @@ def _get_cuda_version():
 
 def _get_numpy_libs():
     "Return info on 'Blas/Lapack' lib linked to numpy."
+
+    # Import are nested to avoid long import time.
+    import numpy as np
+
     with SuppressStd() as capture:
         np.show_config()
     lines = capture.output.splitlines()
@@ -63,6 +63,13 @@ def _get_numpy_libs():
 
 def get_sys_info():
     "Return a dictionary with info from the current system."
+
+    # Import are nested to avoid long import time when func is not called
+    import scipy
+    import psutil
+    import numpy as np
+    from joblib import cpu_count
+
     info = {}
 
     # Info on the env
@@ -75,7 +82,6 @@ def get_sys_info():
     info["platform-version"] = platform.version()
 
     # Info on the hardware
-    import psutil
     info["system-cpus"] = cpu_count()
     info["system-processor"] = _get_processor_name()
     info["system-ram (GB)"] = round(

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -1,6 +1,5 @@
 import os
 import re
-import psutil
 import platform
 import subprocess
 from shutil import which
@@ -76,6 +75,7 @@ def get_sys_info():
     info["platform-version"] = platform.version()
 
     # Info on the hardware
+    import psutil
     info["system-cpus"] = cpu_count()
     info["system-processor"] = _get_processor_name()
     info["system-ram (GB)"] = round(

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -5,7 +5,7 @@ import subprocess
 from shutil import which
 from pathlib import Path
 
-from .stream_redirection import SuppressStd
+from benchopt.utils.stream_redirection import SuppressStd
 
 
 def _get_processor_name():


### PR DESCRIPTION
tests in benchopt/benchmark_lasso#20 fail because when importing a test, `pytest` modify the `sys.path` by pre-pending the root in it. This can cause failure in case the calling `benchopt` is installed in `python3.8` and the conda env where the test are run is with `python3.9`, as the packages are imported from the wrong site-package.

This PR make use of the `--import-mode importlib` option from `pytest` which does not modify the python path, as described here: https://docs.pytest.org/en/stable/pythonpath.html