### PR TITLE
Update results page

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -69,6 +69,21 @@ def generate_plot_benchmark(df, kinds, fname, fig_dir, benchmark_name):
                 plot_func = globals()[PLOT_KINDS[k]]
                 try:
                     fig = plot_func(df_obj, plotly=True)
+                    if plot_func != "plot_histogram":
+                        if len(df_obj["solver_name"].unique()) < 10:
+                            fact_ = 10
+                        else:
+                            fact_ = 100
+                        height = 1000 + fact_ * len(objective_names)
+                        fig.update_layout(legend={"xanchor": "center",
+                                                  "yanchor": "top",
+                                                  "y": -.2,
+                                                  "x": .5
+                                                  },
+                                          autosize=False,
+                                          width=1000,
+                                          height=height
+                                          )
                 except TypeError:
                     fig = plot_func(df_obj)
                 figures[data_name][objective_name][k] = export_figure(
@@ -144,11 +159,14 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         datasets = list(df['data_name'].unique())
         main_info = ['system-cpus', 'system-ram (GB)', "version-cuda"]
         sub_info = ['platform', 'system-processor', 'env-OMP_NUM_THREADS']
+        ter_info = ["version-numpy", "version-scipy"]
         display_sysinfo = ["cpu", "ram (GB)", "cuda",
-                           "processor", "nb threads"]
+                           "processor", "nb threads",
+                           "numpy", "scipy"]
         main_dic = dict.fromkeys(main_info, "")
         sub_dic = dict.fromkeys(sub_info, "")
-        sysinfo = {"main": main_dic, "sub": sub_dic,
+        ter_dic = dict.fromkeys(ter_info, "")
+        sysinfo = {"main": main_dic, "sub": sub_dic, "ter": ter_dic,
                    "all_names": display_sysinfo}
         if "platform" in df:
             platform = (
@@ -157,9 +175,11 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
                 df["platform-architecture"].unique()[0]
             )
             sysinfo["sub"]["platform"] = {'platform': platform}
-            hierarchy = {0: "main", 1: "sub"}
+            hierarchy = {0: "main", 1: "sub", 2: "ter"}
             disp = 0
-            for level, all_keys in enumerate([main_info, sub_info[1:]]):
+            for level, all_keys in enumerate(
+                [main_info, sub_info[1:], ter_info]
+            ):
                 level = hierarchy[level]
                 for idx, key in enumerate(all_keys):
                     val = df[key].unique()[0]

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -227,7 +227,7 @@ def render_index(benchmark_names, static_dir, len_fnames):
         A str with the HTML code for the index page.
     """
 
-    pretty_names = [name.replace("benchmark_", "").replace("_", " ")
+    pretty_names = [name.replace("benchmark_", "").replace("_", " ").capitalize()
                     for name in benchmark_names]
     len_fnames, pretty_names, benchmark_names = map(
         list, zip(*sorted(zip(len_fnames, pretty_names, benchmark_names),
@@ -478,7 +478,7 @@ def plot_benchmark_html_all(patterns=(), benchmarks=(), root=None,
             with open(result_filename, "w") as f:
                 f.write(html)
 
-    # Create an index that referes all benchmarks.
+    # Create an index that lists all benchmarks.
     rendered = render_index([b.name for b in benchmarks], static_dir,
                             len_fnames)
     index_filename = DEFAULT_HTML_DIR / 'index.html'

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -187,10 +187,10 @@ def get_sysinfo(df):
     """Get a dictionnary of the recorded system informations.
 
     System informations are sorted in 3 levels: main, sub and ter.
-        - Main : cpu - ram - cuda informations.
+        - Main : cpu - ram - cuda.
             Displayed directly in the benchmark and result pages
             and can be filtered on.
-        - Sub : platform - processor - number of threds.
+        - Sub : platform - processor - number of threads.
             Displayed on click in the benchmark and results pages.
         - Ter : numpy - scipy.
             Displayed on click in the result page.
@@ -211,7 +211,7 @@ def get_sysinfo(df):
                  ("version-cuda", 'cuda')
                  ],
         "sub": [('platform', 'platform'),
-                ('system-processor', 'processur'),
+                ('system-processor', 'processor'),
                 ('env-OMP_NUM_THREADS', 'nb threads')
                 ],
         "ter": [("version-numpy", "numpy"),
@@ -234,13 +234,10 @@ def get_sysinfo(df):
                 return ''
         else:
             return ''
-
     sysinfo = {
-        level: {name: get_val(df, key) for key, name in keys.items()}
+        level: {name: get_val(df, key) for key, name in keys}
         for level, keys in SYS_INFO.items()
         }
-
-    print(sysinfo)
     return sysinfo
 
 

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -151,8 +151,8 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         if "platform" in df:
             platform = (
                 df["platform"].unique()[0] +
-                df["platform-architecture"].unique()[0] + "-" +
-                df["platform-release"].unique()[0]
+                df["platform-release"].unique()[0] + "-" +
+                df["platform-architecture"].unique()[0]
             )
             sysinfo["platform"] = {"system": platform}
             for idx, key in enumerate(keys_sysinfo):

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -148,7 +148,8 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
                            "processor", "nb threads"]
         main_dic = dict.fromkeys(main_info, "")
         sub_dic = dict.fromkeys(sub_info, "")
-        sysinfo = {"main": main_dic, "sub": sub_dic}
+        sysinfo = {"main": main_dic, "sub": sub_dic,
+                   "all_names": display_sysinfo}
         if "platform" in df:
             platform = (
                 df["platform"].unique()[0] +
@@ -157,12 +158,14 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             )
             sysinfo["sub"]["platform"] = {'platform': platform}
             hierarchy = {0: "main", 1: "sub"}
+            disp = 0
             for level, all_keys in enumerate([main_info, sub_info[1:]]):
                 level = hierarchy[level]
                 for idx, key in enumerate(all_keys):
                     val = df[key].unique()[0]
                     if not pd.isnull(val):
-                        sysinfo[level][key] = {display_sysinfo[idx]: val}
+                        sysinfo[level][key] = {display_sysinfo[disp]: val}
+                    disp += 1
         # Copy CSV if necessary and give a relative path for HTML page access
         if copy:
             fname_in_output = out_dir / f"{benchmark_name}_{fname.name}"

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -227,11 +227,12 @@ def render_index(benchmark_names, static_dir, len_fnames):
         A str with the HTML code for the index page.
     """
 
-    pretty_names = [name.replace("benchmark_", "").replace("_", " ").capitalize()
+    pretty_names = [name.replace("benchmark_", "").replace("_",
+                                                           " ").capitalize()
                     for name in benchmark_names]
-    len_fnames, pretty_names, benchmark_names = map(
-        list, zip(*sorted(zip(len_fnames, pretty_names, benchmark_names),
-                          reverse=True))
+    pretty_names, len_fnames, benchmark_names = map(
+        list, zip(*sorted(zip(pretty_names, len_fnames, benchmark_names),
+                          reverse=False))
     )
 
     return Template(

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -220,7 +220,8 @@ def get_sysinfo(df):
     disp = 0
     for level, all_keys in enumerate(
             [main_info, sub_info[1:], ter_info]):
-        if any([item in df for item in all_keys]):
+        # check if columns exist (empty or not) by level
+        if all([item in df for item in all_keys]):
             if level == 1:
                 platform = (
                     df["platform"].unique()[0] +

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -205,36 +205,42 @@ def get_sysinfo(df):
     sysinfo : dict
         Contains the three-level sytem informations.
     """
