### PR TITLE
FIX instabilities in R/Julia install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           activate-environment: ${{ env.CONDA_ENV }}
           python-version: ${{ matrix.version_python }}
-          channels: conda-forge
+          # Use miniforge to only get conda-forge as default channel.
+          miniforge-version: latest
 
       - run: conda info
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -117,17 +117,17 @@ class Benchmark:
         "Get the location for the config file of the benchmark."
         return self.benchmark_dir / 'config.ini'
 
-    def get_xfail_file(self):
-        """Get the location for the xfail file for the benchmark.
+    def get_test_config_file(self):
+        """Get the location for the test config file for the benchmark.
 
-        This file will be used to check if a test should be xfailed on specific
-        solvers and platforms when we have installation or running issues.
-        Returns None if this file does not exists.
+        This file will be used to check if a test should be xfailed/skipped on
+        specific solvers and platforms when we have installation or running
+        issues. Returns None if this file does not exists.
         """
-        xfail_file = self.benchmark_dir / 'xfail.py'
-        if not xfail_file.exists():
+        test_config_file = self.benchmark_dir / 'test_config.py'
+        if not test_config_file.exists():
             return None
-        return xfail_file
+        return test_config_file
 
     def get_output_folder(self):
         """Get the folder to store the output of the benchmark.

--- a/benchopt/tests/conftest.py
+++ b/benchopt/tests/conftest.py
@@ -87,21 +87,21 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def xfail_check(request):
+def check_test(request):
 
     if 'benchmark' not in request.fixturenames:
         raise ValueError(
-            '`xfail_check` fixture should only be used in tests parametrized '
+            '`check_test` fixture should only be used in tests parametrized '
             'with `benchmark` fixture'
         )
 
     benchmark = request.getfixturevalue('benchmark')
-    xfail_file = benchmark.get_xfail_file()
-    if xfail_file is None:
+    test_config_file = benchmark.get_test_config_file()
+    if test_config_file is None:
         return None
-    xfail_module = _get_module_from_file(xfail_file)
-    xfail_func_name = f"xfail_{request.function.__name__}"
-    return getattr(xfail_module, xfail_func_name, None)
+    test_config_module = _get_module_from_file(test_config_file)
+    check_func_name = f"check_{request.function.__name__}"
+    return getattr(test_config_module, check_func_name, None)
 
 
 @pytest.fixture(scope='session')

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -116,10 +116,10 @@ def test_solver_install_api(benchmark, solver_class):
 
 
 @pytest.mark.requires_install
-def test_solver_install(test_env_name, benchmark, solver_class, xfail_check):
+def test_solver_install(test_env_name, benchmark, solver_class, check_test):
 
-    if xfail_check is not None:
-        xfail_check(solver_class)
+    if check_test is not None:
+        check_test(solver_class)
 
     # assert that install works when forced to reinstalls
     solver_class.install(env_name=test_env_name)

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 
-def xfail_test_solver_install(solver_class):
+def check_test_solver_install(solver_class):
 
     if solver_class.name.lower() == 'cyanure' and sys.platform == 'darwin':
         pytest.xfail('Cyanure is not easy to install on macos.')

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -113,11 +113,6 @@ def create_conda_env(env_name, recreate=False, with_pytest=False, empty=False):
             f"{CONDA_CMD} env create {force} -n {env_name} -f {env_yaml.name}",
             capture_stdout=True, raise_on_error=True
         )
-        _run_shell_in_conda_env(
-            f"{CONDA_CMD} config --env --add channels conda-forge\n"
-            f"{CONDA_CMD} config --show channels",
-            env_name=env_name, capture_stdout=not DEBUG, raise_on_error=True
-        )
         if empty:
             return
         # Check that the correct version of benchopt is installed in the env

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -111,7 +111,7 @@ def create_conda_env(env_name, recreate=False, with_pytest=False, empty=False):
         _run_shell_in_conda_env(
             f"{CONDA_CMD} config --env --add channels conda-forge\n"
             f"{CONDA_CMD} config --show channels",
-            env_name=env_name, capture_stdout=True, raise_on_error=True
+            env_name=env_name, capture_stdout=not DEBUG, raise_on_error=True
         )
         if empty:
             return
@@ -164,8 +164,10 @@ def install_in_conda_env(*packages, env_name=None, force=False):
         cmd = f"{CONDA_CMD} install -y {packages}"
         if force:
             cmd += ' --force-reinstall'
