### PR TITLE
Style mobile sidebar

### DIFF
--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -268,6 +268,10 @@ td.number {
   transition: 0.5s;
 }
 
+.sidenav .closebtn{
+  display: none;
+}
+
 .main {
   margin-left: 200px;
   padding: 1px 16px;
@@ -275,18 +279,45 @@ td.number {
 }
 
 @media screen and (max-width: 900px) {
-  .sidenav {
-    width: 100%;
-    height: auto;
-    position: relative;
-    margin-left: auto;
-    margin-right: auto;
-  }
   .sidenav .myselect {float: none;
-                      width: auto;
-                      margin-bottom: 0;}
-  .sidenav label {float: left;}
+                      width: 75vw;
+                      text-align: center;
+                      margin-bottom: 15px;}
+  .sidenav {
+    height: 0%;
+    width: 100%;
+    position: fixed;
+    z-index: 1;
+    top: 0;
+    left: 0;
+    background-color: rgb(0,0,0);
+    background-color: rgba(0,0,0, 0.9);
+    overflow-y: hidden;
+    transition: 0.5s;
+  }
+
+  .sidenav .closebtn {
+    position: absolute;
+    font-size: 40px;
+    display: block;
+    }
+
+
   div.main {margin-left: 0;}
+  .menu {
+    position: relative;
+    margin: auto;
+    text-align: center;
+    margin-top: 30px;
+    margin-left: 12.5vw;
+    display: block;
+    width: 75vw;
+  }
+
+  .menu label{
+    font-size: 200%;
+    float: left;
+  }
 }
 
 @media screen and (max-width: 400px) {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -24,7 +24,7 @@
   need_filter = False
 %>
 
-<div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear; z-index: 10;">
+<div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear; z-index: 100;">
   <a href="javascript:void(0)" class="closebtn" onclick="closeSideNav()">&times;</a>
   <div class="menu">
     % for key, val in ll_main.items():
@@ -172,7 +172,7 @@
 </tbody>
 </table>
 
-<a class="backtotop" title="Back to top" href="#top"><i class="fas fa-level-up-alt"></i></a>
+<a class="backtotop" title="Back to top" href="#top" style="z-index: 50;"><i class="fas fa-level-up-alt"></i></a>
 
 <script type="text/javascript">
 $(document).ready(function() {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -24,26 +24,29 @@
   need_filter = False
 %>
 
-<div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear;">
-  % for key, val in ll_main.items():
-  <label for=${'select'+str(key.replace(" ", ""))} style="font-size: 120%; padding: 8px; color: white;">
-     ${key}
-  </label>
-  <select class="myselect" id=${'select'+str(key.replace(" ", ""))} onchange="change(${list(ll_main.keys())})">
-    <option value=""> Any </option>
-    % for result in results:
-    <%
-      current_item = result['sysinfo']['main'][key]
-    %>
-      % if current_item != "":
+<div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear; z-index: 10;">
+  <a href="javascript:void(0)" class="closebtn" onclick="closeSideNav()">&times;</a>
+  <div class="menu">
+    % for key, val in ll_main.items():
+    <label for=${'select'+str(key.replace(" ", ""))} style="padding: 8px; color: white;">
+       ${key}
+    </label>
+    <select class="myselect" id=${'select'+str(key.replace(" ", ""))} onchange="change(${list(ll_main.keys())})">
+      <option value=""> Any </option>
+      % for result in results:
       <%
-        need_filter = True
+        current_item = result['sysinfo']['main'][key]
       %>
-        <option value="<b>${key}</b>: ${current_item}"> ${current_item} </option>
-      % endif
+        % if current_item != "":
+        <%
+          need_filter = True
+        %>
+          <option value="<b>${key}</b>: ${current_item}"> ${current_item} </option>
+        % endif
+      % endfor
+    </select>
     % endfor
-  </select>
-  % endfor
+  </div>
 </div>
 
 % if need_filter:
@@ -227,7 +230,6 @@ function displaymore(id, loop_index) {
 
 var openbtn = document.getElementById("open");
 var closebtn = document.getElementById("close");
-var closewithin = document.getElementById("closewithin");
 openbtn.style.display = 'none';
 
 function openSideNav() {
@@ -235,7 +237,7 @@ function openSideNav() {
     navbar.style.visibility = "visible";
     main = document.getElementById("main")
     if ($(window).width() < 900) {
-      navbar.style.height = "auto";
+      navbar.style.height = "100%";
       main.style.marginLeft = "0";
     }
     else {
@@ -247,7 +249,12 @@ function openSideNav() {
     closebtn.style.display = '';
 }
 
-openSideNav()
+if ($(window).width() > 900){
+  openSideNav()
+}
+else {
+  closeSideNav()
+}
 
 function closeSideNav() {
     navbar = document.getElementById("sidenav")


### PR DESCRIPTION
A menu-type filter for mobiles that can replace the temporary fix-style.
The sidebar for non-mobile is not changed.

Before             |  After
:-------------------------:|:-------------------------:
![Capture d’écran de 2021-05-28 15-01-27](https://user-images.githubusercontent.com/57089823/119987852-c5a01f80-bfc5-11eb-8d27-689bfb42c763.png) | ![Capture d’écran de 2021-05-28 14-59-44](https://user-images.githubusercontent.com/57089823/119987855-c638b600-bfc5-11eb-8a11-2417c41210c9.png)
