### PR TITLE
FIX pattern should *start* with solver or dataset name

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -293,7 +293,7 @@ def is_matched(name, include_patterns=None):
     name = str(name)
     for p in include_patterns:
         p = p.replace("*", '.*')
-        if re.match(f".*{p}.*", name, flags=re.IGNORECASE) is not None:
+        if re.match(f"^{p}.*", name, flags=re.IGNORECASE) is not None:
             return True
     return False
 

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -11,7 +11,7 @@ DUMMY_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'dummy_benchmark'
 # Pattern to select specific datasets or solvers.
 SELECT_ONE_SIMULATED = r'simulated*500*rho=0\]'
 SELECT_ONE_PGD = r'python-pgd*step_size=1\]'
-SELECT_ONE_OBJECTIVE = r'dummy sparse regression*reg=0.1\]'
+SELECT_ONE_OBJECTIVE = r'dummy*reg=0.1\]'
 
 try:
     DUMMY_BENCHMARK = Benchmark(DUMMY_BENCHMARK_PATH)

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -11,6 +11,7 @@ DUMMY_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'dummy_benchmark'
 # Pattern to select specific datasets or solvers.
 SELECT_ONE_SIMULATED = r'simulated*500*rho=0\]'
 SELECT_ONE_PGD = r'python-pgd*step_size=1\]'
+SELECT_ONE_OBJECTIVE = r'dummy sparse regression*reg=0.1\]'
 
 try:
     DUMMY_BENCHMARK = Benchmark(DUMMY_BENCHMARK_PATH)

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -83,8 +83,8 @@ class TestRunCmd:
             with pytest.raises(SystemExit, match='False'):
                 run([str(DUMMY_BENCHMARK_PATH), '--env-name', test_env_name,
                      '-d', SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD,
-                     '-n', '1', '-r', '1', '-p', '0.1', '--no-plot'],
-                    'benchopt', standalone_mode=False)
+                     '-n', '1', '-r', '1', '-p', SELECT_ONE_OBJECTIVE,
+                     '--no-plot'], 'benchopt', standalone_mode=False)
 
         out.check_output(f'conda activate {test_env_name}')
         out.check_output('Simulated', repetition=1)
@@ -101,7 +101,7 @@ class TestRunCmd:
         n_rep = 2
         run_cmd = [str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
                    '-s', SELECT_ONE_PGD, '-n', '1', '-r', str(n_rep),
-                   '-p', '0.1', '--no-plot']
+                   '-p', SELECT_ONE_OBJECTIVE, '--no-plot']
 
         # Make a first run that should be put in cache
         with CaptureRunOutput() as out:
@@ -184,8 +184,8 @@ class TestPlotCmd:
         "Make sure at least one result file is available"
         with SuppressStd() as out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
-                 '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-p', '0.1',
-                 '--no-plot'], 'benchopt', standalone_mode=False)
+                 '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-p',
+                 SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt', standalone_mode=False)
         result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
         assert len(result_files) == 1, out.output
         result_file = result_files[0]

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -185,7 +185,8 @@ class TestPlotCmd:
         with SuppressStd() as out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
                  '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-p',
-                 SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt', standalone_mode=False)
+                 SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
+                standalone_mode=False)
         result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
         assert len(result_files) == 1, out.output
         result_file = result_files[0]

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -11,6 +11,7 @@ from benchopt.utils.stream_redirection import SuppressStd
 from benchopt.tests import CaptureRunOutput
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
+from benchopt.tests import SELECT_ONE_OBJECTIVE
 from benchopt.tests import DUMMY_BENCHMARK
 from benchopt.tests import DUMMY_BENCHMARK_PATH
 
@@ -66,8 +67,8 @@ class TestRunCmd:
     def test_benchopt_run(self):
         with CaptureRunOutput() as out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
-                 '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-p', '0.1',
-                 ], 'benchopt', standalone_mode=False)
+                 '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-p',
+                 SELECT_ONE_OBJECTIVE], 'benchopt', standalone_mode=False)
 
         out.check_output('Simulated', repetition=1)
         out.check_output('Dummy Sparse Regression', repetition=1)

--- a/examples/plot_run_benchmark_python_R_julia.py
+++ b/examples/plot_run_benchmark_python_R_julia.py
@@ -21,7 +21,7 @@ try:
         Benchmark(BENCHMARK_PATH),
         ['Python-PGD[^-]*use_acceleration=False', 'R-PGD', 'Julia-PGD'],
         dataset_names=[SELECT_ONE_SIMULATED],
-        objective_filters=['reg=0.5'],
+        objective_filters=['*reg=0.5'],
         max_runs=100, timeout=100, n_repetitions=5,
         plot_result=False, show_progress=False
     )


### PR DESCRIPTION
cf #178 
I think we could even change it to "^{p} {opening bracket or end of string}.*"   
at least with this change `-s celer` does not trigger `pgd[use_acceleration=False]"

WDYT @tomMoral ?