-        _run_shell_in_conda_env(cmd, env_name=env_name,
-                                raise_on_error=error_msg)
+        _run_shell_in_conda_env(
+            cmd, env_name=env_name, raise_on_error=error_msg,
+            capture_stdout=not DEBUG
+        )
     if pip_packages:
         packages = ' '.join(pip_packages)
         cmd = f"pip install {packages}"

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -113,6 +113,10 @@ def create_conda_env(env_name, recreate=False, with_pytest=False, empty=False):
             f"{CONDA_CMD} env create {force} -n {env_name} -f {env_yaml.name}",
             capture_stdout=True, raise_on_error=True
         )
+        _run_shell_in_conda_env(
+            f"{CONDA_CMD} config --show channels", env_name=env_name,
+            capture_stdout=not DEBUG, raise_on_error=True
+        )
         if empty:
             return
         # Check that the correct version of benchopt is installed in the env

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -113,10 +113,6 @@ def create_conda_env(env_name, recreate=False, with_pytest=False, empty=False):
             f"{CONDA_CMD} env create {force} -n {env_name} -f {env_yaml.name}",
             capture_stdout=True, raise_on_error=True
         )
-        _run_shell_in_conda_env(
-            f"{CONDA_CMD} config --show channels", env_name=env_name,
-            capture_stdout=not DEBUG, raise_on_error=True
-        )
         if empty:
             return
         # Check that the correct version of benchopt is installed in the env

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -109,7 +109,8 @@ def create_conda_env(env_name, recreate=False, with_pytest=False, empty=False):
             capture_stdout=True, raise_on_error=True
         )
         _run_shell_in_conda_env(
-            f"{CONDA_CMD} config --env --add channels conda-forge",
+            f"{CONDA_CMD} config --env --add channels conda-forge\n"
+            f"{CONDA_CMD} config --show channels",
             env_name=env_name, capture_stdout=True, raise_on_error=True
         )
         if empty:

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -19,8 +19,8 @@ CONDA_CMD = get_setting('conda_cmd')
 # Yaml config file for benchopt env.
 BENCHOPT_ENV = """
 channels:
-  - defaults
   - conda-forge
+  - nodefaults
 dependencies:
   - numpy
   - cython
@@ -32,8 +32,8 @@ dependencies:
 
 EMPTY_ENV = """
 channels:
-  - defaults
   - conda-forge
+  - nodefaults
 """
 
 

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -43,15 +43,17 @@ def _run_shell(script, raise_on_error=None, capture_stdout=True,
             'return_output=True can only be used with capture_stdout=True'
         )
 
+    # Make sure the script fail at first failure
+    fast_failure_script = f"set -e\n{script}"
+
     # Use a TemporaryFile to make sure this file is cleaned up at
     # the end of this function.
     tmp = tempfile.NamedTemporaryFile(mode="w+")
-    fast_failure_script = f"set -e\n{script}"
     tmp.write(fast_failure_script)
     tmp.flush()
 
     if DEBUG:
-        print(fast_failure_script)
+        print("-" * 60 + f'\n{fast_failure_script}\n' + "-" * 60)
 
     if raise_on_error is True:
         raise_on_error = "{output}"
@@ -108,10 +110,22 @@ def _run_shell_in_conda_env(script, env_name=None, raise_on_error=None,
     """
     if env_name is not None:
         # first line to use conda activate in bash script
-        # see https://github.com/conda/conda/issues/7980
-        script = (f'eval "$({CONDA_CMD} shell.bash hook)"\n'
-                  f'{CONDA_CMD} activate {env_name}\n'
-                  f'{script}')
+        # Add necessary calls to make the script run in conda env.
+        script = (
+            # Make sure R_HOME is never passed down to subprocesses in
+            # different conda env as it might lead to trying to load packages
+            # from the wrong R-environment.
+            '# Setup conda\nunset R_HOME\n'
+
+            # Run hook to setup conda and activate the env.
+            # first line to use conda activate in bash script
+            # see https://github.com/conda/conda/issues/7980
+            f'eval "$({CONDA_CMD} shell.bash hook)"\n'
+            f'{CONDA_CMD} activate {env_name}\n\n'
+
+            # Run the actual script
+            f'# Run script\n{script}'
+        )
 
     return _run_shell(
         script, raise_on_error=raise_on_error,


### PR DESCRIPTION
Try to fix instabilities in package install due to having both `defaults` and `conda-forge` by only using `conda-forge`.
Also propagate the changes from #145 as it requires a bit rebase on is related to this.