### PR TITLE
Add minimal plotly version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pygithub
     mako
     psutil
-    plotly
+    plotly>=4.12
     line-profiler
 project_urls =
     Documentation = https://benchopt.github.io/


### PR DESCRIPTION
We use  `fig.add_hline` in helpers_compat.py ; it was added in plotly 4.12 so I made it a requirement. @qb3 had an issue otherwise.

See https://stackoverflow.com/questions/68296479/why-am-i-getting-plotly-express-attribute-error-attributeerror-figure-objec