### PR TITLE
ENH add stopping criterion

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -120,9 +120,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
     -------
     curve : list of Cost
         The cost obtained for all repetitions.
-    status : str
-        The status on which the solver was stopped. Should be one of
-        {'done', 'timeout', 'max_runs', 'diverged', }
+    status : 'done' | 'diverged' | 'timeout' | 'max_runs'
+        The status on which the solver was stopped.
     """
 
     # Create a Memory object to cache the computations in the benchmark folder
@@ -131,15 +130,9 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
 
     # compute initial value
     stopping_criterion.show_progress('initialization')
-    init_stop_val = (
-        0 if solver.stop_strategy == 'iteration' else INFINITY
-    )
-    call_args = dict(
-        objective=objective, solver=solver, meta=meta
-    )
-    cost = run_one_resolution_cached(
-        stop_val=init_stop_val, **call_args
-    )
+    init_stop_val = (0 if solver.stop_strategy == 'iteration' else INFINITY)
+    call_args = dict(objective=objective, solver=solver, meta=meta)
+    cost = run_one_resolution_cached(stop_val=init_stop_val, **call_args)
     curve = [cost]
     stop, status, is_flat = stopping_criterion.should_stop_solver(curve)
 
@@ -191,8 +184,8 @@ class _Callback:
         A dictionary with info from the current system.
     curve : list
         The convergence curve stored as a list of dict.
-    status : 'done' | 'diverged' | 'timeout' | 'max_runs'
-        The convergence status.
+    status : 'running' | 'done' | 'diverged' | 'timeout' | 'max_runs'
+        The status on which the solver is or was stopped.
     time_iter : float
         Computation time to reach the current iteration.
         Excluding the times to evaluate objective.
@@ -262,7 +255,8 @@ class _Callback:
         -------
         curve : list
             Details on the run and the objective value obtained.
-        status : 'done' | 'diverged' | 'timeout' | 'unfinished'
+        status : 'done' | 'diverged' | 'timeout' | 'max_runs'
+            The status on which the solver was stopped.
         """
         return self.curve, self.status
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -7,7 +7,7 @@ from .benchmark import _check_name_lists
 from .utils.sys_info import get_sys_info
 from .utils.pdb_helpers import exception_handler
 
-from .stopping_criterion import SufficientDescentCondition
+from .stopping_criterion import SufficientDescentCriterion
 
 from .utils.colorify import colorify
 from .utils.colorify import LINE_LENGTH, RED, GREEN, YELLOW
@@ -318,7 +318,7 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
 
             meta_rep = dict(**meta, idx_rep=rep, solver_name=str(solver))
 
