### PR TITLE
FIX benchopt install in env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ jobs:
               # makes the auto install of julia solver fails when cloning the General
               # repository from julia. To avoid this, we clone this on the system directly.
               # See https://github.com/JuliaLang/julia/issues/33111
-              git clone https://github.com/JuliaRegistries/General.git \
-                      $HOME/.julia/registries/General
+              # git clone https://github.com/JuliaRegistries/General.git \
+              #         $HOME/.julia/registries/General
 
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
               pip install --upgrade --progress-bar off julia

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,6 @@ jobs:
         - run:
             name: Get Python running
             command: |
-
-              # There is an ungoing issue with compat between libgit2 and julia which
-              # makes the auto install of julia solver fails when cloning the General
-              # repository from julia. To avoid this, we clone this on the system directly.
-              # See https://github.com/JuliaLang/julia/issues/33111
-              # git clone https://github.com/JuliaRegistries/General.git \
-              #         $HOME/.julia/registries/General
-
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
               pip install --upgrade --progress-bar off julia
               pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git

--- a/benchopt/cli/__init__.py
+++ b/benchopt/cli/__init__.py
@@ -6,6 +6,8 @@ from benchopt.cli.main import main
 from benchopt.cli.helpers import helpers
 from benchopt.cli.process_results import process_results
 
+from benchopt.utils.misc import get_benchopt_requirement
+
 
 SOURCES = [main, process_results, helpers]
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -14,11 +16,17 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(name='benchopt', cls=click.CommandCollection, sources=SOURCES,
                context_settings=CONTEXT_SETTINGS, invoke_without_command=True)
 @click.option('--version', '-v', is_flag=True, help='Print version')
+@click.option('--check-editable', is_flag=True,
+              help='Print a flag if benchopt is installed in development mode')
 @click.pass_context
-def benchopt(ctx, version=False):
+def benchopt(ctx, version=False, check_editable=False):
     """Command-line interface to benchOpt"""
     if version:
-        print(__version__)
+        output = __version__
+        if check_editable:
+            _, is_editable = get_benchopt_requirement()
+            output = f"{output} {is_editable}"
+        print(output)
         raise SystemExit(0)
     if ctx.invoked_subcommand is None:
         print(benchopt.get_help(ctx))

--- a/benchopt/helpers/julia.py
+++ b/benchopt/helpers/julia.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from contextlib import contextmanager
 
 from benchopt.config import DEBUG
@@ -70,27 +69,6 @@ class JuliaSolver(BaseSolver):
             except Exception:
                 return False
         return success
-
-    @classmethod
-    def _pre_install_hook(cls, env_name=None):
-        """Make sure julia can be installed with conda
-
-        There is an ungoing issue with compat between libgit2 and julia which
-        makes the auto install of julia solver fails when cloning the General
-        repository from julia. To avoid this, we clone this on the system
-        directly.
-        See https://github.com/JuliaLang/julia/issues/33111
-        """
-        julia_dir = Path.home() / '.julia' / 'registries' / 'General'
-        if not julia_dir.exists():
-
-            cmd_clone = (
-                "git clone https://github.com/JuliaRegistries/General.git "
-                f"{julia_dir}"
-            )
-            _run_shell_in_conda_env(
-                cmd_clone, env_name=env_name, raise_on_error=True
-            )
 
     @classmethod
     def _post_install_hook(cls, env_name=None):

--- a/benchopt/utils/misc.py
+++ b/benchopt/utils/misc.py
@@ -1,26 +1,31 @@
 
 
-def get_benchopt_requirement_line():
+def get_benchopt_requirement():
     """Specification for pip requirement to install benchopt in conda env.
 
     Find out how benchopt where installed so we can install the same version
     even if it was installed in develop mode. This requires pip version >= 20.1
+
+    Returns
+    -------
+    pip_requirement : str
+        String to pass to pip to instal benchopt in another environment.
+    is_editable : bool
+        Whether the current installation is in development mode or not.
     """
-    from pip._internal.utils.misc import dist_is_editable
+    from pip._internal.metadata import get_default_environment
     from pip._internal.operations.freeze import FrozenRequirement
-    from pip._internal.utils.misc import get_installed_distributions
+
+    dist = get_default_environment().get_distribution('benchopt')
 
     # If benchopt is installed in editable mode, get the module path to install
     # it directly from the folder. Else, install it correctly even if it is
     # installed with an url.
-    all_dist = [t for t in get_installed_distributions()
-                if t.project_name == 'benchopt']
-    assert len(all_dist) == 1, (
+    assert dist is not None, (
         'benchopt is not installed in the current environment?'
     )
-    dist = all_dist[0]
-    if dist_is_editable(dist):
-        return f'-e {dist.module_path}'
-
     req = FrozenRequirement.from_dist(dist)
-    return str(req)
+    if req.editable:
+        return f'-e {dist.location}', True
+
+    return str(req), False


### PR DESCRIPTION
The failure in benchmark_lasso seems to be linked to a bad fix in #195 that does not work with `benchopt` install in non-dev mode.
This should fix this and also fix bad behavior when installing `benchopt` in dev mode with new commits.