### PR TITLE
Scales plotly option

### DIFF
--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -59,11 +59,15 @@
 .grid figure figcaption,
 .grid figure figcaption > a {
 	position: absolute;
-	top: 0em;
+	top: 0em; /* no space offset top */
 	left: 0;
 	width: 100%;
 	height: 100%;
-	z-index: 1000;
+}
+
+/* only to figcaption <a> tag */
+.grid figure figcaption > a {
+	z-index: 1000; /* top level */
 	text-indent: 0%;
 	white-space: nowrap;
 	font-size: 0; /* do not display the View more */

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -2,61 +2,60 @@
 /***** Stylesheet for the hover index *****/
 /*----------------------------------------*/
 
+/* Place rectangles in a grid */
 .grid {
-	position: relative;
+	position: relative; /* each rectangle is dependant of others */
 	margin: 0 auto;
-	padding: 1em 0 4em;
-	display: grid;
+	padding: 1em 0 4em;  /* padding top horizontal bottom */
+	display: grid; /* type of boxes generated */
 	max-width: 1000px;
-	list-style: none;
+	list-style: none; /* no item */
 	text-align: center;
-	column-gap: 2em;
+	column-gap: 2em; /* space between columns */
 }
 
-/* Common style */
+/* Figure inside grid */
 .grid figure {
 	position: relative;
 	float: left;
-	overflow: hidden;
+	overflow: hidden; /* overflow not taken into account */
 	margin: 10px 1%;
-	width: 100%;
+	width: 100%; /* 100% of the column */
 	background: #3085a3;
 	text-align: center;
-	cursor: pointer;
-	border-radius: 30px;
+	cursor: pointer; /* change shape cursor */
+	border-radius: 30px; /* rounded corners */
 }
 
+/* Each figure contains an img */
 .grid figure img {
 	position: relative;
 	display: block;
-    background-image: #3085a3;
+    background-image: #3085a3; /* color background */
 	max-height: 100%;
 	max-width: 100%;
-	opacity: 1.;
+	opacity: 1.; /* over a dummy image */
 }
 
+/* Style caption (title of benchmarks) */
 .grid figure figcaption {
-	padding: 0.1em;
-	color: #fff;
-	text-transform: uppercase;
+	padding: 0.1em; /* add space */
+	color: #fff;  /* writing color */
+	text-transform: uppercase; /* title in uppercase */
 	font-size: 1.25em;
-	-webkit-backface-visibility: hidden;
-	backface-visibility: hidden;
 }
 
+/* Small sized screens */
 @media (min-width: 600px) {
-	.grid { grid-template-columns: repeat(2, 1fr); }
+	.grid { grid-template-columns: repeat(2, 1fr); } /* split in 2 columns */
   }
 
+/* Larger sized screens */
 @media (min-width: 900px) {
-	.grid { grid-template-columns: repeat(3, 1fr); }
+	.grid { grid-template-columns: repeat(3, 1fr); }  /* split in 3 columns */
   }
 
-.grid figure figcaption::before,
-.grid figure figcaption::after {
-	pointer-events: none;
-}
-
+/* Position and style of <a> elements (the View more) */
 .grid figure figcaption,
 .grid figure figcaption > a {
 	position: absolute;
@@ -64,16 +63,14 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-}
-
-.grid figure figcaption > a {
 	z-index: 1000;
 	text-indent: 0%;
 	white-space: nowrap;
-	font-size: 0;
+	font-size: 0; /* do not display the View more */
 	opacity: 1;
 }
 
+/* h2: Problem name (LASSO, ...) */
 .grid figure h2 {
 	word-spacing: 0em;
 	font-weight: 300;
@@ -88,65 +85,73 @@
 	margin: 0;
 }
 
+/* p: number of files */
 .grid figure p {
 	letter-spacing: 1px;
 	font-size: 70%;
 }
 
+/* Default color */
 figure.effect-ruby {
     background-color: #2c3e50;
 }
 
+/* Color when hovering */
 figure.effect-ruby:hover {
     background-color: DodgerBlue;
 }
 
+/* Define transformation */
 figure.effect-ruby img {
 	opacity: 0;
 	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
-	transition: opacity 0.35s, transform 0.35s;
-	-webkit-transform: scale(1.15);
+	transition: opacity 0.35s, transform 0.35s; /* transition time */
+	-webkit-transform: scale(1.15); /* size transformation -> bigger */
 	transform: scale(1.15);
 }
 
+/* transformation with hovering */
 figure.effect-ruby:hover img {
 	opacity: 0;
 	-webkit-transform: scale(1);
-	transform: scale(1);
+	transform: scale(1); /* size -> smaller */
 }
 
+/* Apply effect to problem name */
 figure.effect-ruby h2 {
-	margin-top: 10;
+	margin-top: 10; /* default margin */
 	-webkit-transition: -webkit-transform 0.35s;
-	transition: transform 0.35s;
-	-webkit-transform: translate3d(0,20px,0);
+	transition: transform 0.35s; /* transition time */
+	-webkit-transform: translate3d(0,20px,0); /* move down */
 	transform: translate3d(0,40px,0);
-	font-size: 1.25em;
+	font-size: 1.25em; /* default font */
 }
 
 figure.effect-ruby p {
     margin: 2em -1em 2em -1em;
 	padding: 1em 0em 1em 0em;
-	border: 1px solid #fff;
+	border: 1px solid #fff; /* create sort of white frame */
 	opacity: 0;
 	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
 	transition: opacity 0.35s, transform 0.35s;
-	-webkit-transform: translate3d(0,20px,0) scale(1.1);
+	-webkit-transform: translate3d(0,20px,0) scale(1.1); /* size transform */
 	transform: translate3d(0,20px,0) scale(1.1);
 }
 
+/* Transform title on hover */
 figure.effect-ruby:hover h2 {
     -webkit-transform: translate3d(0,0,0);
-	transform: translate3d(0px,10px,0) scale(.8);
-	margin-top: 0em;
+	transform: translate3d(0px,10px,0) scale(.8); /* smaller */
+	margin-top: 0em; /* move up */
 }
 
 figure.effect-ruby:hover p {
     opacity: 1;
-	-webkit-transform: translate3d(0,0,0) scale(1.2);
-	transform: translate3d(-15,0,0) scale(1);
+	-webkit-transform: translate3d(0,0,0) scale(1.2); /* bigger size */
+	transform: translate3d(-15,0,0) scale(1); /* placement in box */
 }
 
+/* Button for inside the table with system informations */
 .buttoncent {
 	border:none;
 	background-color:transparent;
@@ -154,10 +159,12 @@ figure.effect-ruby:hover p {
 	text-align: center;
  }
 
+ /* button for inside text
+ in benchmark page above graph for system informations */
  .buttonleft {
 	border:none;
 	background-color:transparent;
 	outline:none;
 	text-align: center;
-	margin-left: 1px;
+	margin-left: 1px; /* add margin */
  }

--- a/benchopt/plotting/html/static/main.css
+++ b/benchopt/plotting/html/static/main.css
@@ -255,56 +255,64 @@ td.number {
   background-color: RoyalBlue;
 }
 
+
+/* sidebar for the filters */
 .sidenav {
   margin: 0;
-  padding: 1%;
-  top: 0;
+  padding: 1%;  /* Text is not stuck to border */
+  top: 0; /* Sidebar begins at the very top of the page without blank space */
   left: 0;
-  width: 200px;
+  width: 200px;  /* Width to be careful with using mobile devices */
   position: fixed;
-  height: 100%;
+  height: 100%; /* On the whole page*/
   overflow: auto;
 	background-color: #2c3e50;
-  transition: 0.5s;
+  transition: 0.5s;  /* Time of animation when appearing */
 }
 
+/* Closing button for sidenav: only displayed with mobile devices */
 .sidenav .closebtn{
   display: none;
 }
 
+/* The main part of the page should adapt to the presence of the sidebar */
 .main {
-  margin-left: 200px;
+  margin-left: 200px; /* same as sidebar width to avoid overlaps */
   padding: 1px 16px;
   height: 1000px;
 }
 
+/* for medium sized screens */
 @media screen and (max-width: 900px) {
-  .sidenav .myselect {float: none;
-                      width: 75vw;
-                      text-align: center;
-                      margin-bottom: 15px;}
+  /* select menu is the sidebar (filters) */
+  .sidenav .myselect {float: none; /* position */
+                      width: 75vw; /* 75% of window width */
+                      text-align: center;  /* center */
+                      margin-bottom: 15px; /* space between menus */
+                    }
+  /* sidebar on medium screens */
   .sidenav {
-    height: 0%;
+    height: 0%; /* not showing */
     width: 100%;
     position: fixed;
-    z-index: 1;
-    top: 0;
+    z-index: 1; /* first plan */
+    top: 0; /* the whole screen is taken */
     left: 0;
-    background-color: rgb(0,0,0);
-    background-color: rgba(0,0,0, 0.9);
+    background-color: rgba(0,0,0, 0.9); /* black filter on the background */
     overflow-y: hidden;
-    transition: 0.5s;
+    transition: 0.5s;  /* time for appearance animation */
   }
 
+  /* close sidebar button with absolute position */
   .sidenav .closebtn {
     position: absolute;
     font-size: 40px;
     display: block;
     }
 
-
-  div.main {margin-left: 0;}
-  .menu {
+  /* main content on medium sized screens */
+  div.main {margin-left: 0;} /* no more sidebar so no more margin */
+  .menu { /* style menu for filters */
     position: relative;
     margin: auto;
     text-align: center;
@@ -314,12 +322,14 @@ td.number {
     width: 75vw;
   }
 
+  /* name of the dropdown menus placement */
   .menu label{
-    font-size: 200%;
-    float: left;
+    font-size: 200%; /* twice bigger than normal */
+    float: left; /* on the left */
   }
 }
 
+/* filters for very small screens (inherits from medium)*/
 @media screen and (max-width: 400px) {
   .sidenav {
     text-align: center;
@@ -328,34 +338,31 @@ td.number {
 }
 
 .sidenav .myselect {
-  padding: 1% 1% 1% 1.5%;
+  padding: 1% 1% 1% 1.5%; /* paddings to avoid stuck on borders*/
   text-decoration: none;
   font-size: 25px;
   color: #000;
   display: block;
 }
 
+/* dropdown menus */
 .myselect {
   width: 100%;
   height: 50px;
   font-size: 100%;
   font-weight: bold;
-  cursor: pointer;
-  border-radius: 10px;
-  background-color: DodgerBlue;
-  border-bottom: 10px solid #2c3e50;
+  cursor: pointer;  /* points when hovering and using */
+  border-radius: 10px;  /* size of rectangle borders */
+  background-color: DodgerBlue;  /* blue background */
   border: none;
-  color: white;
-  appearance: none;
-  padding: 1%;
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  color: white;  /* text color in the options */
   padding: 1%;
   margin-bottom: 10%;
 }
 
+/* only when hovering */
 .myselect:hover {
   color: #2c3e50;
-  background-color: white;
-  border-bottom-color: #DCDCDC;
+  background-color: white; /* white background */
+  border-bottom-color: #DCDCDC;  /* white-ish border */
 }

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -108,15 +108,11 @@ def plot_objective_curve(df, plotly=False, suboptimality=False,
                     direction="down",
                     pad={"r": 10, "t": 10},
                     showactive=True,
-                    x=0.09,
-                    xanchor="left",
-                    y=1.08,
-                    yanchor="top"
                 )
             ],
             annotations=[
-                dict(text="Log-scale", x=0., xref="paper", y=1.045,
-                     yref="paper", showarrow=False)
+                dict(text="Log-scale", x=-0.15, xref="paper",
+                     y=1.01, yref="paper", showarrow=False)
             ]
         )
     else:

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -86,7 +86,38 @@ def plot_objective_curve(df, plotly=False, suboptimality=False,
             xaxis_tickformat=".0e",
             xaxis_tickangle=-45,
             title=title,
-            legend_title='solver'
+            legend_title='solver',
+            )
+
+        # options for log scale
+        fig.update_layout(
+            updatemenus=[
+                dict(
+                    buttons=list([
+                        dict(
+                            args=["xaxis.type", "log"],
+                            label="loglog",
+                            method="relayout"
+                        ),
+                        dict(
+                            args=["xaxis.type", "linear"],
+                            label="semilog-y",
+                            method="relayout"
+                        )
+                    ]),
+                    direction="down",
+                    pad={"r": 10, "t": 10},
+                    showactive=True,
+                    x=0.09,
+                    xanchor="left",
+                    y=1.08,
+                    yanchor="top"
+                )
+            ],
+            annotations=[
+                dict(text="Log-scale", x=0., xref="paper", y=1.045,
+                     yref="paper", showarrow=False)
+            ]
         )
     else:
         plt.legend(fontsize=14)


### PR DESCRIPTION
- Add an option to toggle between semilogy plots and loglog with plotly (cc @mathurinm). It presents iself as a dropdown menu and the active element is showed. Default is loglog (current plots). (Of course after clicking it shrinks back to a normal menu, the image below is to show how options are displayed)
- Comments in CSS added for clarity.

![Capture d’écran de 2021-07-01 16-57-16](https://user-images.githubusercontent.com/57089823/124145937-8ca80e80-da8d-11eb-87c8-f5bc074a0b66.png)
