### PR TITLE
Remove inf values from plotting

### DIFF
--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -44,8 +44,7 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
     dataset_name = df['data_name'].unique()[0]
     objective_name = df['objective_name'].unique()[0]
     title = f"{objective_name}\nData: {dataset_name}"
-
-    df.query(f"{obj_col} not in [inf, -inf]", inplace=True)
+    df.query(f"`{obj_col}` not in [inf, -inf]", inplace=True)
     y_label = "F(x)"
     if suboptimality:
         eps = 1e-10

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -45,13 +45,13 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
     objective_name = df['objective_name'].unique()[0]
     title = f"{objective_name}\nData: {dataset_name}"
 
-    df = df.query(f"{obj_col} not in [inf, -inf]")
+    df.query(f"{obj_col} not in [inf, -inf]", inplace=True)
     y_label = "F(x)"
     if suboptimality:
         eps = 1e-10
         y_label = "F(x) - F(x*)"
         c_star = df[obj_col].min() - eps
-        df[obj_col] -= c_star
+        df.loc[:, obj_col] -= c_star
 
     if relative:
         if suboptimality:
@@ -59,7 +59,7 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
         else:
             y_label = "F(x) / F(x0)"
         max_f_0 = df[df['stop_val'] == 1][obj_col].max()
-        df[obj_col] /= max_f_0
+        df.loc[:, obj_col] /= max_f_0
 
     fig = get_figure(plotly)
 

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -45,6 +45,8 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
     objective_name = df['objective_name'].unique()[0]
     title = f"{objective_name}\nData: {dataset_name}"
 
+    inf = float("inf")
+    df = df[df[obj_col] != inf]
     y_label = "F(x)"
     if suboptimality:
         eps = 1e-10

--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -45,8 +45,7 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
     objective_name = df['objective_name'].unique()[0]
     title = f"{objective_name}\nData: {dataset_name}"
 
-    inf = float("inf")
-    df = df[df[obj_col] != inf]
+    df = df.query(f"{obj_col} not in [inf, -inf]")
     y_label = "F(x)"
     if suboptimality:
         eps = 1e-10


### PR DESCRIPTION
The reason why the `logreg_l2` plots were "weird looking" was that there was a point that took a very long time to be computed that had for value `inf`: so not visible.
By removing the `inf` values in the plots, axis scales are much more relevant (see before/after)

| Before | After  |
|---|---|
| ![With inf values](https://user-images.githubusercontent.com/57089823/133259489-f1a98f59-01b1-43f1-bf59-3b8dcfd70395.png)|![Without inf values](https://user-images.githubusercontent.com/57089823/133259628-0ba8a4a9-2360-44bd-ac0e-1adce8703f70.png)|