-    main_info = ['system-cpus', 'system-ram (GB)', "version-cuda"]
-    sub_info = ['platform', 'system-processor', 'env-OMP_NUM_THREADS']
-    ter_info = ["version-numpy", "version-scipy"]
-    display_sysinfo = ["cpu", "ram (GB)", "cuda",
-                       "processor", "nb threads",
-                       "numpy", "scipy"]
-    main_dic = dict.fromkeys(main_info, "")
-    sub_dic = dict.fromkeys(sub_info, "")
-    ter_dic = dict.fromkeys(ter_info, "")
-    sysinfo = {"main": main_dic, "sub": sub_dic, "ter": ter_dic,
-               "all_names": display_sysinfo}
-    hierarchy = {0: "main", 1: "sub", 2: "ter"}
-    disp = 0
-    for level, all_keys in enumerate(
-            [main_info, sub_info[1:], ter_info]):
-        # check if columns exist (empty or not) by level
-        if all([item in df for item in all_keys]):
-            if level == 1:
-                platform = (
-                    df["platform"].unique()[0] +
-                    df["platform-release"].unique()[0] + "-" +
-                    df["platform-architecture"].unique()[0]
-                )
-                sysinfo["sub"]["platform"] = {'platform': platform}
-            level = hierarchy[level]
-            for key in all_keys:
+    SYS_INFO = {
+        "main": [('system-cpus', 'cpu'),
+                 ('system-ram (GB)', 'ram (GB)'),
+                 ("version-cuda", 'cuda')
+                 ],
+        "sub": [('platform', 'platform'),
+                ('system-processor', 'processur'),
+                ('env-OMP_NUM_THREADS', 'nb threads')
+                ],
+        "ter": [("version-numpy", "numpy"),
+                ("version-scipy", "scipy")
+                ]
+    }
+
+    def get_val(df, key):
+        if key in df:
+            if key == 'platform':
+                return (
+                        df["platform"].unique()[0] +
+                        df["platform-release"].unique()[0] + "-" +
+                        df["platform-architecture"].unique()[0]
+                    )
+            else:
                 val = df[key].unique()[0]
                 if not pd.isnull(val):
-                    sysinfo[level][key] = {display_sysinfo[disp]: val}
-                disp += 1
+                    return val
+                return ''
+        else:
+            return ''
+
+    sysinfo = {
+        level: {name: get_val(df, key) for key, name in keys.items()}
+        for level, keys in SYS_INFO.items()
+        }
+
+    print(sysinfo)
     return sysinfo
 
 

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -145,8 +145,9 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         keys_sysinfo = ['system-cpus',
                         'system-ram (GB)', 'system-processor',
                         'version-cuda', 'env-OMP_NUM_THREADS']
+                        # 'version-numpy', 'version-scipy']
         display_sysinfo = ["cpu", "ram (GB)", "processor", "cuda",
-                           "nb threads"]
+                           "nb threads"]  # , 'numpy', 'scipy']
         sysinfo = dict.fromkeys(["platform"] + keys_sysinfo, "")
         if "platform" in df:
             platform = (

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -25,6 +25,20 @@ TEMPLATE_BENCHMARK = ROOT / "templates" / "benchmark.mako.html"
 TEMPLATE_RESULT = ROOT / "templates" / "result.mako.html"
 TEMPLATE_LOCAL_RESULT = ROOT / "templates" / "local_result.mako.html"
 
+SYS_INFO = {
+    "main": [('system-cpus', 'cpu'),
+             ('system-ram (GB)', 'ram (GB)'),
+             ("version-cuda", 'cuda')
+             ],
+    "sub": [('platform', 'platform'),
+            ('system-processor', 'processor'),
+            ('env-OMP_NUM_THREADS', 'nb threads')
+            ],
+    "ter": [("version-numpy", "numpy"),
+            ("version-scipy", "scipy")
+            ]
+}
+
 
 def generate_plot_benchmark(df, kinds, fname, fig_dir, benchmark_name):
     """Generate all possible plots for a given benchmark run.
@@ -205,19 +219,6 @@ def get_sysinfo(df):
     sysinfo : dict
         Contains the three-level sytem informations.
     """
-    SYS_INFO = {
-        "main": [('system-cpus', 'cpu'),
-                 ('system-ram (GB)', 'ram (GB)'),
-                 ("version-cuda", 'cuda')
-                 ],
-        "sub": [('platform', 'platform'),
-                ('system-processor', 'processor'),
-                ('env-OMP_NUM_THREADS', 'nb threads')
-                ],
-        "ter": [("version-numpy", "numpy"),
-                ("version-scipy", "scipy")
-                ]
-    }
 
     def get_val(df, key):
         if key in df:

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -152,7 +152,6 @@ figure.effect-ruby:hover p {
 	background-color:transparent;
 	outline:none;
 	text-align: center;
-	margin-left: 40%;
  }
 
  .buttonleft {

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -6,9 +6,11 @@
 	position: relative;
 	margin: 0 auto;
 	padding: 1em 0 4em;
+	display: grid;
 	max-width: 1000px;
 	list-style: none;
 	text-align: center;
+	column-gap: 2em;
 }
 
 /* Common style */
@@ -17,7 +19,7 @@
 	float: left;
 	overflow: hidden;
 	margin: 10px 1%;
-	width: 30%;
+	width: 100%;
 	background: #3085a3;
 	text-align: center;
 	cursor: pointer;
@@ -41,6 +43,14 @@
 	-webkit-backface-visibility: hidden;
 	backface-visibility: hidden;
 }