-            stopping_criterion = SufficientDescentCondition._get_instance(
+            stopping_criterion = SufficientDescentCriterion._get_instance(
                 max_runs=max_runs, timeout=timeout / n_repetitions,
                 progress_str=progress_str
             )

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -14,6 +14,7 @@ from .utils.colorify import LINE_LENGTH, RED, GREEN, YELLOW
 
 
 # Get config values
+from .config import DEBUG
 from .config import RAISE_INSTALL_ERROR
 
 
@@ -77,6 +78,9 @@ def run_one_resolution(objective, solver, meta, stop_val):
         raise ImportError(
             f"Failure during import in {solver.__module__}."
         )
+
+    if DEBUG:
+        print(f"DEBUG - Calling solver {solver} with stop val: {stop_val}")
 
     t_start = time.perf_counter()
     solver.run(stop_val)
@@ -150,8 +154,10 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
 
         # Check the stopping criterion and update rho if necessary.
         stop, status, is_flat = stopping_criterion.should_stop_solver(curve)
-        if is_flat == 0:
+        if is_flat:
             rho *= RHO_INC
+            if DEBUG:
+                print("DEBUG - curve is flat -> increasing rho:", rho)
 
         # compute next evaluation point
         stop_val = get_next(stop_val, rho=rho, strategy=solver.stop_strategy)

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,4 +1,3 @@
-import math
 import time
 from datetime import datetime
 
@@ -8,23 +7,23 @@ from .benchmark import _check_name_lists
 from .utils.sys_info import get_sys_info
 from .utils.pdb_helpers import exception_handler
 
+from .stopping_criterion import SufficientDescentCondition
+
 from .utils.colorify import colorify
 from .utils.colorify import LINE_LENGTH, RED, GREEN, YELLOW
 
 
 # Get config values
-from .config import DEBUG
 from .config import RAISE_INSTALL_ERROR
 
 
 # Define some constants
 # TODO: better parametrize this?
-PATIENCE = 5
 MAX_ITER = int(1e6)
 MIN_TOL = 1e-15
 INFINITY = 3e38  # see: np.finfo('float32').max
 RHO = 1.5
-EPS = 1e-10
+RHO_INC = 1.2  # multiplicative update if rho is too small
 
 
 def get_next(stop_val, rho=RHO, strategy="iteration"):
@@ -72,8 +71,6 @@ def run_one_resolution(objective, solver, meta, stop_val):
     -------
     cost : dict
         Details on the run and the objective value obtained.
-    objective_value : float
-        Value of the objective function reached, used to detect convergence.
     """
     # check if the module caught a failed import
     if not solver.is_installed():
@@ -90,13 +87,12 @@ def run_one_resolution(objective, solver, meta, stop_val):
     # Add system info in results
     info = get_sys_info()
 
-    return (dict(**meta, stop_val=stop_val, time=delta_t,
-                 **objective_dict, **info),
-            objective_dict['objective_value'])
+    return dict(**meta, stop_val=stop_val, time=delta_t,
+                **objective_dict, **info)
 
 
-def run_one_to_cvg(benchmark, objective, solver, meta, max_runs, deadline=None,
-                   progress_str=None, force=False):
+def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
+                   force=False):
     """Run all repetitions of the solver for a value of stopping criterion.
 
     Parameters
@@ -110,13 +106,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, max_runs, deadline=None,
     meta : dict
         Metadata passed to store in Cost results.
         Contains objective, data, dimension.
-    max_runs : int
-        The maximum number of solver runs to perform to estimate
-        the convergence curve.
-    deadline : float
-        The computer time solver cannot exceed to complete.
-    progress_str : str
-        The string to display in the progress bar.
+    stopping_criterion : StoppingCriterion
+        Object to check if we need to stop a solver.
     force : bool
         If force is set to True, ignore the cache and run the computations
         for the solver anyway. Else, use the cache if available.
@@ -125,82 +116,45 @@ def run_one_to_cvg(benchmark, objective, solver, meta, max_runs, deadline=None,
     -------
     curve : list of Cost
         The cost obtained for all repetitions.
-    max_objective_value : float
-        The maximum of the objective values obtained across the repetitions for
-        the given stop_val. It is used to detect when to stop adding points to
-        the curve.
+    status : str
+        The status on which the solver was stopped. Should be one of
+        {'done', 'timeout', 'max_runs', 'diverged', }
     """
-
-    def progress(id_stop_val, delta):
-        return max(id_stop_val / max_runs,
-                   math.log(max(delta, EPS)) / math.log(EPS))
 
     # Create a Memory object to cache the computations in the benchmark folder
     # and handle cases where we force the run.
     run_one_resolution_cached = cache(run_one_resolution, benchmark, force)
 
     # compute initial value
-    if progress_str is not None:
-        print(progress_str.format(progress='initialization').ljust(LINE_LENGTH)
-              + '\r', end='', flush=True)
+    stopping_criterion.show_progress('initialization')
     init_stop_val = (
         0 if solver.stop_strategy == 'iteration' else INFINITY
     )
     call_args = dict(
         objective=objective, solver=solver, meta=meta
     )
-    cost, objective_value = run_one_resolution_cached(
+    cost = run_one_resolution_cached(
         stop_val=init_stop_val, **call_args
     )
-
     curve = [cost]
+    stop, status, is_flat = stopping_criterion.should_stop_solver(curve)
 
-    id_stop_val = 0
     stop_val = 1
     rho = RHO
-    delta_objectives = [1e15]
-    prev_objective_value = objective_value
+    while not stop:
 
-    for id_stop_val in range(max_runs):
-        if (-EPS <= max(delta_objectives) < EPS):
-            # We are on a plateau and the objective is not improving
-            # stop here for the stop_val
-            status = 'done'
-            break
-        if max(delta_objectives) < -1e10:
-            # The algorithm is diverging, stopping here
-            status = 'diverged'
-            break
-
-        if time.time() > deadline:
-            # We reached the timeout so stop the computation here
-            status = 'timeout'
-            break
-
-        if progress_str is not None:
-            p = progress(id_stop_val, max(delta_objectives))
-            print(progress_str.format(progress=f'{p:6.1%}').ljust(LINE_LENGTH)
-                  + '\r', end='', flush=True)
-        cost, objective_value = run_one_resolution_cached(
+        cost = run_one_resolution_cached(
             stop_val=stop_val, **call_args
         )
         curve.append(cost)
 
-        delta_objective = prev_objective_value - objective_value
-        delta_objectives.append(delta_objective)
-        if delta_objective == 0:
-            rho *= 1.2
-        if len(delta_objectives) > PATIENCE:
-            delta_objectives.pop(0)
-        prev_objective_value = objective_value
-        stop_val = get_next(stop_val, rho=rho, strategy=solver.stop_strategy)
-    else:
-        status = 'unfinished'
+        # Check the stopping criterion and update rho if necessary.
+        stop, status, is_flat = stopping_criterion.should_stop_solver(curve)
+        if is_flat == 0:
+            rho *= RHO_INC
 
-    if DEBUG:
-        delta = max(*delta_objectives)
-        print(f"DEBUG - Exit with delta_objective = {delta:.2e} "
-              f"and stop_val={stop_val:.1e}.")
+        # compute next evaluation point
+        stop_val = get_next(stop_val, rho=rho, strategy=solver.stop_strategy)
 
     return curve, status
 
@@ -212,24 +166,18 @@ class _Callback:
     ----------
     objective : instance of BaseObjective
         The objective to minimize.
-    max_iter : int
-        Maximum number of iterations to run for.
-    deadline : float
-        Deadline after which to stop the computations. This will be
-        used to respect the timeout for each solver.
     meta : dict
         Metadata passed to store in Cost results.
         Contains objective and data names, problem dimension, etc.
+    stopping_criterion : StoppingCriterion
+        Object to check if we need to stop a solver.
 
     Attributes
     ----------
     objective : instance of BaseObjective
         The objective to minimize.
-    max_iter : int
-        Maximum number of iterations to run for.
-    deadline : float
-        Deadline after which to stop the computations. This will be
-        used to respect the timeout for each solver.
+    stopping_criterion : StoppingCriterion
+        Object to check if we need to stop a solver.
     meta : dict
         Metadata passed to store in Cost results.
         Contains objective and data names, problem dimension, etc.
@@ -237,7 +185,7 @@ class _Callback:
         A dictionary with info from the current system.
     curve : list
         The convergence curve stored as a list of dict.
-    status : 'done' | 'diverged' | 'timeout' | 'unfinished'
+    status : 'done' | 'diverged' | 'timeout' | 'max_runs'
         The convergence status.
     time_iter : float
         Computation time to reach the current iteration.
@@ -251,22 +199,27 @@ class _Callback:
     time_callback : float
         The time when exiting the callback call.
     """
-    def __init__(self, objective, max_iter, deadline, meta):
+    def __init__(self, objective, meta, stopping_criterion):
         self.objective = objective
-        self.max_iter = max_iter
-        self.deadline = deadline
         self.meta = meta
+        self.stopping_criterion = stopping_criterion
+
+        # Initialize local variables
         self.info = get_sys_info()
         self.curve = []
-        self.status = 'unfinished'
+        self.status = 'running'
         self.it = 0
+        self.rho = RHO
         self.time_iter = 0.
         self.next_stopval = 0
         self.time_callback = time.perf_counter()
 
     def __call__(self, x):
+        # Stop time and update computation time since the begining
         t0 = time.perf_counter()
         self.time_iter += t0 - self.time_callback
+
+        # Evaluate the iteration if necessary.
         if self.it == self.next_stopval:
             objective_dict = self.objective(x)
             self.curve.append(dict(
@@ -275,16 +228,23 @@ class _Callback:
                 **objective_dict, **self.info
             ))
 
-            if self.deadline is not None and time.time() > self.deadline:
-                self.status = 'timeout'
-                return False
-            if self.it == self.max_iter:
+            # Check the stopping criterion and update rho if necessary.
+            stop, status, is_flat = self.stopping_criterion.should_stop_solver(
+                self.curve
+            )
+            if stop:
+                self.status = status
                 return False
 
-            self.next_stopval = min(
-                get_next(self.next_stopval, strategy="iteration"),
-                self.max_iter
+            if is_flat:
+                self.rho *= RHO_INC
+
+            # compute next evaluation point
+            self.next_stopval = get_next(
+                self.next_stopval, rho=self.rho, strategy="iteration"
             )
+
+        # Update iteration number and restart time measurment.
         self.it += 1
         self.time_callback = time.perf_counter()
         return True
@@ -342,7 +302,7 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
 
     # Create a Memory object to cache the computations in the benchmark folder
     run_one_to_cvg_cached = cache(run_one_to_cvg, benchmark, force,
-                                  ignore=['deadline', 'force', 'progress_str'])
+                                  ignore=['force'])
 
     curve = []
     states = []
@@ -358,35 +318,32 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
 
             meta_rep = dict(**meta, idx_rep=rep, solver_name=str(solver))
 
-            # Force the run if needed
-            deadline = time.time() + timeout / n_repetitions
+            stopping_criterion = SufficientDescentCondition._get_instance(
+                max_runs=max_runs, timeout=timeout / n_repetitions,
+                progress_str=progress_str
+            )
 
             if solver.stop_strategy == "callback":
-                max_iter = int(2 * RHO ** (max_runs - 1))
                 callback = _Callback(
-                    objective, max_iter, deadline, meta_rep
+                    objective, meta_rep, stopping_criterion
                 )
                 solver.run(callback)
                 curve_one_rep, status = callback.get_results()
             else:
                 curve_one_rep, status = run_one_to_cvg_cached(
                     benchmark=benchmark, objective=objective, solver=solver,
-                    meta=meta_rep, max_runs=max_runs, deadline=deadline,
-                    progress_str=progress_str, force=force
+                    meta=meta_rep, stopping_criterion=stopping_criterion,
+                    force=force
                 )
 
             curve.extend(curve_one_rep)
             states.append(status)
 
-            if deadline is not None and deadline < time.time():
-                # Reached the timeout so stop the computation here
-                break
-
         if 'diverged' in states:
             final_status = colorify('diverged', RED)
         elif 'timeout' in states:
             final_status = colorify('done (timeout)', YELLOW)
-        elif 'unfinished' in states:
+        elif 'max_runs' in states:
             final_status = colorify("done (not enough run)", YELLOW)
         else:
             final_status = colorify('done', GREEN)

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -1,0 +1,192 @@
+import time
+import math
+
+
+from .config import DEBUG
+from .utils.colorify import LINE_LENGTH
+
+
+EPS = 1e-10
+PATIENCE = 3
+
+
+class StoppingCriterion():
+    """Class to check if we need to stop an algorithm.
+
+    This base class will check for the timeout and the max_run.
+    It should be sub-classed to check for the convergence of the algorithm.
+
+    This class also handle the detection of diverging solvers and print the
+    progress if given a ``prgress_str``.
+    """
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @classmethod
+    def _get_instance(cls, *args, max_runs=1, timeout=None, progress_str=None,
+                      **kwargs):
+        # Instanciate the subclass
+        stopping_criterion = cls(*args, **kwargs)
+
+        # Store critical parameters for hashing and reconstruction
+        stopping_criterion.timeout = timeout
+        stopping_criterion.max_runs = max_runs
+        stopping_criterion.args = args
+        stopping_criterion.kwargs = kwargs
+
+        # Store running arguments
+        if timeout is not None:
+            stopping_criterion._deadline = time.time() + timeout
+        else:
+            stopping_criterion._deadline = None
+        stopping_criterion._prev_objective_value = 1e100
+        stopping_criterion._progress_str = progress_str
+        return stopping_criterion
+
+    def should_stop_solver(self, cost_curve):
+        """Base call to check if we should stop running a solver.
+
+        This base call check for the timeout and the max number of runs.
+        It also notify the runner if the curve is too flat, to increase
+        the number of points between 2 evaluations of the objective.
+
+        Parameters
+        ----------
+        cost_curve : list of dict
+            List of dict containing the values associated to the objective at
+            each evaluated points.
+
+        Returns
+        -------
+        stop : bool - wether or not we should stop the algorithm.
+        status : str - reason why the algorithm was stopped if stop is True.
+        is_flat : bool - indicate if 2 successive evaluation yielded the same
+            objective value. Useful for moving faster on tolerance.
+        """
+        # Modify the criterion state:
+        # - compute the number of run with the curve. We need to remove 1 as
+        #   it contains the initial evaluation.
+        # - compute the delta_objective for debugging and stalled progress.
+        n_eval = len(cost_curve) - 1
+        objective_value = cost_curve[-1]['objective_value']
+        delta_objective = self._prev_objective_value - objective_value
+        self._prev_objective_value = objective_value
+
+        # default for value for is_flat
+        is_flat = False
+
+        # check the different conditions:
+        #     timeout / max_runs / diverging / stopping_criterion
+        if self._deadline is not None and time.time() > self._deadline:
+            stop = True
+            status = 'timeout'
+
+        elif n_eval == self.max_runs:
+            stop = True
+            status = 'max_runs'
+
+        elif delta_objective < -1e10:
+            stop = True
+            status = 'diverged'
+
+        else:
+            # Call the sub-class hook, used to check stopping criterion
+            # on the curve.
+            stop, progress = self.check_convergence(cost_curve)
+
+            # Display the progress if necessary
+            self.show_progress(progress=progress)
+            progress = max(n_eval / self.max_runs, progress)
+
+            # Compute status and notify the runner if the curve is flat.
+            status = 'done' if stop else None
+            is_flat = delta_objective == 0
+
+        if stop and DEBUG:
+            print(f"DEBUG - Exit with delta_objective = {delta_objective:.2e} "
+                  f"and n_eval={n_eval:.1e}.")
+
+        return stop, status, is_flat
+
+    def show_progress(self, progress):
+        """Display progress in the CLI interface."""
+        if self._progress_str is not None:
+            if isinstance(progress, float):
+                progress = f'{progress:6.1%}'
+            print(
+                self._progress_str.format(progress=progress)
+                .ljust(LINE_LENGTH) + '\r',
+                end='', flush=True
+            )
+
+    def check_convergence(self, cost_curve):
+        """Check if the solver should be stopped based on the objective curve.
+
+        Parameters
+        ----------
+        cost_curve : list of dict
+            List of dict containing the values associated to the objective at
+            each evaluated points.
+
+        Returns
+        -------
+        stop : bool - wether or not we should stop the algorithm.
+        progress : float - measure of how far the solver is from convergence.
+            This should be in [0, 1], 0 meaning no progress and 1 meaning
+            that the solver has converged.
+        """
+        return False, 0
+
+    def __reduce__(self):
+        return self._get_instance, self.args, dict(
+            max_runs=self.max_runs, timeout=self.timeout,
+            **self.kwargs
+        )
+
+
+class SufficientDescentCondition(StoppingCriterion):
+    """Stopping criterion based on sufficient descent.
+
+    The solver will be stopped once successive evaluations do not make enough
+    progress. The number of successive evaluation and the definition of
+    sufficient progress is controled by ``eps`` and ``patience``.
+    """
+    def __init__(self, eps=EPS, patience=PATIENCE):
+        self.eps = eps
+        self.patience = patience
+
+        self.delta_objectives = []
+        self.prev_objective_value = 1e100
+
+    def check_convergence(self, cost_curve):
+        """Check if the solver should be stopped based on the objective curve.
+
+        Parameters
+        ----------
+        cost_curve : list of dict
+            List of dict containing the values associated to the objective at
+            each evaluated points.
+
+        Returns
+        -------
+        stop : bool - wether or not we should stop the algorithm.
+        progress : float - measure of how far the solver is from convergence.
+            This should be in [0, 1], 0 meaning no progress and 1 meaning
+            that the solver has converged.
+        """
+        # Compute the current objective
+        objective_value = cost_curve[-1]['objective_value']
+        delta_objective = self.prev_objective_value - objective_value
+        self.delta_objectives.append(delta_objective)
+
+        if len(self.delta_objectives) > self.patience:
+            self.delta_objectives.pop(0)
+        self.prev_objective_value = objective_value
+
+        delta = max(self.delta_objectives)
+        if (-self.eps <= delta <= self.eps):
+            return True, 1
+
+        progress = math.log(max(delta, EPS)) / math.log(EPS)
+        return False, progress

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -145,7 +145,7 @@ class StoppingCriterion():
         )
 
 
-class SufficientDescentCondition(StoppingCriterion):
+class SufficientDescentCriterion(StoppingCriterion):
     """Stopping criterion based on sufficient descent.
 
     The solver will be stopped once successive evaluations do not make enough

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -16,7 +16,7 @@ class StoppingCriterion():
     This base class will check for the timeout and the max_run.
     It should be sub-classed to check for the convergence of the algorithm.
 
-    This class also handle the detection of diverging solvers and print the
+    This class also handles the detection of diverging solvers and prints the
     progress if given a ``prgress_str``.
     """
 
@@ -47,8 +47,8 @@ class StoppingCriterion():
     def should_stop_solver(self, cost_curve):
         """Base call to check if we should stop running a solver.
 
-        This base call check for the timeout and the max number of runs.
-        It also notify the runner if the curve is too flat, to increase
+        This base call checks for the timeout and the max number of runs.
+        It also notifies the runner if the curve is too flat, to increase
         the number of points between 2 evaluations of the objective.
 
         Parameters
@@ -59,9 +59,12 @@ class StoppingCriterion():
 
         Returns
         -------
-        stop : bool - wether or not we should stop the algorithm.
-        status : str - reason why the algorithm was stopped if stop is True.
-        is_flat : bool - indicate if 2 successive evaluation yielded the same
+        stop : bool
+            Whether or not we should stop the algorithm.
+        status : str
+            Reason why the algorithm was stopped if stop is True.
+        is_flat : bool
+            Indicate if 2 successive evaluations yielded the same
             objective value. Useful for moving faster on tolerance.
         """
         # Modify the criterion state:
@@ -73,7 +76,7 @@ class StoppingCriterion():
         delta_objective = self._prev_objective_value - objective_value
         self._prev_objective_value = objective_value
 
-        # default for value for is_flat
+        # default value for is_flat
         is_flat = False
 
         # check the different conditions:
@@ -131,8 +134,10 @@ class StoppingCriterion():
 
         Returns
         -------
-        stop : bool - wether or not we should stop the algorithm.
-        progress : float - measure of how far the solver is from convergence.
+        stop : bool
+            Whether or not we should stop the algorithm.
+        progress : float
+            Measure of how far the solver is from convergence.
             This should be in [0, 1], 0 meaning no progress and 1 meaning
             that the solver has converged.
         """

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -109,8 +109,8 @@ class StoppingCriterion():
             stop, progress = self.check_convergence(cost_curve)
 
             # Display the progress if necessary
-            self.show_progress(progress=progress)
             progress = max(n_eval / self.max_runs, progress)
+            self.show_progress(progress=progress)
 
             # Compute status and notify the runner if the curve is flat.
             status = 'done' if stop else None

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -18,6 +18,16 @@ class StoppingCriterion():
 
     This class also handles the detection of diverging solvers and prints the
     progress if given a ``prgress_str``.
+
+    Instances of this class should only be created with `cls._get_instance`,
+    to make sure the class holds the proper attirbutes. This factory mechanism
+    allow for easy subclassing without requesting to call the `super.__init___`
+    in the subclass.
+
+    Similarly, sub-classes should implement `check-convergence` to check if the
+    algorithm has converged. This function will be called internally as a hook
+    in `should_stop_solver`, which also handles `timeout`, `max_runs` and
+    plateau detection.
     """
 
     def __init__(self, *args, **kwargs):
@@ -156,6 +166,15 @@ class SufficientDescentCriterion(StoppingCriterion):
     The solver will be stopped once successive evaluations do not make enough
     progress. The number of successive evaluation and the definition of
     sufficient progress is controled by ``eps`` and ``patience``.
+
+    Parameters
+    ----------
+    eps :  float (default: benchopt.stopping_criterion.EPS)
+        The objective function change is considered as insufficient when it is
+        in the interval ``[-eps, eps]``.
+    patience :  float (default: benchopt.stopping_criterion.PATIENCE)
+        The solver is stopped after ``patience`` successive insufficient
+        updates.
     """
     def __init__(self, eps=EPS, patience=PATIENCE):
         self.eps = eps
@@ -175,8 +194,10 @@ class SufficientDescentCriterion(StoppingCriterion):
 
         Returns
         -------
-        stop : bool - wether or not we should stop the algorithm.
-        progress : float - measure of how far the solver is from convergence.
+        stop : bool
+            Whether or not we should stop the algorithm.
+        progress : float
+            Measure of how far the solver is from convergence.
             This should be in [0, 1], 0 meaning no progress and 1 meaning
             that the solver has converged.
         """

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from benchopt.base import STOP_STRATEGIES
 from benchopt.runner import _Callback
+from benchopt.stopping_criterion import StoppingCriterion
 
 
 def test_benchmark_objective(benchmark, dataset_simu):
@@ -159,8 +160,9 @@ def test_solver(benchmark, solver_class):
 
     # Either call run_with_cb or run
     if solver.stop_strategy == 'callback':
+        sc = StoppingCriterion._get_instance(max_runs=25, timeout=None)
         cb = _Callback(
-            objective, max_iter=5000, deadline=None,  meta={}
+            objective, meta={}, stopping_criterion=sc
         )
         solver.run(cb)
     else:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,10 @@ API
 - ``Solver.skip`` can now be used to skip objectives that are incompatible
   for the Solver, by `Thomas Moreau`_ (:gh:`113`).
 
+- ``Solver`` can now use ``stop_strategy = 'callback'`` to allow for
+  single call curve construction, by `Tanguy Lefort`_ and `Thomas Moreau`_
+  (:gh:`137`).
+
 CLI
 ~~~
 


### PR DESCRIPTION
This is a concurrent solution for #149.

I propose to refactor the code for the stopping criterion with 2 parts:

- One which check global stuff like `timeout`, `max_runs` and make sure we stop when we diverged.
- One which is for now fixed but should be made objective specific: the actual stopping criterion.

For now, I implemented the `SufficientDescentCriterion`, which check the same as what we were checking before.
But we could add other easily and make the choice depend on the `objective`.