### PR TITLE
ENH add xfail config file for benchmark test

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -117,6 +117,18 @@ class Benchmark:
         "Get the location for the config file of the benchmark."
         return self.benchmark_dir / 'config.ini'
 
+    def get_xfail_file(self):
+        """Get the location for the xfail file for the benchmark.
+
+        This file will serve to check is a test should be xfailed on specific
+        solvers and platforms when we have install or running problems.
+        Returns None if this file does not exists.
+        """
+        xfail_file = self.benchmark_dir / 'xfail.py'
+        if not xfail_file.exists():
+            return None
+        return xfail_file
+
     def get_output_folder(self):
         """Get the folder to store the output of the benchmark.
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -120,8 +120,8 @@ class Benchmark:
     def get_xfail_file(self):
         """Get the location for the xfail file for the benchmark.
 
-        This file will serve to check is a test should be xfailed on specific
-        solvers and platforms when we have install or running problems.
+        This file will be used to check if a test should be xfailed on specific
+        solvers and platforms when we have installation or running issues.
         Returns None if this file does not exists.
         """
         xfail_file = self.benchmark_dir / 'xfail.py'

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from benchopt.benchmark import Benchmark
 
-
+# Default benchmark
 TEST_BENCHMARK_DIR = Path(__file__).parent / 'test_benchmarks'
 DUMMY_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'dummy_benchmark'
+
+# Pattern to select specific datasets or solvers.
 SELECT_ONE_SIMULATED = r'simulated*500*rho=0\]'
 SELECT_ONE_PGD = r'python-pgd*step_size=1\]'
 

--- a/benchopt/tests/conftest.py
+++ b/benchopt/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from benchopt.benchmark import Benchmark
 from benchopt.utils.shell_cmd import delete_conda_env
 from benchopt.utils.shell_cmd import create_conda_env
+from benchopt.utils.dynamic_modules import _get_module_from_file
 
 from benchopt.tests import TEST_BENCHMARK_DIR
 
@@ -14,15 +15,10 @@ os.environ['BENCHOPT_RAISE_INSTALL_ERROR'] = '1'
 _TEST_ENV_NAME = None
 
 
-def class_ids(parameters):
-    name_id = ''
-    for p in parameters:
-        if hasattr(p, 'name'):
-            p = p.name.lower()
-        name_id = f'{name_id}-{p}'
-    if name_id.startswith('-'):
-        name_id = name_id[1:]
-    return name_id
+def class_ids(p):
+    if hasattr(p, 'name'):
+        return p.name.lower()
+    return str(p)
 
 
 def pytest_report_header(config):
@@ -61,28 +57,50 @@ def pytest_generate_tests(metafunc):
     """Generate the test on the fly to take --benchmark into account.
     """
     PARAMETRIZATION = {
-        'benchmark_dataset_simu': lambda benchmarks: [
+        ('benchmark', 'dataset_simu'): lambda benchmarks: [
             (benchmark, dataset_class) for benchmark in benchmarks
             for dataset_class in benchmark.list_benchmark_datasets()
             if dataset_class.name.lower() == 'simulated'
         ],
-        'benchmark_dataset': lambda benchmarks: [
+        ('benchmark', 'dataset_class'): lambda benchmarks: [
             (benchmark, dataset_class) for benchmark in benchmarks
             for dataset_class in benchmark.list_benchmark_datasets()
         ],
-        'benchmark_solver': lambda benchmarks: [
+        ('benchmark', 'solver_class'): lambda benchmarks: [
             (benchmark, solver) for benchmark in benchmarks
             for solver in benchmark.list_benchmark_solvers()
         ]
     }
+
+    # Get all benchmarks
+    benchmarks = metafunc.config.getoption("benchmark")
+    if benchmarks is None or len(benchmarks) == 0:
+        benchmarks = TEST_BENCHMARK_DIR.glob('*/')
+    benchmarks = [Benchmark(b) for b in benchmarks]
+    benchmarks.sort()
+
+    # Parametrize the tests
     for params, func in PARAMETRIZATION.items():
-        if params in metafunc.fixturenames:
-            benchmarks = metafunc.config.getoption("benchmark")
-            if benchmarks is None or len(benchmarks) == 0:
-                benchmarks = TEST_BENCHMARK_DIR.glob('*/')
-            benchmarks = [Benchmark(b) for b in benchmarks]
-            benchmarks.sort()
+        if set(params).issubset(metafunc.fixturenames):
             metafunc.parametrize(params, func(benchmarks), ids=class_ids)
+
+
+@pytest.fixture
+def xfail_check(request):
+
+    if 'benchmark' not in request.fixturenames:
+        raise ValueError(
+            '`xfail_check` fixture should only be used in tests parametrized '
+            'with `benchmark` fixture'
+        )
+
+    benchmark = request.getfixturevalue('benchmark')
+    xfail_file = benchmark.get_xfail_file()
+    if xfail_file is None:
+        return None
+    xfail_module = _get_module_from_file(xfail_file)
+    xfail_func_name = f"xfail_{request.function.__name__}"
+    return getattr(xfail_module, xfail_func_name, None)
 
 
 @pytest.fixture(scope='session')

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -7,13 +7,12 @@ import numpy as np
 from benchopt.base import STOP_STRATEGIES
 
 
-def test_benchmark_objective(benchmark_dataset_simu):
+def test_benchmark_objective(benchmark, dataset_simu):
     """Check that the objective function and the datasets are well defined."""
-    benchmark, dataset_class = benchmark_dataset_simu
     objective_class = benchmark.get_benchmark_objective()
     objective = objective_class.get_instance()
 
-    dataset = dataset_class.get_instance()
+    dataset = dataset_simu.get_instance()
     dimension, data = dataset._get_data()
     objective.set_data(**data)
 
@@ -34,9 +33,8 @@ def test_benchmark_objective(benchmark_dataset_simu):
     )
 
 
-def test_dataset_class(benchmark_dataset):
+def test_dataset_class(benchmark, dataset_class):
     """Check that all dataset_class respects the public API"""
-    _, dataset_class = benchmark_dataset
 
     # Check that the dataset_class exposes a name
     assert hasattr(dataset_class, 'name'), "All dataset should expose a name"
@@ -54,10 +52,9 @@ def test_dataset_class(benchmark_dataset):
     )
 
 
-def test_dataset_get_data(benchmark_dataset):
+def test_dataset_get_data(benchmark, dataset_class):
     """Check that all installed dataset_class.get_data return the right result
     """
-    _, dataset_class = benchmark_dataset
 
     # skip the test if the dataset is not installed
     if not dataset_class.is_installed():
@@ -91,10 +88,8 @@ def test_dataset_get_data(benchmark_dataset):
     )
 
 
-def test_solver_class(benchmark_solver):
+def test_solver_class(benchmark, solver_class):
     """Check that all installed solver_class respects the public API"""
-
-    _, solver_class = benchmark_solver
 
     # Check that the solver_class exposes a name
     assert hasattr(solver_class, 'name'), "All solver should expose a name"
@@ -106,9 +101,8 @@ def test_solver_class(benchmark_solver):
     assert solver_class.stop_strategy in STOP_STRATEGIES
 
 
-def test_solver_install_api(benchmark_solver):
+def test_solver_install_api(benchmark, solver_class):
 
-    _, solver_class = benchmark_solver
     # Check that the solver_class exposes a known install cmd
     assert solver_class.install_cmd in [None, 'conda', 'shell']
 
@@ -120,28 +114,20 @@ def test_solver_install_api(benchmark_solver):
 
 
 @pytest.mark.requires_install
-def test_solver_install(test_env_name, benchmark_solver):
+def test_solver_install(test_env_name, benchmark, solver_class, xfail_check):
 
-    benchmark_name, solver_class = benchmark_solver
-
-    if solver_class.name.lower() == 'cyanure' and sys.platform == 'darwin':
-        pytest.skip('Cyanure is not easy to install on macos.')
-
-    # Skip test_solver_install for julia in OSX as there is a version
-    # conflict with conda packages for R
-    # See issue #64
-    if 'julia' in solver_class.name.lower() and sys.platform == 'darwin':
-        pytest.skip('Julia causes segfault on OSX for now.')
+    if xfail_check is not None:
+        xfail_check(solver_class)
 
     # assert that install works when forced to reinstalls
     solver_class.install(env_name=test_env_name)
-    solver_class.is_installed(env_name=test_env_name,
-                              raise_on_not_installed=True)
+    solver_class.is_installed(
+        env_name=test_env_name, raise_on_not_installed=True
+    )
 
 
-def test_solver(benchmark_solver):
+def test_solver(benchmark, solver_class):
 
-    benchmark, solver_class = benchmark_solver
     if not solver_class.is_installed():
         pytest.skip("Solver is not installed")
 
@@ -158,7 +144,8 @@ def test_solver(benchmark_solver):
 
     assert len(simulated_dataset) == 1, (
         "All benchmark need to implement a simulated dataset for "
-        "testing purpose")
+        "testing purpose"
+    )
 
     dataset_class = simulated_dataset[0]
     dataset = dataset_class.get_instance()

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/xfail.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/xfail.py
@@ -1,0 +1,15 @@
+import sys
+
+import pytest
+
+
+def xfail_test_solver_install(solver_class):
+
+    if solver_class.name.lower() == 'cyanure' and sys.platform == 'darwin':
+        pytest.xfail('Cyanure is not easy to install on macos.')
+
+    # Skip test_solver_install for julia in OSX as there is a version
+    # conflict with conda packages for R
+    # See issue #64
+    if 'julia' in solver_class.name.lower() and sys.platform == 'darwin':
+        pytest.xfail('Julia causes segfault on OSX for now.')


### PR DESCRIPTION
Add an API to allow `xfailing` specific solver in benchmark tests easily.

One should add a file `xfail.py` with a function `xfail_test_name` and use the fixeture `xfail_check` to be able to call this function in the test. See `test_benchmakr.py::test_solver_install` for instance. 