### PR TITLE
[MRG OK] Mobile support sidebar (see #164)

### DIFF
--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -256,34 +256,44 @@ td.number {
 }
 
 .sidenav {
-	height: 100%;
-	width: 10%;
-	position: fixed;
-	z-index: 1;
-	top: 0;
-	left: 0;
+  margin: 0;
+  padding: 1%;
+  top: 0;
+  left: 0;
+  width: 200px;
+  position: fixed;
+  height: 100%;
+  overflow: auto;
 	background-color: #2c3e50;
-	overflow-x: hidden;
   transition: 0.5s;
-	padding: 1%;
-  padding-top: 5%;
 }
 
-@media (min-width: 600px) {
-	.sidenav { padding: 1%;
-             padding-top: 5%;
-             width: 10%;}
-  }
-
-@media (min-width: 900px) {
-	.sidenav { padding: 1%;
-             padding-top: 5%;
-             width: 10%;}
-  }
-
 .main {
-	margin-left: 12%;
-  transition: 0.5s;
+  margin-left: 150px;
+  padding: 1px 16px;
+  height: 1000px;
+}
+
+@media screen and (max-width: 900px) {
+  .sidenav {
+    width: 100%;
+    height: auto;
+    position: relative;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .sidenav .myselect {float: none;
+                      width: auto;
+                      margin-bottom: 0;}
+  .sidenav label {float: left;}
+  div.main {margin-left: 0;}
+}
+
+@media screen and (max-width: 400px) {
+  .sidenav {
+    text-align: center;
+    float: none;
+  }
 }
 
 .sidenav .myselect {

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -269,7 +269,7 @@ td.number {
 }
 
 .main {
-  margin-left: 150px;
+  margin-left: 200px;
   padding: 1px 16px;
   height: 1000px;
 }

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -13,6 +13,7 @@
   crossorigin="anonymous"></script>
 <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 <link href="https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" rel="stylesheet" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 </head>
 
@@ -23,7 +24,7 @@
   need_filter = False
 %>
 
-<div class="sidenav" id="sidenav" style="padding:0px; width:0px;">
+<div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear;">
   % for key, val in ll_main.items():
   <label for=${'select'+str(key.replace(" ", ""))} style="font-size: 120%; padding: 8px; color: white;">
      ${key}
@@ -43,10 +44,6 @@
     % endfor
   </select>
   % endfor
-
-  <span id="closewithin" style="font-size:30px;cursor:pointer;text-align:center;color:white;" onclick="closeSideNav()">
-    <i class="fa fa-times-circle"></i> Close
-  </span>
 </div>
 
 <div class="main" id="main">
@@ -92,23 +89,30 @@
       </a>
     </td>
     <td class="datasets">
-
-      % for dataset in result['datasets']:
+    <ul style="list-style-type: none; margin-top: 0;">
+      % for idx, dataset in enumerate(result['datasets']):
       <div class=dataset>
         <%
-          split = dataset.split('[')
-          if len(split) > 1:
-            name_data, options = split
-            options = options[:-1]
-          else:
-            name_data, options = split[0], []
+        if idx == 0:
+          name_data_old = ""
+        split = dataset.split('[')
+        if len(split) > 1:
+          name_data_new, options = split
+          options = options[:-1]
+        else:
+          name_data_new, options = split[0], []
+        not_disp_name = name_data_new == name_data_old
         %>
-        ${name_data.capitalize()}
-        % if len(options) > 0:
-          </br> <span style="font-size: 80%;padding-left:15px;padding-bottom:15px;">${options} </span>
+        % if not not_disp_name:
+          ${name_data_new.capitalize()}
         % endif
+        % if len(options) > 0:
+          <li><span style="font-size: 80%;padding-left:15px;padding-bottom:5px;">${options} </span> </li>
+        % endif
+        <% name_data_old = name_data_new %>
       </div>
       % endfor
+    </ul>
 
     </td>
     <% disp_button = True %>
@@ -224,9 +228,17 @@ openbtn.style.display = 'none';
 
 function openSideNav() {
     navbar = document.getElementById("sidenav")
-    navbar.style.width = "10%";
-    navbar.style.padding = "1%";
-    document.getElementById("main").style.marginLeft = "12%";
+    navbar.style.visibility = "visible";
+    main = document.getElementById("main")
+    if ($(window).width() < 900) {
+      navbar.style.height = "auto";
+      main.style.marginLeft = "0";
+    }
+    else {
+      navbar.style.height = "1000px";
+      main.style.marginLeft = "150px";
+    }
+    navbar.style.opacity = "1";
 	  openbtn.style.display = 'none';
     closebtn.style.display = '';
 }
@@ -235,10 +247,14 @@ openSideNav()
 
 function closeSideNav() {
     navbar = document.getElementById("sidenav")
-    navbar.style.width = "0";
-    navbar.style.padding = "0";
-    document.getElementById("main").style.marginLeft = "0";
-	  openbtn.style.display = '';
+    main = document.getElementById("main")
+    navbar.style.visibility = "hidden";
+    navbar.style.opacity = "0";
+    navbar.style.height = "0";
+    if ($(window).width() > 900) {
+      main.style.marginLeft = "150px";
+    }
+    openbtn.style.display = '';
     closebtn.style.display = 'none';
 }
 </script>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -236,7 +236,7 @@ function openSideNav() {
     }
     else {
       navbar.style.height = "1000px";
-      main.style.marginLeft = "150px";
+      main.style.marginLeft = "200px";
     }
     navbar.style.opacity = "1";
 	  openbtn.style.display = 'none';

--- a/benchopt/plotting/html/templates/index.mako.html
+++ b/benchopt/plotting/html/templates/index.mako.html
@@ -14,6 +14,7 @@
 <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 <link href="https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" rel="stylesheet" />
 
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 
 <body>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -11,6 +11,8 @@
   src="https://code.jquery.com/jquery-3.5.1.min.js"
   integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
   crossorigin="anonymous"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
 </head>
 <body>
 


### PR DESCRIPTION
#164 wasn't finished because only worked for computers.
Now the sidebar (which isn't handled well on small screens) is replaced by a top bar (to be styled better later on but at least everything is visible for now this way)

PS1: I did the modifications on the dataset names too for the options, see images below showing the mobile behavior
PS2: working on the index issue after that (but can't reproduce the issue for now on devices other than from the fruit company...)

Datasets options modif |  on large screens sidebar | on smaller screens topbar
:-------------------------:|:-------------------------:|:------------------------------:
![Capture d’écran de 2021-05-13 15-12-44](https://user-images.githubusercontent.com/57089823/118130999-4673ee80-b3fe-11eb-8ba3-4e076d92441f.png)   |    ![Capture d’écran de 2021-05-13 15-12-31](https://user-images.githubusercontent.com/57089823/118131003-470c8500-b3fe-11eb-9f3a-90f66d4fcfe3.png)    |    ![Capture d’écran de 2021-05-13 15-12-25](https://user-images.githubusercontent.com/57089823/118131006-47a51b80-b3fe-11eb-9587-375a74cc4f1c.png)