### PR TITLE
remove editable mode in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           conda info
           conda install -yq pip
-          pip install .[test]
+          pip install -e .[test]
 
       - run: continuous_integration/test_script.sh
         name: 'Run the tests'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,6 @@ platforms = any
 [options]
 include_package_data = True
 packages = find:
-setup_requires =
-    # Make sure we install numpy/cython
-    # early for certain deps
-    numpy
-    cython
 install_requires =
     numpy
     scipy


### PR DESCRIPTION
It seems that the editable mode was built and not the wheel. And that created an error with some installs (eg cython).
(left is latest log and right is previous green lighted log, the only changes are at the `Getting requirements to build` lines)
![Capture d’écran de 2021-10-13 13-43-16](https://user-images.githubusercontent.com/57089823/137132492-fb3491d1-ad8c-40ba-9bd5-287a11fa9d09.png)


