### PR TITLE
larger markers, use semilogy scale by default

### DIFF
--- a/benchopt/plotting/helpers_compat.py
+++ b/benchopt/plotting/helpers_compat.py
@@ -16,7 +16,7 @@ def fill_between_x(fig, x, q1, q9, y, color, marker, label, plotly=False):
     fig.add_trace(go.Scatter(
         x=x, y=y,
         line_color=color, marker_symbol=marker, mode='lines+markers',
-        name=label, legendgroup=label,
+        marker_size=10, name=label, legendgroup=label,
         hoverlabel=dict(namelength=-1),
         hovertemplate='%{text} <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
         text=[label for _ in x]

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -78,7 +78,7 @@ def plot_objective_curve(df, plotly=False, suboptimality=False,
     # Format the plot to be nice
     if plotly:
         fig.update_layout(
-            xaxis_type='log',
+            xaxis_type='linear',
             yaxis_type='log',
             xaxis_title=r"Time [sec]",
             yaxis_title=y_label,
@@ -87,7 +87,7 @@ def plot_objective_curve(df, plotly=False, suboptimality=False,
             xaxis_tickangle=-45,
             title=title,
             legend_title='solver',
-            )
+        )
 
         # options for log scale
         fig.update_layout(
@@ -95,15 +95,15 @@ def plot_objective_curve(df, plotly=False, suboptimality=False,
                 dict(
                     buttons=list([
                         dict(
+                            args=["xaxis.type", "linear"],
+                            label="semilog-y",
+                            method="relayout"
+                        ),
+                        dict(
                             args=["xaxis.type", "log"],
                             label="loglog",
                             method="relayout"
                         ),
-                        dict(
-                            args=["xaxis.type", "linear"],
-                            label="semilog-y",
-                            method="relayout"
-                        )
                     ]),
                     direction="down",
                     pad={"r": 10, "t": 10},


### PR DESCRIPTION
1) I changed the default scale to semilogy in plotly. I find loglog very confusing, as it exaggerates the importance of early iterations ; it also does not reflect how crushingly superior an algorithm can be.

2) I increased the marker scales, as I found them hard to read (given that the colors are already quite similar)

Before marker size change (notice how the two red curves are hard to distinguish):
![image](https://user-images.githubusercontent.com/8993218/126477390-a00fd233-9d50-4a8b-af22-03f20c59342f.png)

After:
![image](https://user-images.githubusercontent.com/8993218/126477313-c89ecee5-0cb5-4c33-9829-ddce4b1a49b3.png)
