### PR TITLE
Display options with newline and temporary ci fix setuptools 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             name: Get Python running
             command: |
               mamba install python=3.8 julia r-base rpy2 numpy cython -yq
+              pip install --upgrade "setuptools<58.5"
               pip install --upgrade --progress-bar off julia
               pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
               pip install --upgrade --progress-bar off -e .[doc]

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -15,12 +15,14 @@
 </head>
 
 <body>
-
+    <%
+    benchmark_name = benchmark.replace("benchmark_", "").replace("_", " ")
+    %>
     <a id="top"></a>
     <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
-    <a href="${benchmark}.html"><button class="btn"><i class="fa fa-arrow-left"></i> ${benchmark}</button></a>
+    <a href="${benchmark}.html"><button class="btn"><i class="fa fa-arrow-left"></i> ${benchmark_name}</button></a>
 
-    <h1>Result on ${benchmark} benchmark</h1>
+    <h1>Result on ${benchmark_name} benchmark</h1>
     <summary></summary>
     <p><a href="${result['fname']}">
             <button class="btn"><i class="fa fa-download"></i> ${result["fname_short"]}</button>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -61,12 +61,15 @@
 
 
     <!-- Add selector to display only one plot -->
+    <div>
     <label for='dataset_selector'>Dataset:</label>
     <select id='dataset_selector' onchange="showMe(this);">
         % for data in result['dataset_names']:
         <option value="${data}">${data}</option>
         %endfor
     </select>
+    </div>
+    <div>
     <label for='objective_selector'>Objective:</label>
     <select id='objective_selector' onchange="showMe(this);">
         % for obj in result['objective_names']:
@@ -78,20 +81,21 @@
         <option value="${obj_col}">${obj_col.replace('objective_', '')}</option>
         %endfor
     </select>
+    </div>
+    <div>
     <label for='plot_kind'>Kind:</label>
     <select id='plot_kind' onchange="showMe(this);">
         % for kind in result['kinds']:
         <option value="${kind}">${kind}</option>
         %endfor
     </select>
-    <label for='change_scaling'>Axis type</label>
     <select id="change_scaling" onchange="changeScale(this)">
         <option value="semilog-y">semilog-y</option>
         <option value="semilog-x">semilog-x</option>
         <option value="loglog">loglog</option>
         <option value="linear">linear</option>
     </select>
-
+    </div>
 
     % for data in result['dataset_names']:
     <div class="${data}">

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -83,10 +83,10 @@
     </select>
     </div>
     <div>
-    <label for='plot_kind'>Kind:</label>
+    <label for='plot_kind'>Chart type:</label>
     <select id='plot_kind' onchange="showMe(this);">
         % for kind in result['kinds']:
-        <option value="${kind}">${kind}</option>
+        <option value="${kind}">${kind.replace('_', ' ')}</option>
         %endfor
     </select>
     <select id="change_scaling" onchange="changeScale(this)">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42",
+  "setuptools>=42,<58.5",
   "wheel",
   "setuptools_scm>=6.2"
 ]


### PR DESCRIPTION
- Display options for BenchOpt results a little more organized (poke @mathurinm)
- `setuptools` released the version 58.5.0 that broke the CI (and a lot of others like scipy's), like last time until they fix the problem we can pin the version.