### PR TITLE
FIX use conda install for sklearn

### DIFF
--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/sklearn.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/sklearn.py
@@ -12,7 +12,7 @@ class Solver(BaseSolver):
     name = 'sklearn'
 
     install_cmd = 'conda'
-    requirements = ['pip:scikit-learn']
+    requirements = ['scikit-learn']
 
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd


### PR DESCRIPTION
try to fix failures from https://github.com/benchopt/benchOpt/runs/3718219572?check_suite_focus=true
If this works, we will try to reproduce the segfault for `sklearn` in a separate PR.