+
+@media (min-width: 600px) {
+	.grid { grid-template-columns: repeat(2, 1fr); }
+  }
+
+@media (min-width: 900px) {
+	.grid { grid-template-columns: repeat(3, 1fr); }
+  }
 
 .grid figure figcaption::before,
 .grid figure figcaption::after {

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -17,10 +17,11 @@
 	float: left;
 	overflow: hidden;
 	margin: 10px 1%;
-	width: 48%;
+	width: 30%;
 	background: #3085a3;
 	text-align: center;
 	cursor: pointer;
+	border-radius: 30px;
 }
 
 .grid figure img {
@@ -49,14 +50,12 @@
 .grid figure figcaption,
 .grid figure figcaption > a {
 	position: absolute;
-	top: -3em;
+	top: 0em;
 	left: 0;
 	width: 100%;
 	height: 100%;
 }
 
-/* Anchor will cover the whole item by default */
-/* For some effects it will show as a button */
 .grid figure figcaption > a {
 	z-index: 1000;
 	text-indent: 0%;
@@ -107,16 +106,17 @@ figure.effect-ruby:hover img {
 }
 
 figure.effect-ruby h2 {
-    margin-top: 20%;
+	margin-top: 10;
 	-webkit-transition: -webkit-transform 0.35s;
 	transition: transform 0.35s;
 	-webkit-transform: translate3d(0,20px,0);
-	transform: translate3d(0,20px,0);
+	transform: translate3d(0,40px,0);
+	font-size: 1.25em;
 }
 
 figure.effect-ruby p {
     margin: 2em -1em 2em -1em;
-	padding: 3em 0em 3em 0em;
+	padding: 1em 0em 1em 0em;
 	border: 1px solid #fff;
 	opacity: 0;
 	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
@@ -127,11 +127,56 @@ figure.effect-ruby p {
 
 figure.effect-ruby:hover h2 {
     -webkit-transform: translate3d(0,0,0);
-	transform: translate3d(0,0,0);
+	transform: translate3d(0px,10px,0) scale(.8);
+	margin-top: 0em;
 }
 
 figure.effect-ruby:hover p {
     opacity: 1;
-	-webkit-transform: translate3d(0,0,0) scale(1);
-	transform: translate3d(0,0,0) scale(1);
+	-webkit-transform: translate3d(0,0,0) scale(1.2);
+	transform: translate3d(-15,0,0) scale(1);
+}
+
+summary {
+	padding: 8px 0;
+	position: relative;
+	width: 100%;
+	list-style-image: none;
+	outline: none;
+}
+
+summary::marker {
+	content: "";
+	display: none;
+}
+
+details > summary::marker {
+	content: "";
+	display: none;
+}
+
+/**
+summary:after {
+	background: white;
+	border-radius: 50%;
+	content: "+";
+	border-color: #000000;
+	border-style: solid;
+	border-width: 2px;
+	color: #000000;
+	float: left;
+	font-size: 19px;
+	line-height: 24px;
+	vertical-align: middle;
+	margin: -5px 10px 0 0;
+	padding: 0;
+	text-align: center;
+	width: 24px;
+	height: 24px;
+}
+**/
+
+details[open] > summary:after {
+	line-height: 22px;
+	content: "";
 }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -137,46 +137,10 @@ figure.effect-ruby:hover p {
 	transform: translate3d(-15,0,0) scale(1);
 }
 
-summary {
-	padding: 8px 0;
-	position: relative;
-	width: 100%;
-	list-style-image: none;
-	outline: none;
-}
-
-summary::marker {
-	content: "";
-	display: none;
-}
-
-details > summary::marker {
-	content: "";
-	display: none;
-}
-
-/**
-summary:after {
-	background: white;
-	border-radius: 50%;
-	content: "+";
-	border-color: #000000;
-	border-style: solid;
-	border-width: 2px;
-	color: #000000;
-	float: left;
-	font-size: 19px;
-	line-height: 24px;
-	vertical-align: middle;
-	margin: -5px 10px 0 0;
-	padding: 0;
+button {
+	border:none;
+	background-color:transparent;
+	outline:none;
 	text-align: center;
-	width: 24px;
-	height: 24px;
-}
-**/
-
-details[open] > summary:after {
-	line-height: 22px;
-	content: "";
-}
+	margin-left: 40%;
+ }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -88,7 +88,7 @@ figure.effect-ruby {
 }
 
 figure.effect-ruby:hover {
-    background-color: #e87700;
+    background-color: DodgerBlue;
 }
 
 figure.effect-ruby img {
@@ -143,4 +143,12 @@ figure.effect-ruby:hover p {
 	outline:none;
 	text-align: center;
 	margin-left: 40%;
+ }
+
+ .buttonleft {
+	border:none;
+	background-color:transparent;
+	outline:none;
+	text-align: center;
+	margin-left: 1px;
  }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -1,0 +1,137 @@
+/*----------------------------------------*/
+/***** Stylesheet for the hover index *****/
+/*----------------------------------------*/
+
+.grid {
+	position: relative;
+	margin: 0 auto;
+	padding: 1em 0 4em;
+	max-width: 1000px;
+	list-style: none;
+	text-align: center;
+}
+
+/* Common style */
+.grid figure {
+	position: relative;
+	float: left;
+	overflow: hidden;
+	margin: 10px 1%;
+	width: 48%;
+	background: #3085a3;
+	text-align: center;
+	cursor: pointer;
+}
+
+.grid figure img {
+	position: relative;
+	display: block;
+    background-image: #3085a3;
+	min-height: 100%;
+	max-width: 100%;
+	opacity: 1.;
+}
+
+.grid figure figcaption {
+	padding: 0.1em;
+	color: #fff;
+	text-transform: uppercase;
+	font-size: 1.25em;
+	-webkit-backface-visibility: hidden;
+	backface-visibility: hidden;
+}
+
+.grid figure figcaption::before,
+.grid figure figcaption::after {
+	pointer-events: none;
+}
+
+.grid figure figcaption,
+.grid figure figcaption > a {
+	position: absolute;
+	top: -3em;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
+/* Anchor will cover the whole item by default */
+/* For some effects it will show as a button */
+.grid figure figcaption > a {
+	z-index: 1000;
+	text-indent: 0%;
+	white-space: nowrap;
+	font-size: 0;
+	opacity: 1;
+}
+
+.grid figure h2 {
+	word-spacing: 0em;
+	font-weight: 300;
+}
+
+.grid figure h2 span {
+	font-weight: 800;
+}
+
+.grid figure h2,
+.grid figure p {
+	margin: 0;
+}
+
+.grid figure p {
+	letter-spacing: 1px;
+	font-size: 70%;
+}
+
+figure.effect-ruby {
+    background-color: #1199bb;
+}
+
+figure.effect-ruby:hover {
+    background-color: #4169E1;
+}
+
+figure.effect-ruby img {
+	opacity: 0;
+	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
+	transition: opacity 0.35s, transform 0.35s;
+	-webkit-transform: scale(1.15);
+	transform: scale(1.15);
+}
+
+figure.effect-ruby:hover img {
+	opacity: 0;
+	-webkit-transform: scale(1);
+	transform: scale(1);
+}
+
+figure.effect-ruby h2 {
+    margin-top: 20%;
+	-webkit-transition: -webkit-transform 0.35s;
+	transition: transform 0.35s;
+	-webkit-transform: translate3d(0,20px,0);
+	transform: translate3d(0,20px,0);
+}
+
+figure.effect-ruby p {
+    margin: 2em -1em 2em -1em;
+	padding: 3em 0em 3em 0em;
+	border: 1px solid #fff;
+	opacity: 0;
+	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
+	transition: opacity 0.35s, transform 0.35s;
+	-webkit-transform: translate3d(0,20px,0) scale(1.1);
+	transform: translate3d(0,20px,0) scale(1.1);
+}
+
+figure.effect-ruby:hover h2 {
+    -webkit-transform: translate3d(0,0,0);
+	transform: translate3d(0,0,0);
+}
+
+figure.effect-ruby:hover p {
+    opacity: 1;
+	-webkit-transform: translate3d(0,0,0) scale(1);
+	transform: translate3d(0,0,0) scale(1);
+}

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -84,11 +84,11 @@
 }
 
 figure.effect-ruby {
-    background-color: #1199bb;
+    background-color: #2c3e50;
 }
 
 figure.effect-ruby:hover {
-    background-color: #4169E1;
+    background-color: #e87700;
 }
 
 figure.effect-ruby img {
@@ -137,7 +137,7 @@ figure.effect-ruby:hover p {
 	transform: translate3d(-15,0,0) scale(1);
 }
 
-button {
+.buttoncent {
 	border:none;
 	background-color:transparent;
 	outline:none;

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -114,7 +114,7 @@ td, th {
 td:first-child, th:first-child {
   empty-cells: hide; /* Hide empty cells when they're the first in the row */
 }
-    
+
 /* Custom stuff on top of the base style sheet */
 .status {
     font-weight: bold;
@@ -220,7 +220,7 @@ a.anchor:link {
     margin-left: auto;
     z-index: 999;
 }
-    
+
 .priority1 {
     color: purple;
 }
@@ -247,4 +247,28 @@ td.number {
 /* Darker background on mouse-over */
 .btn:hover {
   background-color: RoyalBlue;
+}
+
+.sidenav {
+	height: 100%;
+	width: 200px;
+	position: fixed;
+	z-index: 1;
+	top: 0;
+	left: 0;
+	background-color: #3085a3;
+	overflow-x: hidden;
+	padding-top: 20px;
+}
+
+.main {
+	margin-left: 50px;
+}
+
+.sidenav select {
+  padding: 6px 8px 6px 16px;
+  text-decoration: none;
+  font-size: 25px;
+  color: #000;
+  display: block;
 }

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -258,11 +258,13 @@ td.number {
 	left: 0;
 	background-color: #2c3e50;
 	overflow-x: hidden;
+  transition: 0.5s;
 	padding: 30px;
 }
 
 .main {
 	margin-left: 50px;
+  transition: 0.5s;
 }
 
 .sidenav .myselect {

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -256,19 +256,44 @@ td.number {
 	z-index: 1;
 	top: 0;
 	left: 0;
-	background-color: #3085a3;
+	background-color: #2c3e50;
 	overflow-x: hidden;
-	padding-top: 20px;
+	padding: 30px;
 }
 
 .main {
 	margin-left: 50px;
 }
 
-.sidenav select {
-  padding: 6px 8px 6px 16px;
+.sidenav .myselect {
+  padding: 10px 10px 10px 16px;
   text-decoration: none;
   font-size: 25px;
   color: #000;
   display: block;
+}
+
+.myselect {
+  width: 100%;
+  height: 50px;
+  font-size: 100%;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 10px;
+  background-color: DodgerBlue;
+  border-bottom: 10px solid #2c3e50;
+  border: none;
+  color: white;
+  appearance: none;
+  padding: 40px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding: 10px;
+  margin-bottom: 10%;
+}
+
+.myselect:hover {
+  color: #2c3e50;
+  background-color: white;
+  border-bottom-color: #DCDCDC;
 }

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -262,6 +262,16 @@ td.number {
 	padding: 30px;
 }
 
+@media (min-width: 600px) {
+	.sidenav { padding: 10px;
+             width: 100px;}
+  }
+
+@media (min-width: 900px) {
+	.sidenav { padding: 20px;
+    width: 150px;}
+  }
+
 .main {
 	margin-left: 50px;
   transition: 0.5s;

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -175,6 +175,10 @@ table.dataframe {
   color: black;
   font-size: .9em;
   table-layout: fixed;
+  border-radius:6px;
+}
+table.datatable {
+  border-radius:6px;
 }
 table.dataframe thead {
   border-bottom: 1px solid black;
@@ -197,14 +201,16 @@ table.dataframe th {
 table.dataframe tbody tr:nth-child(odd) {
   background: #f5f5f5;
 }
-table.dataframe tbody tr:hover {
-  background: rgba(66, 165, 245, 0.2);
+table.datatable.display tbody tr:hover {
+  background-color: #ddd !important;
 }
-
 a.anchor:visited,
 a.anchor:link {
     padding-left: .2em;
     color: #999;
+}
+div.dataTables_filter, div.dataTables_length {
+  padding: 30px;
 }
 
 .backtotop {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -30,7 +30,28 @@
 <p>
     <strong>${nb_total_benchs}</strong> benchmark results in total.
 </p>
-<table class="summary display">
+
+
+<select id='selectcpu' onchange="change()">
+  <option value=""> Any </option>
+  % for result in results:
+    % if result['sysinfo']['system-cpus'] != "":
+      <option value="<b>cpu</b>: ${result['sysinfo']['system-cpus']['cpu']}"> ${result['sysinfo']['system-cpus']['cpu']} </option>
+    % endif
+  % endfor
+</select>
+
+<select id='selectram' onchange="change()">
+  <option value=""> Any </option>
+  % for result in results:
+    % if result['sysinfo']['system-ram (GB)'] != "":
+      <option value="<b>ram (GB)</b>: ${result['sysinfo']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['system-ram (GB)']['ram (GB)']} </option>
+    % endif
+  % endfor
+</select>
+
+
+<table class="summary display" id="summary">
 <thead>
   <tr>
     <th>Results</th>
@@ -84,6 +105,31 @@
 $(document).ready(function() {
     $('.summary').DataTable();
 } );
+
+function change(){
+  var td, i, fil;
+
+  var cpu = document.getElementById('selectcpu').value;
+  var ram = document.getElementById('selectram').value;
+  var filter = [cpu.toUpperCase(), ram.toUpperCase()];
+  console.log(filter);
+  var table = document.getElementById("summary");
+  var tr = table.getElementsByTagName("tr");
+  for (i = 0; i < tr.length; i++) {
+    tr[i].style.display = "";
+    td = tr[i].getElementsByTagName("td")[2];
+    if (td){
+     for (fil = 0; fil < filter.length; fil++){
+       if (td.innerHTML.toUpperCase().indexOf(filter[fil]) > -1 && tr[i].style.display !== "none") {
+         tr[i].style.display = "";
+       }
+       else {
+         tr[i].style.display = "none";
+       }
+     }
+    }
+  }
+}
 </script>
 </body>
 </html>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -44,6 +44,11 @@
     % endfor
   </select>
   % endfor
+
+  <span id="closewithin" style="font-size:30px;cursor:pointer;text-align:center;" onclick="closeSideNav()">
+    <i class="fa fa-times-circle"></i> Close
+  </span>
+
 </div>
 
 <div class="main" id="main">
@@ -62,7 +67,7 @@
     <strong>${nb_total_benchs}</strong> benchmark results in total. <br>
     % if need_filter:
       <span id="open" style="font-size:30px;cursor:pointer" onclick="openSideNav()">&#9776; Filter System Informations</span>
-      <span id="close"style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter System Informations</span>
+      <span id="close" style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter System Informations</span>
     % endif
 </p>
 
@@ -179,6 +184,7 @@ function displaymore(id, loop_index) {
 
 var openbtn = document.getElementById("open");
 var closebtn = document.getElementById("close");
+var closewithin = document.getElementById("closewithin");
 closebtn.style.display = 'none';
 
 function openSideNav() {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -18,12 +18,13 @@
 
 <body>
 
-<div class="sidenav" id="sidenav" style="width:0px; padding: 0px;">
-  <%
-    ll_main = results[0]["sysinfo"]['main']
-    ll_main_nospace = [item.replace(" ", "") for item in ll_main]
-    need_filter = False
-  %>
+<%
+  ll_main = results[0]["sysinfo"]['main']
+  ll_main_nospace = [item.replace(" ", "") for item in ll_main]
+  need_filter = False
+%>
+
+<div class="sidenav" id="sidenav" style="padding:0px; width:0px;">
   % for idx, item in enumerate(ll_main):
   <label for=${'select'+str(ll_main_nospace[idx])} style="font-size: 120%; padding: 8px; color: white;">
      ${results[0]['sysinfo']['all_names'][idx]}
@@ -48,32 +49,29 @@
   <span id="closewithin" style="font-size:30px;cursor:pointer;text-align:center;" onclick="closeSideNav()">
     <i class="fa fa-times-circle"></i> Close
   </span>
-
 </div>
 
 <div class="main" id="main">
 <a id="top"></a>
-<a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
 <h1>
-  BenchOpt benchmark results: ${benchmark}
+  <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
+  BenchOpt results: ${benchmark.replace('benchmark_', '').replace('_', " ")}
   <a href="https://github.com/benchopt/${benchmark}">
     <i class="fab fa-github-square"></i>
   </a>
 </h1>
 
-<p><em>Last updated: ${last_updated.isoformat(sep=' ', timespec='minutes') | h}</em></p>
-<h2>Summary</h2>
-<p>
-    <strong>${nb_total_benchs}</strong> benchmark results in total. <br>
-    % if need_filter:
-      <span id="open" style="font-size:30px;cursor:pointer" onclick="openSideNav()">&#9776; Filter System Informations</span>
-      <span id="close" style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter System Informations</span>
-    % endif
+<p><em>Last updated: ${last_updated.isoformat(sep=' ', timespec='minutes') | h}</em>
+  with <strong>${nb_total_benchs}</strong> benchmark results in total. <br>
 </p>
 
+% if need_filter:
+<span id="close" style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter Informations</span>
+<span id="open" style="font-size:30px;cursor:pointer" onclick="openSideNav()">&#9776; Filter Informations</span>
+% endif
 
 <table class="summary display" id="summary">
-<thead>
+<thead style="background-color: dodgerblue;">
   <tr>
     <th>Results</th>
     <th>Datasets</th>
@@ -90,6 +88,8 @@
           fname = result["fname_short"]
           fname, _ = fname.split('.')
           fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
+          subs = list(result['sysinfo']['sub'].values())
+          disp_sub = any([item_sub != '' for item_sub in subs])
         %>
         ${fname}
       </a>
@@ -97,7 +97,18 @@
     <td class="datasets">
       % for dataset in result['datasets']:
       <div class=dataset>
-        ${dataset}
+        <%
+          split = dataset.split('[')
+          if len(split) > 1:
+            name_data, options = split
+            options = options[:-1]
+          else:
+            name_data, options = split[0], []
+        %>
+        ${name_data.capitalize()}
+        % if len(options) > 0:
+          </br> <span style="font-size: 80%;padding-left:15px;padding-bottom:15px;">${options} </span>
+        % endif
       </div>
       % endfor
     </td>
@@ -108,7 +119,7 @@
         <div class="info">
           % for idx in range(len(all_info)):
           <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
-            % if result['sysinfo']['sub']['platform'] != '' and idx_info == 0:
+            % if disp_sub and idx_info == 0:
               <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
                 <i class='fas fa-plus-circle'></i>
               </button>
@@ -118,9 +129,7 @@
       </div>
       % endfor
 
-      <!-- platform is one result monitored everytime in new csv files -->
-
-      % if result['sysinfo']['sub']['platform'] != '':
+      % if disp_sub:
         <div id=${"subinfo"+str(loop.index)} style="display:none;">
           % for all_info_sub in result['sysinfo']['sub'].values():
           <div class="all_info">
@@ -153,6 +162,20 @@
 $(document).ready(function() {
     $('.summary').DataTable();
 } );
+
+$('table').each(function(a, tbl) {
+        var currentTableRows = $(tbl).find('tbody tr').length;
+        $(tbl).find('th').each(function(i) {
+            var remove = 0;
+            var currentTable = $(this).parents('table');
+            var tds = currentTable.find('tr td:nth-child(' + (i + 1) + ')');
+            tds.each(function(j) { if ($(this)[0].innerText.length == 0) remove++; });
+            if (remove == currentTableRows) {
+                $(this).hide();
+                tds.hide();
+            }
+        });
+    });
 
 function change(ll_item){
   var td, i, fil;
@@ -193,7 +216,7 @@ function displaymore(id, loop_index) {
 var openbtn = document.getElementById("open");
 var closebtn = document.getElementById("close");
 var closewithin = document.getElementById("closewithin");
-closebtn.style.display = 'none';
+openbtn.style.display = 'none';
 
 function openSideNav() {
     navbar = document.getElementById("sidenav")
@@ -204,11 +227,13 @@ function openSideNav() {
     closebtn.style.display = '';
 }
 
+openSideNav()
+
 function closeSideNav() {
     navbar = document.getElementById("sidenav")
     navbar.style.width = "0";
     navbar.style.padding = "0";
-    document.getElementById("main").style.marginLeft= "0";
+    document.getElementById("main").style.marginLeft = "0";
 	  openbtn.style.display = '';
     closebtn.style.display = 'none';
 }

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -35,6 +35,7 @@
   <tr>
     <th>Results</th>
     <th>Datasets</th>
+    <th>System info</th>
     <th></th>
   </tr>
 </thead>
@@ -50,6 +51,17 @@
       % for dataset in result['datasets']:
       <div class=dataset>
         ${dataset}
+      </div>
+      %endfor
+    </td>
+    <td class="sysinfo">
+      % for all_info in result['sysinfo'].values():
+      <div class="all_info">
+        % for idx in range(len(all_info)):
+        <div class="info">
+          <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+        </div>
+        %endfor
       </div>
       %endfor
     </td>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -18,10 +18,11 @@
 
 <body>
 
-<div class="sidenav">
+<div class="sidenav" id="sidenav" style="width:0px; padding: 0px;">
   <%
     ll_main = results[0]["sysinfo"]['main']
     ll_main_nospace = [item.replace(" ", "") for item in ll_main]
+    need_filter = False
   %>
   % for idx, item in enumerate(ll_main):
   <label for=${'select'+str(ll_main_nospace[idx])} style="font-size: 120%; padding: 8px; color: white;">
@@ -36,6 +37,7 @@
       % if current_item != "":
       <%
         name = list(current_item.keys())[0]
+        need_filter = True
       %>
         <option value="<b>${name}</b>: ${current_item[name]}"> ${current_item[name]} </option>
       % endif
@@ -44,7 +46,7 @@
   % endfor
 </div>
 
-<div class="main">
+<div class="main" id="main">
 <a id="top"></a>
 <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
 <h1>
@@ -57,8 +59,13 @@
 <p><em>Last updated: ${last_updated.isoformat(sep=' ', timespec='minutes') | h}</em></p>
 <h2>Summary</h2>
 <p>
-    <strong>${nb_total_benchs}</strong> benchmark results in total.
+    <strong>${nb_total_benchs}</strong> benchmark results in total. <br>
+    % if need_filter:
+      <span id="open" style="font-size:30px;cursor:pointer" onclick="openSideNav()">&#9776; Filter System Informations</span>
+      <span id="close"style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter System Informations</span>
+    % endif
 </p>
+
 
 <table class="summary display" id="summary">
 <thead>
@@ -168,6 +175,28 @@ function displaymore(id, loop_index) {
   else {
     x.style.display = "none";
   }
+}
+
+var openbtn = document.getElementById("open");
+var closebtn = document.getElementById("close");
+closebtn.style.display = 'none';
+
+function openSideNav() {
+    navbar = document.getElementById("sidenav")
+    navbar.style.width = "200px";
+    navbar.style.padding = "30px";
+    document.getElementById("main").style.marginLeft = "50px";
+	  openbtn.style.display = 'none';
+    closebtn.style.display = '';
+}
+
+function closeSideNav() {
+    navbar = document.getElementById("sidenav")
+    navbar.style.width = "0";
+    navbar.style.padding = "0";
+    document.getElementById("main").style.marginLeft= "0";
+	  openbtn.style.display = '';
+    closebtn.style.display = 'none';
 }
 </script>
 </div>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📈</text></svg>">
+<link href="${static_dir}/hover_index.css" rel="stylesheet" />
 <link href="${static_dir}/main.css" rel="stylesheet" />
 
 <script defer src="https://use.fontawesome.com/releases/v5.0.10/js/all.js" integrity="sha384-slN8GvtUJGnv6ca26v8EzVaR9DC58QEwsIk9q1QXdCU8Yu8ck/tL/5szYlBbqmS+" crossorigin="anonymous"></script>
@@ -92,20 +93,25 @@
         %endfor
       </div>
       %endfor
-      <details>
-        <summary> p
-          <i class="fa fa-plus-circle plus"></i>
-        </summary>
-        % for all_info in result['sysinfo']['sub'].values():
-        <div class="all_info">
-          % for idx in range(len(all_info)):
-          <div class="info">
-            <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+
+      <!-- platform is the one result monitored everytime in new csv files -->
+
+      % if result['sysinfo']['sub']['platform'] != '':
+        <button onclick="displaymore(this,${loop.index})" id=${"btn_subinfo"+str(loop.index)}>
+          <i class='fas fa-plus-circle'></i>
+        </button>
+        <div id=${"subinfo"+str(loop.index)} style="display:none;">
+          % for all_info in result['sysinfo']['sub'].values():
+          <div class="all_info">
+            % for idx in range(len(all_info)):
+            <div class="info">
+              <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+            </div>
+            %endfor
           </div>
           %endfor
         </div>
-        %endfor
-      </details>
+      % endif
     </td>
     <td class="buttons">
       <a href="${result['page']}">
@@ -148,6 +154,17 @@ function change(){
        }
      }
     }
+  }
+}
+
+function displaymore(id, loop_index) {
+  var x = document.getElementById("subinfo"+loop_index);
+  $(id).find('svg').toggleClass('fa-plus-circle fa-minus-circle');
+  if (x.style.display === 'none') {
+    x.style.display = "block";
+  }
+  else {
+    x.style.display = "none";
   }
 }
 </script>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -111,23 +111,30 @@
       % endfor
 
     </td>
+    <% disp_button = True %>
     <td class="sysinfo">
-
       <ul style="list-style-type: none; margin-top: 0;">
-      % for idx_info, (keys_info, vals_info) in enumerate(result['sysinfo']['main'].items()):
-        % if vals_info != "":
+      % for key_main, val_main in result['sysinfo']['main'].items():
+        % if val_main != "":
           <li>
-            <b>${keys_info}</b>: ${vals_info}
-            % if disp_sub and idx_info == 0:
+            <b>${key_main}</b>: ${val_main}
+            % if disp_sub and disp_button:
               <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
                 <i class='fas fa-plus-circle'></i>
               </button>
+              <% disp_button = False %>
             % endif
           </li>
         % endif
       % endfor
 
       % if disp_sub:
+        <!--Case where sub infos are available but somehow main infos are not-->
+        % if disp_button:
+          <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+            <i class='fas fa-plus-circle'></i>
+          </button>
+        % endif
         <div id=${"subinfo"+str(loop.index)} style="display:none;">
           % for key_sub, val_sub in result['sysinfo']['sub'].items():
             % if val_sub != "":

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -16,6 +16,30 @@
 </head>
 
 <body>
+
+<div class="sidenav">
+
+  <select id='selectcpu' onchange="change()">
+    <option value=""> Any </option>
+    % for result in results:
+      % if result['sysinfo']['system-cpus'] != "":
+        <option value="<b>cpu</b>: ${result['sysinfo']['system-cpus']['cpu']}"> ${result['sysinfo']['system-cpus']['cpu']} </option>
+      % endif
+    % endfor
+  </select>
+
+  <select id='selectram' onchange="change()">
+    <option value=""> Any </option>
+    % for result in results:
+      % if result['sysinfo']['system-ram (GB)'] != "":
+        <option value="<b>ram (GB)</b>: ${result['sysinfo']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['system-ram (GB)']['ram (GB)']} </option>
+      % endif
+    % endfor
+  </select>
+
+</div>
+
+<div class="main">
 <a id="top"></a>
 <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
 <h1>
@@ -32,23 +56,6 @@
 </p>
 
 
-<select id='selectcpu' onchange="change()">
-  <option value=""> Any </option>
-  % for result in results:
-    % if result['sysinfo']['system-cpus'] != "":
-      <option value="<b>cpu</b>: ${result['sysinfo']['system-cpus']['cpu']}"> ${result['sysinfo']['system-cpus']['cpu']} </option>
-    % endif
-  % endfor
-</select>
-
-<select id='selectram' onchange="change()">
-  <option value=""> Any </option>
-  % for result in results:
-    % if result['sysinfo']['system-ram (GB)'] != "":
-      <option value="<b>ram (GB)</b>: ${result['sysinfo']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['system-ram (GB)']['ram (GB)']} </option>
-    % endif
-  % endfor
-</select>
 
 
 <table class="summary display" id="summary">
@@ -131,5 +138,6 @@ function change(){
   }
 }
 </script>
+</div>
 </body>
 </html>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -20,33 +20,31 @@
 
 <%
   ll_main = results[0]["sysinfo"]['main']
-  ll_main_nospace = [item.replace(" ", "") for item in ll_main]
   need_filter = False
 %>
 
 <div class="sidenav" id="sidenav" style="padding:0px; width:0px;">
-  % for idx, item in enumerate(ll_main):
-  <label for=${'select'+str(ll_main_nospace[idx])} style="font-size: 120%; padding: 8px; color: white;">
-     ${results[0]['sysinfo']['all_names'][idx]}
+  % for key, val in ll_main.items():
+  <label for=${'select'+str(key.replace(" ", ""))} style="font-size: 120%; padding: 8px; color: white;">
+     ${key}
   </label>
-  <select class="myselect" id=${'select'+str(ll_main_nospace[idx])} onchange="change(${ll_main_nospace})">
+  <select class="myselect" id=${'select'+str(key.replace(" ", ""))} onchange="change(${list(ll_main.keys())})">
     <option value=""> Any </option>
     % for result in results:
     <%
-      current_item = result['sysinfo']['main'][item]
+      current_item = result['sysinfo']['main'][key]
     %>
       % if current_item != "":
       <%
-        name = list(current_item.keys())[0]
         need_filter = True
       %>
-        <option value="<b>${name}</b>: ${current_item[name]}"> ${current_item[name]} </option>
+        <option value="<b>${key}</b>: ${current_item}"> ${current_item} </option>
       % endif
     % endfor
   </select>
   % endfor
 
-  <span id="closewithin" style="font-size:30px;cursor:pointer;text-align:center;" onclick="closeSideNav()">
+  <span id="closewithin" style="font-size:30px;cursor:pointer;text-align:center;color:white;" onclick="closeSideNav()">
     <i class="fa fa-times-circle"></i> Close
   </span>
 </div>
@@ -71,7 +69,7 @@
 % endif
 
 <table class="summary display" id="summary">
-<thead style="background-color: dodgerblue;">
+<thead style="background-color: dodgerblue; color: white;">
   <tr>
     <th>Results</th>
     <th>Datasets</th>
@@ -88,13 +86,13 @@
           fname = result["fname_short"]
           fname, _ = fname.split('.')
           fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
-          subs = list(result['sysinfo']['sub'].values())
-          disp_sub = any([item_sub != '' for item_sub in subs])
+          disp_sub = any([val != '' for val in result['sysinfo']['sub'].values()])
         %>
         ${fname}
       </a>
     </td>
     <td class="datasets">
+
       % for dataset in result['datasets']:
       <div class=dataset>
         <%
@@ -111,37 +109,37 @@
         % endif
       </div>
       % endfor
+
     </td>
     <td class="sysinfo">
 
-      % for idx_info, all_info in enumerate(result['sysinfo']['main'].values()):
-      <div class="all_info">
-        <div class="info">
-          % for idx in range(len(all_info)):
-          <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+      <ul style="list-style-type: none; margin-top: 0;">
+      % for idx_info, (keys_info, vals_info) in enumerate(result['sysinfo']['main'].items()):
+        % if vals_info != "":
+          <li>
+            <b>${keys_info}</b>: ${vals_info}
             % if disp_sub and idx_info == 0:
               <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
                 <i class='fas fa-plus-circle'></i>
               </button>
             % endif
-        </div>
-        % endfor
-      </div>
+          </li>
+        % endif
       % endfor
 
       % if disp_sub:
         <div id=${"subinfo"+str(loop.index)} style="display:none;">
-          % for all_info_sub in result['sysinfo']['sub'].values():
-          <div class="all_info">
-            % for idx in range(len(all_info_sub)):
-            <div class="info">
-              <b>${list(all_info_sub.keys())[idx]}</b>: ${list(all_info_sub.values())[idx]}
-            </div>
-            %endfor
-          </div>
+          % for key_sub, val_sub in result['sysinfo']['sub'].items():
+            % if val_sub != "":
+              <li>
+                <b>${key_sub}</b>: ${val_sub}
+              </li>
+            % endif
           %endfor
         </div>
+      </ul>
       % endif
+
     </td>
     <td class="buttons">
       <a href="${result['page']}">
@@ -180,9 +178,8 @@ $('table').each(function(a, tbl) {
 function change(ll_item){
   var td, i, fil;
   var filter = new Array;
-  console.log(ll_item)
   for (item = 0; item < ll_item.length; item++){
-    filter.push(document.getElementById("select"+ll_item[item]).value.toUpperCase());
+    filter.push(document.getElementById("select"+ll_item[item].replace(/\s/g, "")).value.toUpperCase());
   }
   var table = document.getElementById("summary");
   var tr = table.getElementsByTagName("tr");

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -22,8 +22,8 @@
   <select id='selectcpu' onchange="change()">
     <option value=""> Any </option>
     % for result in results:
-      % if result['sysinfo']['system-cpus'] != "":
-        <option value="<b>cpu</b>: ${result['sysinfo']['system-cpus']['cpu']}"> ${result['sysinfo']['system-cpus']['cpu']} </option>
+      % if result['sysinfo']["main"]['system-cpus'] != "":
+        <option value="<b>cpu</b>: ${result['sysinfo']['main']['system-cpus']['cpu']}"> ${result['sysinfo']['main']['system-cpus']['cpu']} </option>
       % endif
     % endfor
   </select>
@@ -31,8 +31,8 @@
   <select id='selectram' onchange="change()">
     <option value=""> Any </option>
     % for result in results:
-      % if result['sysinfo']['system-ram (GB)'] != "":
-        <option value="<b>ram (GB)</b>: ${result['sysinfo']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['system-ram (GB)']['ram (GB)']} </option>
+      % if result['sysinfo']["main"]['system-ram (GB)'] != "":
+        <option value="<b>ram (GB)</b>: ${result['sysinfo']['main']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['main']['system-ram (GB)']['ram (GB)']} </option>
       % endif
     % endfor
   </select>
@@ -83,7 +83,7 @@
       %endfor
     </td>
     <td class="sysinfo">
-      % for all_info in result['sysinfo'].values():
+      % for all_info in result['sysinfo']['main'].values():
       <div class="all_info">
         % for idx in range(len(all_info)):
         <div class="info">
@@ -92,6 +92,20 @@
         %endfor
       </div>
       %endfor
+      <details>
+        <summary> p
+          <i class="fa fa-plus-circle plus"></i>
+        </summary>
+        % for all_info in result['sysinfo']['sub'].values():
+        <div class="all_info">
+          % for idx in range(len(all_info)):
+          <div class="info">
+            <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+          </div>
+          %endfor
+        </div>
+        %endfor
+      </details>
     </td>
     <td class="buttons">
       <a href="${result['page']}">
@@ -119,7 +133,6 @@ function change(){
   var cpu = document.getElementById('selectcpu').value;
   var ram = document.getElementById('selectram').value;
   var filter = [cpu.toUpperCase(), ram.toUpperCase()];
-  console.log(filter);
   var table = document.getElementById("summary");
   var tr = table.getElementsByTagName("tr");
   for (i = 0; i < tr.length; i++) {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -82,11 +82,16 @@
   </tr>
 </thead>
 <tbody>
-% for result in results:
+% for idx_res, result in enumerate(results):
   <tr>
     <td class="fname">
       <a href="${result['page']}">
-        ${result["fname_short"]}
+        <%
+          fname = result["fname_short"]
+          fname, _ = fname.split('.')
+          fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
+        %>
+        ${fname}
       </a>
     </td>
     <td class="datasets">
@@ -97,11 +102,17 @@
       % endfor
     </td>
     <td class="sysinfo">
-      % for all_info in result['sysinfo']['main'].values():
+
+      % for idx_info, all_info in enumerate(result['sysinfo']['main'].values()):
       <div class="all_info">
-        % for idx in range(len(all_info)):
         <div class="info">
+          % for idx in range(len(all_info)):
           <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+            % if result['sysinfo']['sub']['platform'] != '' and idx_info == 0:
+              <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+                <i class='fas fa-plus-circle'></i>
+              </button>
+            % endif
         </div>
         % endfor
       </div>
@@ -110,9 +121,6 @@
       <!-- platform is one result monitored everytime in new csv files -->
 
       % if result['sysinfo']['sub']['platform'] != '':
-        <button onclick="displaymore(this,${loop.index})" id=${"btn_subinfo"+str(loop.index)} class="button buttoncent">
-          <i class='fas fa-plus-circle'></i>
-        </button>
         <div id=${"subinfo"+str(loop.index)} style="display:none;">
           % for all_info_sub in result['sysinfo']['sub'].values():
           <div class="all_info">

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -19,25 +19,29 @@
 <body>
 
 <div class="sidenav">
-
-  <select id='selectcpu' onchange="change()">
+  <%
+    ll_main = results[0]["sysinfo"]['main']
+    ll_main_nospace = [item.replace(" ", "") for item in ll_main]
+  %>
+  % for idx, item in enumerate(ll_main):
+  <label for=${'select'+str(ll_main_nospace[idx])} style="font-size: 120%; padding: 8px; color: white;">
+     ${results[0]['sysinfo']['all_names'][idx]}
+  </label>
+  <select class="myselect" id=${'select'+str(ll_main_nospace[idx])} onchange="change(${ll_main_nospace})">
     <option value=""> Any </option>
     % for result in results:
-      % if result['sysinfo']["main"]['system-cpus'] != "":
-        <option value="<b>cpu</b>: ${result['sysinfo']['main']['system-cpus']['cpu']}"> ${result['sysinfo']['main']['system-cpus']['cpu']} </option>
+    <%
+      current_item = result['sysinfo']['main'][item]
+    %>
+      % if current_item != "":
+      <%
+        name = list(current_item.keys())[0]
+      %>
+        <option value="<b>${name}</b>: ${current_item[name]}"> ${current_item[name]} </option>
       % endif
     % endfor
   </select>
-
-  <select id='selectram' onchange="change()">
-    <option value=""> Any </option>
-    % for result in results:
-      % if result['sysinfo']["main"]['system-ram (GB)'] != "":
-        <option value="<b>ram (GB)</b>: ${result['sysinfo']['main']['system-ram (GB)']['ram (GB)']}"> ${result['sysinfo']['main']['system-ram (GB)']['ram (GB)']} </option>
-      % endif
-    % endfor
-  </select>
-
+  % endfor
 </div>
 
 <div class="main">
@@ -55,9 +59,6 @@
 <p>
     <strong>${nb_total_benchs}</strong> benchmark results in total.
 </p>
-
-
-
 
 <table class="summary display" id="summary">
 <thead>
@@ -81,7 +82,7 @@
       <div class=dataset>
         ${dataset}
       </div>
-      %endfor
+      % endfor
     </td>
     <td class="sysinfo">
       % for all_info in result['sysinfo']['main'].values():
@@ -90,22 +91,22 @@
         <div class="info">
           <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
         </div>
-        %endfor
+        % endfor
       </div>
-      %endfor
+      % endfor
 
-      <!-- platform is the one result monitored everytime in new csv files -->
+      <!-- platform is one result monitored everytime in new csv files -->
 
       % if result['sysinfo']['sub']['platform'] != '':
-        <button onclick="displaymore(this,${loop.index})" id=${"btn_subinfo"+str(loop.index)}>
+        <button onclick="displaymore(this,${loop.index})" id=${"btn_subinfo"+str(loop.index)} class="button buttoncent">
           <i class='fas fa-plus-circle'></i>
         </button>
         <div id=${"subinfo"+str(loop.index)} style="display:none;">
-          % for all_info in result['sysinfo']['sub'].values():
+          % for all_info_sub in result['sysinfo']['sub'].values():
           <div class="all_info">
-            % for idx in range(len(all_info)):
+            % for idx in range(len(all_info_sub)):
             <div class="info">
-              <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+              <b>${list(all_info_sub.keys())[idx]}</b>: ${list(all_info_sub.values())[idx]}
             </div>
             %endfor
           </div>
@@ -133,12 +134,13 @@ $(document).ready(function() {
     $('.summary').DataTable();
 } );
 
-function change(){
+function change(ll_item){
   var td, i, fil;
-
-  var cpu = document.getElementById('selectcpu').value;
-  var ram = document.getElementById('selectram').value;
-  var filter = [cpu.toUpperCase(), ram.toUpperCase()];
+  var filter = new Array;
+  console.log(ll_item)
+  for (item = 0; item < ll_item.length; item++){
+    filter.push(document.getElementById("select"+ll_item[item]).value.toUpperCase());
+  }
   var table = document.getElementById("summary");
   var tr = table.getElementsByTagName("tr");
   for (i = 0; i < tr.length; i++) {

--- a/benchopt/plotting/html/templates/index.mako.html
+++ b/benchopt/plotting/html/templates/index.mako.html
@@ -25,7 +25,7 @@
     <strong>${nb_total_benchs}</strong> benchmarks in total.
 </p>
 
-<h2>Available Regression Benchmarks</h2>
+<h2>Available Benchmarks</h2>
 <div class="content">
 <div class="grid">
 % for benchmark in benchmarks:
@@ -40,8 +40,9 @@
     %endfor
   </div>
 
-  <!-- ?
-  <h2> Available Classification Benchmarks </h2>
+  <!--
+  <h2> Available Regression/Classification Benchmarks </h2>
+  Give an attribute to benchmarks for regression / classification
   ...
   -->
 

--- a/benchopt/plotting/html/templates/index.mako.html
+++ b/benchopt/plotting/html/templates/index.mako.html
@@ -2,6 +2,7 @@
 <head>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📈</text></svg>">
 <link href="${static_dir}/main.css" rel="stylesheet" />
+<link href="${static_dir}/hover_index.css", rel="stylesheet" />
 
 <script defer src="https://use.fontawesome.com/releases/v5.0.10/js/all.js" integrity="sha384-slN8GvtUJGnv6ca26v8EzVaR9DC58QEwsIk9q1QXdCU8Yu8ck/tL/5szYlBbqmS+" crossorigin="anonymous"></script>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet" />
@@ -25,13 +26,26 @@
 </p>
 
 <h2>Available Benchmarks</h2>
+<div class="content">
+<div class="grid">
 % for benchmark in benchmarks:
-  <div>
+    <figure class="effect-ruby">
+      <img src="https://via.placeholder.com/350x250/1E90FF" alt="backgrd"/>
+      <figcaption>
+        <h2>${pretty_names[loop.index]}</h2>
+        <p>${len_fnames[loop.index]} files available</p>
+        <a href="${benchmark}.html">View more</a>
+      </figcaption>
+    </figure>
+
+    <!--
     <a href="${benchmark}.html">
       <button class="btn"><i class="fa fa-search"></i> ${benchmark}</button>
     </a>
+    -->
+    %endfor
   </div>
-%endfor
+
 
 <a class="backtotop" title="Back to top" href="#top"><i class="fas fa-level-up-alt"></i></a>
 

--- a/benchopt/plotting/html/templates/index.mako.html
+++ b/benchopt/plotting/html/templates/index.mako.html
@@ -25,26 +25,25 @@
     <strong>${nb_total_benchs}</strong> benchmarks in total.
 </p>
 
-<h2>Available Benchmarks</h2>
+<h2>Available Regression Benchmarks</h2>
 <div class="content">
 <div class="grid">
 % for benchmark in benchmarks:
     <figure class="effect-ruby">
-      <img src="https://via.placeholder.com/350x250/1E90FF" alt="backgrd"/>
+      <img src="https://via.placeholder.com/250x150/1E90FF" alt="backgrd"/>
       <figcaption>
         <h2>${pretty_names[loop.index]}</h2>
         <p>${len_fnames[loop.index]} files available</p>
         <a href="${benchmark}.html">View more</a>
       </figcaption>
     </figure>
-
-    <!--
-    <a href="${benchmark}.html">
-      <button class="btn"><i class="fa fa-search"></i> ${benchmark}</button>
-    </a>
-    -->
     %endfor
   </div>
+
+  <!-- ?
+  <h2> Available Classification Benchmarks </h2>
+  ...
+  -->
 
 
 <a class="backtotop" title="Back to top" href="#top"><i class="fas fa-level-up-alt"></i></a>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -2,20 +2,63 @@
 <head>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>📈</text></svg>">
 <link href="${static_dir}/main.css" rel="stylesheet" />
+<link href="${static_dir}/hover_index.css" rel="stylesheet" />
+
 <script defer src="https://use.fontawesome.com/releases/v5.0.10/js/all.js" integrity="sha384-slN8GvtUJGnv6ca26v8EzVaR9DC58QEwsIk9q1QXdCU8Yu8ck/tL/5szYlBbqmS+" crossorigin="anonymous"></script>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet" />
 <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-
+<script
+  src="https://code.jquery.com/jquery-3.5.1.min.js"
+  integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+  crossorigin="anonymous"></script>
 </head>
 <body>
+
 <a id="top"></a>
 <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
 <a href="${benchmark}.html"><button class="btn"><i class="fa fa-arrow-left"></i> ${benchmark}</button></a>
-<h1>Result on ${benchmark} benchmark</h1>
 
+<h1>Result on ${benchmark} benchmark</h1>
+<summary></summary>
 <p><a href="${result['fname']}">
 	<button class="btn"><i class="fa fa-download"></i> ${result["fname_short"]}</button>
 </a></p>
+
+<!--Display all system informations if you want to-->
+% if result['sysinfo']['sub']['platform'] != '':
+<p>System informations:
+  % for all_info in result['sysinfo']['main'].values():
+    % for idx in range(len(all_info)):
+      <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
+    % endfor
+  % endfor
+    <button id="btn_subinfo" class="button buttonleft toggle">
+      <i class='fas fa-plus-circle' id="logo_btn_info"></i>
+    </button>
+    <div id="subinfo" style="display:none;transition: 0.5s;">
+      <ul>
+        % for all_info_sub in result['sysinfo']['sub'].values():
+          % for idx in range(len(all_info_sub)):
+            <li> <b>${list(all_info_sub.keys())[idx]}</b>: ${list(all_info_sub.values())[idx]} </li>
+          %endfor
+        %endfor
+        % for all_info_sub in result['sysinfo']['ter'].values():
+          % for idx in range(len(all_info_sub)):
+            <%
+              name = list(all_info_sub.keys())[idx]
+              val = list(all_info_sub.values())[idx]
+              if len(val) > 1:
+                val = val.split()
+                val = [''.join(l for l in item if l.isalnum() or l in [".", "_", '=']) for item in val]
+                val = " ".join(val)
+            %>
+            <li> <b>${name}</b>: ${val} </li>
+          %endfor
+        %endfor
+      </ul>
+    </div>
+  </p>
+  %endif
 
 
 <!-- Add selector to display only one plot -->
@@ -45,12 +88,12 @@
     % for kind in result['kinds']:
     <div class="${kind}">
       <%
-          fig = result['figures'][data][obj][kind]
+      fig = result['figures'][data][obj][kind]
       %>
       % if fig.endswith('.svg'):
-        <img src="${fig}"><br/>
+      <img src="${fig}"><br/>
       % else:
-        ${fig}
+      ${fig}
       %endif
     </div>
     %endfor
@@ -75,12 +118,24 @@
 			all_obj[j].style.display = "block";
   }
 
+  $('.toggle').click(function() {
+    $(this).find('svg').toggleClass('fa-plus-circle fa-minus-circle');
+    var x = document.getElementById("subinfo")
+    if (x.style.display === 'none') {
+      x.style.display = "block";
+    }
+    else {
+      x.style.display = "none";
+    }
+  });
+
   var obj = document.getElementById('dataset_selector');
   obj.onchange();
   var obj = document.getElementById('objective_selector');
   obj.onchange();
   var obj = document.getElementById('plot_kind');
   obj.onchange();
+
 </script>
 </body>
 </html>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -25,35 +25,32 @@
 </a></p>
 
 <!--Display all system informations if you want to-->
-% if result['sysinfo']['sub']['platform'] != '':
+% if any([val != "" for _, val in result['sysinfo']['sub'].items()]):
 <p>System informations:
-  % for all_info in result['sysinfo']['main'].values():
-    % for idx in range(len(all_info)):
-      <b>${list(all_info)[idx]}</b>: ${list(all_info.values())[idx]}
-    % endfor
+  % for name, val in result['sysinfo']['main'].items():
+    % if val != "":
+      <b>${name}</b>: ${val}
+    % endif
   % endfor
     <button id="btn_subinfo" class="button buttonleft toggle">
       <i class='fas fa-plus-circle' id="logo_btn_info"></i>
     </button>
     <div id="subinfo" style="display:none;transition: 0.5s;">
       <ul>
-        % for all_info_sub in result['sysinfo']['sub'].values():
-          % for idx in range(len(all_info_sub)):
-            <li> <b>${list(all_info_sub.keys())[idx]}</b>: ${list(all_info_sub.values())[idx]} </li>
-          %endfor
+        % for key_sub, val_sub in result['sysinfo']['sub'].items():
+          % if val_sub != "":
+            <li> <b>${key_sub}</b>: ${val_sub} </li>
+          % endif
         %endfor
-        % for all_info_sub in result['sysinfo']['ter'].values():
-          % for idx in range(len(all_info_sub)):
+        % for key_ter, val_ter in result['sysinfo']['ter'].items():
+          % if val_ter != "":
             <%
-              name = list(all_info_sub.keys())[idx]
-              val = list(all_info_sub.values())[idx]
-              if len(val) > 1:
-                val = val.split()
+                val = val_ter.split()
                 val = [''.join(l for l in item if l.isalnum() or l in [".", "_", '=']) for item in val]
                 val = " ".join(val)
             %>
-            <li> <b>${name}</b>: ${val} </li>
-          %endfor
+            <li> <b>${key_ter}</b>: ${val} </li>
+          % endif
         %endfor
       </ul>
     </div>


### PR DESCRIPTION
This PR modifies for the results page:
- the index is in a grid
- the table contains main and subsidiary system informations (main=cpu/ram/cuda, sub=plateform/num_threads/processor) and displays them if available
- we can filter the table from the main informations (for when there will be a lot of files)
- informations + scipy/numpy versions appear if needed above plots that are up to date with modifications from PR that didn't make the cut to the main repo in the transfer.
- Responsive to different screen sizes + ok chrome / firefox

See the video attached to tell me where modifications are needed :slightly_smiling_face: 

https://user-images.githubusercontent.com/57089823/117458298-6dd44280-af4a-11eb-926f-792e8a72fcfc.mp4

