### PR TITLE
[ENH]  better hovers with plotly

### DIFF
--- a/benchopt/plotting/helpers_compat.py
+++ b/benchopt/plotting/helpers_compat.py
@@ -16,7 +16,10 @@ def fill_between_x(fig, x, q1, q9, y, color, marker, label, plotly=False):
     fig.add_trace(go.Scatter(
         x=x, y=y,
         line_color=color, marker_symbol=marker, mode='lines+markers',
-        name=label, legendgroup=label, hoverlabel=dict(namelength=-1)
+        name=label, legendgroup=label,
+        hoverlabel=dict(namelength=-1),
+        hovertemplate='%{text} <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
+        text=[label for _ in x]
     ))
     fig.add_trace(go.Scatter(
         x=q1, y=y, mode='lines', showlegend=False,

--- a/benchopt/plotting/helpers_compat.py
+++ b/benchopt/plotting/helpers_compat.py
@@ -16,15 +16,17 @@ def fill_between_x(fig, x, q1, q9, y, color, marker, label, plotly=False):
     fig.add_trace(go.Scatter(
         x=x, y=y,
         line_color=color, marker_symbol=marker, mode='lines+markers',
-        name=label, legendgroup=label,
+        name=label, legendgroup=label, hoverlabel=dict(namelength=-1)
     ))
     fig.add_trace(go.Scatter(
         x=q1, y=y, mode='lines', showlegend=False,
         line={'width': 0, 'color': color}, legendgroup=label,
+        hovertemplate='(%{x:.1e},%{y:.1e}) <extra></extra>',
     ))
     fig.add_trace(go.Scatter(
         x=q9, y=y, mode='lines', fill='tonextx', showlegend=False,
         line={'width': 0, 'color': color}, legendgroup=label,
+        hovertemplate='(%{x:.1e},%{y:.1e}) <extra></extra>',
     ))
 
     return fig


### PR DESCRIPTION
Now the overs show the whole name of the solver (better when different solvers with the same prefix showing)I
And for the quantiles traces, it removes the "trace .." on the right side of the hover box.