### PR TITLE
FIX editable distribution in pip

### DIFF
--- a/benchopt/utils/misc.py
+++ b/benchopt/utils/misc.py
@@ -6,16 +6,21 @@ def get_benchopt_requirement_line():
     Find out how benchopt where installed so we can install the same version
     even if it was installed in develop mode. This requires pip version >= 20.1
     """
+    from pip._internal.utils.misc import dist_is_editable
     from pip._internal.operations.freeze import FrozenRequirement
     from pip._internal.utils.misc import get_installed_distributions
 
     # If benchopt is installed in editable mode, get the module path to install
     # it directly from the folder. Else, install it correctly even if it is
     # installed with an url.
-    dist = [t for t in get_installed_distributions()
-            if t.project_name == 'benchopt'][0]
-    req = FrozenRequirement.from_dist(dist)
-    if req.editable:
+    all_dist = [t for t in get_installed_distributions()
+                if t.project_name == 'benchopt']
+    assert len(all_dist) == 1, (
+        'benchopt is not installed in the current environment?'
+    )
+    dist = all_dist[0]
+    if dist_is_editable(dist):
         return f'-e {dist.module_path}'
 
+    req = FrozenRequirement.from_dist(dist)
     return str(req)


### PR DESCRIPTION
The test are broken on `master` due to an update in `pip`.
It seems that now, distribution do not have a `editable` attribute but rely on `dist_is_editable` to check if it is editable.

This PR should make this more robust.