### PR TITLE
Use tab10, cycle through colors

### DIFF
--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -81,7 +81,7 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
 
         fill_between_x(
             fig, curve['time'], q1, q9, curve[obj_col], color=CMAP(i % CMAP.N),
-            marker=markers[i], label=solver_name, plotly=plotly
+            marker=markers[i % len(markers)], label=solver_name, plotly=plotly
         )
 
     if suboptimality and not relative:


### PR DESCRIPTION
closes #216 : use tab10 instead of tab20 as @josephsalmon suggested

This made me realize we use` cmap(i)` which returns the last color of the cmap when` i >= len(cmap.colors)`:

![image](https://user-images.githubusercontent.com/8993218/136363963-2d3223bd-50a5-426b-985f-49c7d82edf6c.png)


So I used a modulo to fix. Using tab10 reduces the number of colors, but we have 41 (sic) markers to differentiate after that and I believe it's still readable:
![image](https://user-images.githubusercontent.com/8993218/136364282-2687da52-a3dd-41f4-9a8f-a5d1eb0764f3.png)
