### PR TITLE
Fix doc CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             name: Get Python running
             command: |
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
+              pip install --upgrade setuptools==57.4.0
               pip install --upgrade --progress-bar off julia
               pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
               pip install --upgrade --progress-bar off -e .[doc]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42",
+  "setuptools>=42,<=57.4.0",
   "wheel",
   "setuptools_scm>=6.2"
 ]


### PR DESCRIPTION
Circle CI doc build fails. 

It would seem that the support for the parameter `use_2to3` was dropped in the last version (58.0) of setuptools (as it was deprecated for some time now). But sphinx-bootstrap uses it.
Setuptools developers are working on some fixes since the release, but in the mean time maybe we should pin the version to build the doc.