### PR TITLE
Reverse setuptools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             name: Get Python running
             command: |
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
+              pip install --upgrade setuptools==57.4.0
               pip install --upgrade --progress-bar off julia
               pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
               pip install --upgrade --progress-bar off -e .[doc]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
             name: Get Python running
             command: |
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
-              pip install --upgrade setuptools==57.4.0
               pip install --upgrade --progress-bar off julia
               pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
               pip install --upgrade --progress-bar off -e .[doc]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42",
+  "setuptools>=42,<=57.4.0",
   "wheel",
   "setuptools_scm>=6.2"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42,<=57.4.0",
+  "setuptools>=42",
   "wheel",
   "setuptools_scm>=6.2"
 ]


### PR DESCRIPTION
Now that sphinx-bootstrap-theme has released the version 0.8.0 we should no longer need to pin setuptools version.
(pending that other packages don't use the `use_2to3` parameter). 