### PR TITLE
Stop the solver with callback

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -328,6 +328,8 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
     states = []
 
     with exception_handler(tag, pdb=pdb):
+        if solver.stop_strategy == "callback":
+            n_repetitions += 1  # warmup
         for rep in range(n_repetitions):
             if show_progress:
                 progress_str = (
@@ -354,7 +356,8 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
                     meta=meta_rep, max_runs=max_runs, deadline=deadline,
                     progress_str=progress_str, force=force
                 )
-
+            if rep == 0 and solver.stop_strategy == "callback":
+                continue
             curve.extend(curve_one_rep)
             states.append(status)
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -357,8 +357,6 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
     states = []
 
     with exception_handler(tag, pdb=pdb):
-        if solver.stop_strategy == "callback":
-            n_repetitions += 1  # warmup
         for rep in range(n_repetitions):
             if show_progress:
                 progress_str = (
@@ -385,8 +383,6 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
                     meta=meta_rep, max_runs=max_runs, deadline=deadline,
                     progress_str=progress_str, force=force
                 )
-            if rep == 0 and solver.stop_strategy == "callback":
-                continue
             curve.extend(curve_one_rep)
             states.append(status)
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -236,6 +236,7 @@ class _Callback:
         self.it = 0
         self.time_iter = 0.
         self.next_stopval = 0
+        self.prev_objective = 1e10
         self.time_callback = time.perf_counter()
 
     def __call__(self, x):
@@ -254,7 +255,12 @@ class _Callback:
                 return False
             if self.it == self.max_iter:
                 return False
+            current_obj = objective_dict["objective_value"]
+            if (-EPS <= self.prev_objective - current_obj <= EPS):
+                self.status = 'done'
+                return False
 
+            self.prev_objective = current_obj
             self.next_stopval = min(
                 get_next(self.next_stopval, strategy="iteration"),
                 self.max_iter

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -248,6 +248,9 @@ class _Callback:
     next_stopval : int
         The next iteration for which the curve should be
         updated.
+    prev_objective : float
+        The objective value at the previous iteration. Set to
+        inf at start.
     time_callback : float
         The time when exiting the callback call.
     """
@@ -262,7 +265,7 @@ class _Callback:
         self.it = 0
         self.time_iter = 0.
         self.next_stopval = 0
-        self.prev_objective = 1e10
+        self.prev_objective = math.inf
         self.time_callback = time.perf_counter()
 
     def __call__(self, x):


### PR DESCRIPTION
Use delta objective to stop the solver when using callbacks.
O.w, it went on until MAXITER was reached and because of the timeout only did one run and results were biased (see comment below, thank you @agramfort for noticing the problem).

See [nlls PR](https://github.com/benchopt/benchmark_nnls/pull/5) for a plot.