### PR TITLE
CLN remove allow_install

### DIFF
--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -16,7 +16,6 @@ GLOBAL_CONFIG_FILE_MODE = stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR
 
 DEFAULT_GLOBAL_CONFIG = {
     'debug': False,
-    'allow_install': False,
     'raise_install_error': False,
     'github_token': None,
     'data_dir': './data/',
@@ -25,8 +24,6 @@ DEFAULT_GLOBAL_CONFIG = {
 }
 """
 * ``debug``: If set to true, enable debug logs.
-* ``allow_install``, *boolean*: Install in current env are disabled by
-  default. If set to true, enable installing in the current env.
 * ``raise_install_error``, *boolean*: If set to true, raise error when
   install fails.
 * ``github_token``, *str*: token to publish results on ``benchopt/results``
@@ -202,5 +199,4 @@ class BooleanFlag(object):
 
 
 DEBUG = BooleanFlag('debug')
-ALLOW_INSTALL = BooleanFlag('allow_install')
 RAISE_INSTALL_ERROR = BooleanFlag('raise_install_error')

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -9,8 +9,8 @@ from .shell_cmd import _run_shell
 from .shell_cmd import _run_shell_in_conda_env
 from .misc import get_benchopt_requirement_line
 
+from ..config import DEBUG
 from ..config import get_setting
-from ..config import DEBUG, ALLOW_INSTALL
 
 SHELL = get_setting('shell')
 CONDA_CMD = get_setting('conda_cmd')
@@ -151,10 +151,6 @@ def delete_conda_env(env_name):
 
 def install_in_conda_env(*packages, env_name=None, force=False):
     """Install the packages with conda in the given environment"""
-    if env_name is None and not ALLOW_INSTALL:
-        raise ValueError("Trying to install solver not in a conda env "
-                         "managed by benchopt. To allow this, "
-                         "set BENCHOPT_ALLOW_INSTALL=True.")
 
     pip_packages = [pkg[4:] for pkg in packages if pkg.startswith('pip:')]
     conda_packages = [pkg for pkg in packages if not pkg.startswith('pip:')]
@@ -180,9 +176,6 @@ def install_in_conda_env(*packages, env_name=None, force=False):
 
 def shell_install_in_conda_env(script, env_name=None):
     """Run a shell install script in the given environment"""
-    if env_name is None and not ALLOW_INSTALL:
-        raise ValueError("Trying to install solver not in a conda env. "
-                         "To allow this, set BENCHOPT_ALLOW_INSTALL=True.")
 
     cmd = f"{SHELL} {script} $CONDA_PREFIX"
     _run_shell_in_conda_env(cmd, env_name=env_name,

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,10 @@ Changelog
 - Move most CI to github action, with auto-release on pypi,
   by `Thomas Moreau`_ (:gh:`150`, :gh:`154`).
 
+- Remove ``BENCHOPT_ALLOW_INSTALL`` and always install to requested env as
+  user now must request explicitely the install,
+  by `Thomas Moreau`_ (:gh:`155`).
+
 API
 ~~~
 
@@ -68,7 +72,7 @@ CLI
 - Add ``benchopt config`` command to allow easy configuration of ``benchopt``
   using the CLI, by `Thomas Moreau`_ (:gh:`128`).
 
-- Add ``benchopt install`` command to install benchmark requirements
+  - Add ``benchopt install`` command to install benchmark requirements
   (not done in ``benchopt run`` anymore) by `Ghislain Durif`_ (:gh:`135`).
 
 BUG

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -72,7 +72,7 @@ CLI
 - Add ``benchopt config`` command to allow easy configuration of ``benchopt``
   using the CLI, by `Thomas Moreau`_ (:gh:`128`).
 
-  - Add ``benchopt install`` command to install benchmark requirements
+- Add ``benchopt install`` command to install benchmark requirements
   (not done in ``benchopt run`` anymore) by `Ghislain Durif`_ (:gh:`135`).
 
 BUG


### PR DESCRIPTION
The rational of allow install was to avoid silently installing stuff on `benchopt run`.
Now that per #135, `install` and `run` are spearated, the user knows that he is doing an install so the allow install is not really relevant anymore.

this PR supress it as it might be confusing.