### PR TITLE
Alternative to remove local file 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,138 +2,138 @@
 # Tagging a commit with [circle full] will build everything.
 version: 2
 jobs:
-    build_docs:
-      docker:
-        - image: circleci/python:3.8.1-buster
-      steps:
-        - checkout
-        - run:
-            name: Set BASH_ENV
-            command: |
-              echo "set -e" >> $BASH_ENV
-              echo "export DISPLAY=:99" >> $BASH_ENV
-              echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
-              echo "BASH_ENV:"
-              cat $BASH_ENV
+  build_docs:
+    docker:
+      - image: circleci/python:3.8.1-buster
+    steps:
+      - checkout
+      - run:
+          name: Set BASH_ENV
+          command: |
+            echo "set -e" >> $BASH_ENV
+            echo "export DISPLAY=:99" >> $BASH_ENV
+            echo "export OPENBLAS_NUM_THREADS=4" >> $BASH_ENV
+            echo "BASH_ENV:"
+            cat $BASH_ENV
 
-        - run:
-            name: Merge with upstream
-            command: |
-              echo $(git log -1 --pretty=%B) | tee gitlog.txt
-              echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
-              if [[ $(cat merge.txt) != "" ]]; then
-                echo "Merging $(cat merge.txt)";
-                git remote add upstream git://github.com/benchopt/benchOpt.git;
-                git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
-                git fetch upstream master;
-              fi
+      - run:
+          name: Merge with upstream
+          command: |
+            echo $(git log -1 --pretty=%B) | tee gitlog.txt
+            echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
+            if [[ $(cat merge.txt) != "" ]]; then
+              echo "Merging $(cat merge.txt)";
+              git remote add upstream git://github.com/benchopt/benchOpt.git;
+              git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+              git fetch upstream main;
+            fi
 
-        # Load our data
-        - restore_cache:
-            keys:
-              - pkgs-cache
+      # Load our data
+      - restore_cache:
+          keys:
+            - pkgs-cache
 
-        - run:
-            name: Spin up Xvfb
-            command: |
-              /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+      - run:
+          name: Spin up Xvfb
+          command: |
+            /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
 
-        - run:
-            name: Get conda running
-            command: |
+      - run:
+          name: Get conda running
+          command: |
 
-              wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh -O ~/miniconda.sh;
-              chmod +x ~/miniconda.sh;
-              ~/miniconda.sh -b -p ~/miniconda;
-              echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
+            wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh -O ~/miniconda.sh;
+            chmod +x ~/miniconda.sh;
+            ~/miniconda.sh -b -p ~/miniconda;
+            echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
 
-              # update conda pkgs cache
-              mkdir ~/conda_pkgs 2>/dev/null || echo 'already exists'
-              cp -r ~/miniconda/pkgs/* ~/conda_pkgs/
-              rm -rf ~/miniconda/pkgs
-              ln -s ~/conda_pkgs ~/miniconda/pkgs
+            # update conda pkgs cache
+            mkdir ~/conda_pkgs 2>/dev/null || echo 'already exists'
+            cp -r ~/miniconda/pkgs/* ~/conda_pkgs/
+            rm -rf ~/miniconda/pkgs
+            ln -s ~/conda_pkgs ~/miniconda/pkgs
 
-        - run:
-            name: Get Python running
-            command: |
-              mamba install python=3.8 julia r-base rpy2 numpy cython -yq
-              pip install --upgrade "setuptools<58.5"
-              pip install --upgrade --progress-bar off julia
-              pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
-              pip install --upgrade --progress-bar off -e .[doc]
+      - run:
+          name: Get Python running
+          command: |
+            mamba install python=3.8 julia r-base rpy2 numpy cython -yq
+            pip install --upgrade "setuptools<58.5"
+            pip install --upgrade --progress-bar off julia
+            pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
+            pip install --upgrade --progress-bar off -e .[doc]
 
-        - save_cache:
-            key: pkgs-cache
-            paths:
-              - ~/.cache/pip
-              - ~/conda_pkgs
+      - save_cache:
+          key: pkgs-cache
+          paths:
+            - ~/.cache/pip
+            - ~/conda_pkgs
 
-        # Look at what we have and fail early if there is some library conflict
-        - run:
-            name: Check installation
-            command: |
-               which python
-               python -c "import benchopt"
+      # Look at what we have and fail early if there is some library conflict
+      - run:
+          name: Check installation
+          command: |
+            which python
+            python -c "import benchopt"
 
-        # Build docs
-        - run:
-            name: make html
-            command: |
-              cd doc;
-              make html;
+      # Build docs
+      - run:
+          name: make html
+          command: |
+            cd doc;
+            make html;
 
-        # Save the outputs
-        - store_artifacts:
-            path: doc/_build/html/
-            destination: dev
-        - persist_to_workspace:
-            root: doc/_build
-            paths:
-              - html
+      # Save the outputs
+      - store_artifacts:
+          path: doc/_build/html/
+          destination: dev
+      - persist_to_workspace:
+          root: doc/_build
+          paths:
+            - html
 
-    deploy:
-      docker:
-        - image: circleci/python:3.8.1-buster
-      steps:
-        - attach_workspace:
-            at: /tmp/build
-        - run:
-            name: Fetch docs
-            command: |
-              set -e
-              mkdir -p ~/.ssh
-              echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
-              chmod og= ~/.ssh/config
-              if [ ! -d ~/benchopt.github.io ]; then
-                git clone git@github.com:/benchopt/benchopt.github.io.git ~/benchopt.github.io --depth=1
-              fi
-        - run:
-            name: Deploy docs
-            command: |
-              set -e;
+  deploy:
+    docker:
+      - image: circleci/python:3.8.1-buster
+    steps:
+      - attach_workspace:
+          at: /tmp/build
+      - run:
+          name: Fetch docs
+          command: |
+            set -e
+            mkdir -p ~/.ssh
+            echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config
+            chmod og= ~/.ssh/config
+            if [ ! -d ~/benchopt.github.io ]; then
+              git clone git@github.com:/benchopt/benchopt.github.io.git ~/benchopt.github.io --depth=1
+            fi
+      - run:
+          name: Deploy docs
+          command: |
+            set -e;
+            cd ~/benchopt.github.io;
+            if [[ "${CIRCLE_BRANCH}" != "main" ]]; then
+              echo "No deployment (build: ${CIRCLE_BRANCH}).";
+            else
+              git config --global user.email "circle@benchopt.com";
+              git config --global user.name "Circle CI";
               cd ~/benchopt.github.io;
-              if [[ "${CIRCLE_BRANCH}" != "master" ]]; then
-                echo "No deployment (build: ${CIRCLE_BRANCH}).";
+              git checkout main
+              git remote -v
+              git fetch origin
+              git reset --hard origin/main
+              git clean -xdf
+              echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
+              cp -a /tmp/build/html/* .;
+              if [[ -z $(git diff) ]]; then
+                echo "Nothing to commit"
               else
-                git config --global user.email "circle@benchopt.com";
-                git config --global user.name "Circle CI";
-                cd ~/benchopt.github.io;
-                git checkout master
-                git remote -v
-                git fetch origin
-                git reset --hard origin/master
-                git clean -xdf
-                echo "Deploying dev docs for ${CIRCLE_BRANCH}.";
-                cp -a /tmp/build/html/* .;
-                if [[ -z $(git diff) ]]; then
-                  echo "Nothing to commit"
-                else
-                  touch .nojekyll;
-                  git add -A;
-                  git commit -m "CircleCI update of dev docs (${CIRCLE_BUILD_NUM}).";
-                  git push origin master;
-                fi
+                touch .nojekyll;
+                git add -A;
+                git commit -m "CircleCI update of dev docs (${CIRCLE_BUILD_NUM}).";
+                git push origin main;
               fi
+            fi
 
 workflows:
   version: 2
@@ -147,4 +147,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -1,0 +1,152 @@
+$(document).ready(function () {
+  $(".summary").dataTable({
+    order: [[0, "desc"]],
+  }); // reorder table by date
+  if (location.hostname === "") {
+    // local file
+    $("[name='checkfiles']").css({
+      display: "block",
+      "margin-left": "auto",
+      float: "left",
+    }); // display checkboxes
+    $("#trashBtn").css({
+      display: "block",
+      float: "left",
+      "margin-bottom": "5vh",
+    });
+  }
+});
+
+$("table").each(function (a, tbl) {
+  var currentTableRows = $(tbl).find("tbody tr").length;
+  $(tbl)
+    .find("th")
+    .each(function (i) {
+      var remove = 0;
+      var currentTable = $(this).parents("table");
+      var tds = currentTable.find("tr td:nth-child(" + (i + 1) + ")");
+      tds.each(function (j) {
+        if ($(this)[0].innerText.length == 0) remove++;
+      });
+      if (remove == currentTableRows) {
+        $(this).hide();
+        tds.hide();
+      }
+    });
+});
+
+function change(ll_item) {
+  var td, i, fil;
+  var filter = new Array();
+  for (item = 0; item < ll_item.length; item++) {
+    filter.push(
+      document
+        .getElementById("select" + ll_item[item].replace(/\s/g, ""))
+        .value.toUpperCase()
+    );
+  }
+  var table = document.getElementById("summary");
+  var tr = table.getElementsByTagName("tr");
+  for (i = 0; i < tr.length; i++) {
+    tr[i].style.display = "";
+    td = tr[i].getElementsByTagName("td")[2];
+    if (td) {
+      for (fil = 0; fil < filter.length; fil++) {
+        if (
+          td.innerHTML.toUpperCase().indexOf(filter[fil]) > -1 &&
+          tr[i].style.display !== "none"
+        ) {
+          tr[i].style.display = "";
+        } else {
+          tr[i].style.display = "none";
+        }
+      }
+    }
+  }
+}
+
+function displaymore(id, loop_index) {
+  var x = document.getElementById("subinfo" + loop_index);
+  $(id).find("svg").toggleClass("fa-plus-circle fa-minus-circle");
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+}
+
+var openbtn = document.getElementById("open");
+if (openbtn) {
+  var closebtn = document.getElementById("close");
+  openbtn.style.display = "none";
+
+  function openSideNav() {
+    navbar = document.getElementById("sidenav");
+    navbar.style.visibility = "visible";
+    main = document.getElementById("main");
+    if ($(window).width() < 900) {
+      navbar.style.height = "100%";
+      main.style.marginLeft = "0";
+    } else {
+      navbar.style.height = "1000px";
+      main.style.marginLeft = "200px";
+    }
+    navbar.style.opacity = "1";
+    openbtn.style.display = "none";
+    closebtn.style.display = "";
+  }
+
+  if ($(window).width() > 900) {
+    openSideNav();
+  } else {
+    closeSideNav();
+  }
+
+  function closeSideNav() {
+    navbar = document.getElementById("sidenav");
+    main = document.getElementById("main");
+    navbar.style.visibility = "hidden";
+    navbar.style.opacity = "0";
+    navbar.style.height = "0";
+    if ($(window).width() > 900) {
+      main.style.marginLeft = "0px";
+    }
+    openbtn.style.display = "";
+    closebtn.style.display = "none";
+  }
+}
+
+$(function () {
+  $("#dialogRm").dialog({
+    autoOpen: false,
+  });
+
+  $("#trashBtn").click(function () {
+    allChecked = document.querySelectorAll("input[name=checkfiles]:checked");
+    delCmd = "rm \\\n <br />"; // n and br for html and copy to clipboard
+    for (check of allChecked) {
+      delCmd += $(check).attr("data-csv") + " \\\n <br />";
+      delCmd += "html/" + $(check).attr("data-html") + " \\\n <br />";
+    }
+    $("#dialogRm").html(delCmd);
+    $("#dialogRm")
+      .dialog({
+        title: "Remove selected entries",
+        modal: true,
+        draggable: true,
+        resizable: false,
+        width: "auto",
+        buttons: {
+          "Copy to clipboard": function () {
+            navigator.clipboard.writeText($("#dialogRm").text());
+          },
+          "Remove row": function () {
+            for (check of allChecked) {
+              $(check).closest("tr").remove();
+            }
+          },
+        },
+      })
+      .dialog("open");
+  });
+});

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -126,8 +126,9 @@ $(function () {
     delCmd = "rm \\\n <br />"; // n and br for html and copy to clipboard
     for (check of allChecked) {
       delCmd += $(check).attr("data-csv") + " \\\n <br />";
-      delCmd += "html/" + $(check).attr("data-html") + " \\\n <br />";
+      delCmd += $(check).attr("data-html") + " \\\n <br />";
     }
+    delCmd += "cache_run_list.json";
     $("#dialogRm").html(delCmd);
     $("#dialogRm")
       .dialog({

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -7,11 +7,12 @@
 * - Order the table based on run date.
 * - Add trash button if it is a local file.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-$(document).ready(function () {
+$(function () {
   // Sort the table by descending date order (date being in column 0)
   $(".summary").dataTable({
     order: [[0, "desc"]],
   }); // reorder table by date
+
   if (location.hostname === "") {
     // local file and not doc website
     $("[name='checkfiles']").css({
@@ -26,27 +27,26 @@ $(document).ready(function () {
       "margin-bottom": "5vh",
     });
   }
-});
-
-/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Hide the system information column if it is empty
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-$("table").each(function (a, tbl) {
-  var currentTableRows = $(tbl).find("tbody tr").length;
-  $(tbl)
-    .find("th") // also take care of table head
-    .each(function (i) {
-      var remove = 0;
-      var currentTable = $(this).parents("table");
-      var tds = currentTable.find("tr td:nth-child(" + (i + 1) + ")");
-      tds.each(function (j) {
-        if ($(this)[0].innerText.length == 0) remove++;
+  /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  * Hide the system information column if it is empty
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+  $("table").each(function (a, tbl) {
+    var currentTableRows = $(tbl).find("tbody tr").length;
+    $(tbl)
+      .find("th") // also take care of table head
+      .each(function (i) {
+        var remove = 0;
+        var currentTable = $(this).parents("table");
+        var tds = currentTable.find("tr td:nth-child(" + (i + 1) + ")");
+        tds.each(function (j) {
+          if ($(this)[0].innerText.length == 0) remove++;
+        });
+        if (remove == currentTableRows) {
+          $(this).hide();
+          tds.hide();
+        }
       });
-      if (remove == currentTableRows) {
-        $(this).hide();
-        tds.hide();
-      }
-    });
+  });
 });
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -99,54 +99,75 @@ function displayMore(id, loop_index) {
   }
 }
 
-// handle sidebar navigation
-var openbtn = document.getElementById("open");
-if (openbtn) {
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Open or close sidebar when document ready
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+$(function () {
+  var openbtn = document.getElementById("open");
   var closebtn = document.getElementById("close");
-  openbtn.style.display = "none"; // only display close button is sidenav opened
-
-  // function to open the sidebar navigation
-  function openSideNav() {
-    navbar = document.getElementById("sidenav");
-    navbar.style.visibility = "visible";
-    main = document.getElementById("main");
-    if ($(window).width() < 900) {
-      // mobile adaptativity
-      navbar.style.height = "100%";
-      main.style.marginLeft = "0";
-    } else {
-      navbar.style.height = "1000px";
-      main.style.marginLeft = "200px";
-    }
-    navbar.style.opacity = "1";
-    openbtn.style.display = "none"; // hide open button
-    closebtn.style.display = ""; // show close button
-  }
-
-  // default display depending on device
-  if ($(window).width() > 900) {
-    openSideNav();
-  } else {
-    closeSideNav();
-  }
-
-  // function to close the sidebar navigation
-  function closeSideNav() {
-    navbar = document.getElementById("sidenav");
-    main = document.getElementById("main");
-    navbar.style.visibility = "hidden";
-    navbar.style.opacity = "0";
-    navbar.style.height = "0";
+  if (openbtn) {
+    openbtn.style.display = "none"; // only display close button is sidenav opened
+    // default display depending on device
     if ($(window).width() > 900) {
-      // adapt to devices
-      main.style.marginLeft = "0px";
+      openSideNav({ data: { op: openbtn, cl: closebtn } });
+    } else {
+      closeSideNav({ data: { op: openbtn, cl: closebtn } });
     }
-    openbtn.style.display = ""; // show open button
-    closebtn.style.display = "none"; // hide close button
   }
+  // click method is the recommended way
+  $("#open").click({ op: openbtn, cl: closebtn }, openSideNav);
+  $("#close").click({ op: openbtn, cl: closebtn }, closeSideNav);
+  $(".closebtn").click({ op: openbtn, cl: closebtn }, closeSideNav);
+});
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Open sidebar: the argument must be an event
+* ie an object containing a data dictionnary
+* the data has a key op for the open button
+* and a key cl for the close button.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+function openSideNav(event) {
+  openbtn = event.data.op;
+  closebtn = event.data.cl;
+  navbar = document.getElementById("sidenav");
+  navbar.style.visibility = "visible";
+  main = document.getElementById("main");
+  if ($(window).width() < 900) {
+    // mobile adaptativity
+    navbar.style.height = "100%";
+    main.style.marginLeft = "0";
+  } else {
+    navbar.style.height = "1000px";
+    main.style.marginLeft = "200px";
+  }
+  navbar.style.opacity = "1";
+  openbtn.style.display = "none"; // hide open button
+  closebtn.style.display = ""; // show close button
 }
 
-// dialog box to get path of files we would like to remove
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Same as openSideNav above but for closing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+function closeSideNav(event) {
+  openbtn = event.data.op;
+  closebtn = event.data.cl;
+  navbar = document.getElementById("sidenav");
+  main = document.getElementById("main");
+  navbar.style.visibility = "hidden";
+  navbar.style.opacity = "0";
+  navbar.style.height = "0";
+  if ($(window).width() > 900) {
+    // adapt to devices
+    main.style.marginLeft = "0px";
+  }
+  openbtn.style.display = ""; // show open button
+  closebtn.style.display = "none"; // hide close button
+}
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Launch a dialog box to hide rows in table or
+* get the files checked by user in local rendering.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 $(function () {
   $("#dialogRm").dialog({
     autoOpen: false, // only open when needed

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -1,3 +1,12 @@
+/*********************************************
+*  JS functions for the benchmark page.
+*********************************************/
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Format the table once the page has been loaded.
+* - Order the table based on run date.
+* - Add trash button if it is a local file.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 $(document).ready(function () {
   // Sort the table by descending date order (date being in column 0)
   $(".summary").dataTable({
@@ -19,7 +28,9 @@ $(document).ready(function () {
   }
 });
 
-// hide columns without content (if system informations not available)
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Hide the system information column if it is empty
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 $("table").each(function (a, tbl) {
   var currentTableRows = $(tbl).find("tbody tr").length;
   $(tbl)
@@ -38,9 +49,11 @@ $("table").each(function (a, tbl) {
     });
 });
 
-/**
- * Filter table from dropdown current value
- */
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Callback for the side bar select box.
+* Filter the benchmark runs in the table
+* based on the current selected values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 function change(ll_item) {
   var td, i, fil;
   var filter = new Array();
@@ -72,10 +85,10 @@ function change(ll_item) {
   }
 }
 
-/**
- * Display subinfo in the table
- * Toggle between + and - icon button
- */
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Callback for the +/- button of system-info.
+* Display sub info in the table.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 function displaymore(id, loop_index) {
   var x = document.getElementById("subinfo" + loop_index);
   $(id).find("svg").toggleClass("fa-plus-circle fa-minus-circle");
@@ -162,7 +175,7 @@ $(function () {
             // copy content in clipboard
             navigator.clipboard.writeText($("#dialogRm").text());
           },
-          "Remove row": function () {
+          "Hide row": function () {
             // remove rows with checked checkboxes until refresh
             for (check of allChecked) {
               $(check).closest("tr").remove();

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -1,10 +1,12 @@
 $(document).ready(function () {
+  // Sort the table by descending date order (date being in column 0)
   $(".summary").dataTable({
     order: [[0, "desc"]],
   }); // reorder table by date
   if (location.hostname === "") {
-    // local file
+    // local file and not doc website
     $("[name='checkfiles']").css({
+      // only show lines that not hidden by user
       display: "block",
       "margin-left": "auto",
       float: "left",
@@ -17,10 +19,11 @@ $(document).ready(function () {
   }
 });
 
+// hide columns without content (if system informations not available)
 $("table").each(function (a, tbl) {
   var currentTableRows = $(tbl).find("tbody tr").length;
   $(tbl)
-    .find("th")
+    .find("th") // also take care of table head
     .each(function (i) {
       var remove = 0;
       var currentTable = $(this).parents("table");
@@ -35,6 +38,9 @@ $("table").each(function (a, tbl) {
     });
 });
 
+/**
+ * Filter table from dropdown current value
+ */
 function change(ll_item) {
   var td, i, fil;
   var filter = new Array();
@@ -43,7 +49,7 @@ function change(ll_item) {
       document
         .getElementById("select" + ll_item[item].replace(/\s/g, ""))
         .value.toUpperCase()
-    );
+    ); // Add dropdown value on top of the array (order is necessary)
   }
   var table = document.getElementById("summary");
   var tr = table.getElementsByTagName("tr");
@@ -51,6 +57,7 @@ function change(ll_item) {
     tr[i].style.display = "";
     td = tr[i].getElementsByTagName("td")[2];
     if (td) {
+      // do not display elements from table not in filter
       for (fil = 0; fil < filter.length; fil++) {
         if (
           td.innerHTML.toUpperCase().indexOf(filter[fil]) > -1 &&
@@ -65,6 +72,10 @@ function change(ll_item) {
   }
 }
 
+/**
+ * Display subinfo in the table
+ * Toggle between + and - icon button
+ */
 function displaymore(id, loop_index) {
   var x = document.getElementById("subinfo" + loop_index);
   $(id).find("svg").toggleClass("fa-plus-circle fa-minus-circle");
@@ -75,16 +86,19 @@ function displaymore(id, loop_index) {
   }
 }
 
+// handle sidebar navigation
 var openbtn = document.getElementById("open");
 if (openbtn) {
   var closebtn = document.getElementById("close");
-  openbtn.style.display = "none";
+  openbtn.style.display = "none"; // only display close button is sidenav opened
 
+  // function to open the sidebar navigation
   function openSideNav() {
     navbar = document.getElementById("sidenav");
     navbar.style.visibility = "visible";
     main = document.getElementById("main");
     if ($(window).width() < 900) {
+      // mobile adaptativity
       navbar.style.height = "100%";
       main.style.marginLeft = "0";
     } else {
@@ -92,16 +106,18 @@ if (openbtn) {
       main.style.marginLeft = "200px";
     }
     navbar.style.opacity = "1";
-    openbtn.style.display = "none";
-    closebtn.style.display = "";
+    openbtn.style.display = "none"; // hide open button
+    closebtn.style.display = ""; // show close button
   }
 
+  // default display depending on device
   if ($(window).width() > 900) {
     openSideNav();
   } else {
     closeSideNav();
   }
 
+  // function to close the sidebar navigation
   function closeSideNav() {
     navbar = document.getElementById("sidenav");
     main = document.getElementById("main");
@@ -109,45 +125,51 @@ if (openbtn) {
     navbar.style.opacity = "0";
     navbar.style.height = "0";
     if ($(window).width() > 900) {
+      // adapt to devices
       main.style.marginLeft = "0px";
     }
-    openbtn.style.display = "";
-    closebtn.style.display = "none";
+    openbtn.style.display = ""; // show open button
+    closebtn.style.display = "none"; // hide close button
   }
 }
 
+// dialog box to get path of files we would like to remove
 $(function () {
   $("#dialogRm").dialog({
-    autoOpen: false,
+    autoOpen: false, // only open when needed
   });
 
+  // click on delete button in the dialog box
   $("#trashBtn").click(function () {
+    // get files with checheck checkbox
     allChecked = document.querySelectorAll("input[name=checkfiles]:checked");
     delCmd = "rm \\\n <br />"; // n and br for html and copy to clipboard
     for (check of allChecked) {
       delCmd += $(check).attr("data-csv") + " \\\n <br />";
       delCmd += $(check).attr("data-html") + " \\\n <br />";
     }
-    delCmd += "cache_run_list.json";
-    $("#dialogRm").html(delCmd);
-    $("#dialogRm")
+    delCmd += "cache_run_list.json"; // add the cache file
+    $("#dialogRm").html(delCmd); // modify the content in the html file
+    $("#dialogRm") // dialog box
       .dialog({
         title: "Remove selected entries",
         modal: true,
-        draggable: true,
-        resizable: false,
+        draggable: true, // the user can move it
+        resizable: false, // but not resize it
         width: "auto",
         buttons: {
           "Copy to clipboard": function () {
+            // copy content in clipboard
             navigator.clipboard.writeText($("#dialogRm").text());
           },
           "Remove row": function () {
+            // remove rows with checked checkboxes until refresh
             for (check of allChecked) {
               $(check).closest("tr").remove();
             }
           },
         },
       })
-      .dialog("open");
+      .dialog("open"); // open dialog box on click
   });
 });

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -1,6 +1,6 @@
 /*********************************************
-*  JS functions for the benchmark page.
-*********************************************/
+ *  JS functions for the benchmark page.
+ *********************************************/
 
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Format the table once the page has been loaded.
@@ -89,7 +89,7 @@ function change(ll_item) {
 * Callback for the +/- button of system-info.
 * Display sub info in the table.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-function displaymore(id, loop_index) {
+function displayMore(id, loop_index) {
   var x = document.getElementById("subinfo" + loop_index);
   $(id).find("svg").toggleClass("fa-plus-circle fa-minus-circle");
   if (x.style.display === "none") {

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -135,7 +135,7 @@
           <li>
             <b>${key_main}</b>: ${val_main}
             % if disp_sub and disp_button:
-              <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+              <button onclick="displayMore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
                 <i class='fas fa-plus-circle'></i>
               </button>
               <% disp_button = False %>
@@ -147,7 +147,7 @@
       % if disp_sub:
         <!--Case where sub infos are available but somehow main infos are not-->
         % if disp_button:
-          <button onclick="displaymore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+          <button onclick="displayMore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
             <i class='fas fa-plus-circle'></i>
           </button>
         % endif

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -12,12 +12,12 @@
   src="https://code.jquery.com/jquery-3.5.1.min.js"
   integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
   crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
-<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css" />
-<script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+  <link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css" />
+  <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 <link href="https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" rel="stylesheet" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+<script type="text/javascript" src="${static_dir}/benchmark.js" async></script>
 </head>
 
 <body>
@@ -135,7 +135,7 @@
           <li>
             <b>${key_main}</b>: ${val_main}
             % if disp_sub and disp_button:
-              <button onclick="displayMore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+              <button data-idx=${idx_res} id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
                 <i class='fas fa-plus-circle'></i>
               </button>
               <% disp_button = False %>
@@ -147,7 +147,7 @@
       % if disp_sub:
         <!--Case where sub infos are available but somehow main infos are not-->
         % if disp_button:
-          <button onclick="displayMore(this,${idx_res})" id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
+          <button data-idx=${idx_res} id=${"btn_subinfo"+str(idx_res)} class="button buttoncent" style="float:right;">
             <i class='fas fa-plus-circle'></i>
           </button>
         % endif
@@ -182,6 +182,5 @@
 <a class="backtotop" title="Back to top" href="#top" style="z-index: 50;"><i class="fas fa-level-up-alt"></i></a>
 
 </div>
-<script type="text/javascript" src="${static_dir}/benchmark.js"></script>
 </body>
 </html>

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -33,7 +33,7 @@
 %>
 
 <div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear; z-index: 100;">
-  <a href="javascript:void(0)" class="closebtn" onclick="closeSideNav()">&times;</a>
+  <a href="javascript:void(0)" class="closebtn">&times;</a>
   <div class="menu">
     % for key, val in ll_main.items():
     <label for=${'select'+str(key.replace(" ", ""))} style="padding: 8px; color: white;">
@@ -73,8 +73,8 @@
 </p>
 
 % if need_filter:
-<span id="close" style="font-size:30px;cursor:pointer" onclick="closeSideNav()">&#9776; Filter Informations</span>
-<span id="open" style="font-size:30px;cursor:pointer" onclick="openSideNav()">&#9776; Filter Informations</span>
+<span id="close" style="font-size:30px;cursor:pointer">&#9776; Filter Informations</span>
+<span id="open" style="font-size:30px;cursor:pointer">&#9776; Filter Informations</span>
 % endif
 
 <table class="summary display" id="summary">

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -29,7 +29,7 @@
   for key, val in ll_main.items():
     all_items = list(set([r['sysinfo']['main'][key] for r in results]))
     items_unique[key] = sorted(all_items)
-
+  benchmark_name = benchmark.replace('benchmark_', '').replace('_', " ")
 %>
 
 <div class="sidenav" id="sidenav" style="visibility: hidden; height:0; opacity: 0; transition: visibility 0s, opacity 0.5s linear; z-index: 100;">
@@ -62,7 +62,7 @@
   <a id="top"></a>
 <h1>
   <a href="${home}"><button class="btn"><i class="fa fa-home"></i></button></a>
-  BenchOpt results: ${benchmark.replace('benchmark_', '').replace('_', " ")}
+  BenchOpt results: ${benchmark_name}
   <a href="https://github.com/benchopt/${benchmark}">
     <i class="fab fa-github-square"></i>
   </a>
@@ -92,15 +92,13 @@
     <td class="fname">
       <a href="${result['page']}">
         <%
-        fname = result["fname_short"]
-        csv_name = "outputs/benchopt_run" + fname.split("benchopt_run")[1]
-        fname, _ = fname.split('.')
-        fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
+        fname = "".join(result["fname_short"].split("_")[-2:])
+        fname = benchmark_name + " " + fname.split(".")[0]
         disp_sub = any([val != '' for val in result['sysinfo']['sub'].values()])
         %>
         ${fname}
       </a>
-      <input type="checkbox" name="checkfiles" data-csv=${csv_name} data-html="${result['page']}" style="display:none;">
+      <input type="checkbox" name="checkfiles" data-csv="${result['fname']}" data-html="${result['page']}" style="display:none;">
     </td>
     <td class="datasets">
     <ul style="list-style-type: none; margin-top: 0;">

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -12,6 +12,8 @@
   src="https://code.jquery.com/jquery-3.5.1.min.js"
   integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
   crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+<link href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css" />
 <script src="https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min.js"></script>
 <link href="https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" rel="stylesheet" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -90,13 +92,15 @@
     <td class="fname">
       <a href="${result['page']}">
         <%
-          fname = result["fname_short"]
-          fname, _ = fname.split('.')
-          fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
-          disp_sub = any([val != '' for val in result['sysinfo']['sub'].values()])
+        fname = result["fname_short"]
+        csv_name = "outputs/benchopt_run" + fname.split("benchopt_run")[1]
+        fname, _ = fname.split('.')
+        fname = fname.replace("benchmark_", "").replace("_benchopt_run_", " ")
+        disp_sub = any([val != '' for val in result['sysinfo']['sub'].values()])
         %>
         ${fname}
       </a>
+      <input type="checkbox" name="checkfiles" data-csv=${csv_name} data-html="${result['page']}" style="display:none;">
     </td>
     <td class="datasets">
     <ul style="list-style-type: none; margin-top: 0;">
@@ -162,7 +166,7 @@
       % endif
 
     </td>
-    <td class="buttons">
+    <td class="buttons" style='text-align: center'>
       <a href="${result['page']}">
         <button class="btn"><i class="fas fa-chart-line"></i></button>
       </a>
@@ -174,109 +178,12 @@
 %endfor
 </tbody>
 </table>
+<div id="dialogRm" hidden="hidden"> dialog text </div>
+<button class="btn" id="trashBtn" style="display:none;float:right;"><i class="fa fa-trash"></i></button>
 
 <a class="backtotop" title="Back to top" href="#top" style="z-index: 50;"><i class="fas fa-level-up-alt"></i></a>
 
-<script type="text/javascript">
-$(document).ready(function() {
-    $('.summary').dataTable( {
-        "order": [[ 0, "desc" ]]
-      }
-    )
-});
-
-$('table').each(function(a, tbl) {
-        var currentTableRows = $(tbl).find('tbody tr').length;
-        $(tbl).find('th').each(function(i) {
-            var remove = 0;
-            var currentTable = $(this).parents('table');
-            var tds = currentTable.find('tr td:nth-child(' + (i + 1) + ')');
-            tds.each(function(j) { if ($(this)[0].innerText.length == 0) remove++; });
-            if (remove == currentTableRows) {
-                $(this).hide();
-                tds.hide();
-            }
-        });
-    });
-
-function change(ll_item){
-  var td, i, fil;
-  var filter = new Array;
-  for (item = 0; item < ll_item.length; item++){
-    filter.push(document.getElementById("select"+ll_item[item].replace(/\s/g, "")).value.toUpperCase());
-  }
-  var table = document.getElementById("summary");
-  var tr = table.getElementsByTagName("tr");
-  for (i = 0; i < tr.length; i++) {
-    tr[i].style.display = "";
-    td = tr[i].getElementsByTagName("td")[2];
-    if (td){
-     for (fil = 0; fil < filter.length; fil++){
-       if (td.innerHTML.toUpperCase().indexOf(filter[fil]) > -1 && tr[i].style.display !== "none") {
-         tr[i].style.display = "";
-       }
-       else {
-         tr[i].style.display = "none";
-       }
-     }
-    }
-  }
-}
-
-function displaymore(id, loop_index) {
-  var x = document.getElementById("subinfo"+loop_index);
-  $(id).find('svg').toggleClass('fa-plus-circle fa-minus-circle');
-  if (x.style.display === 'none') {
-    x.style.display = "block";
-  }
-  else {
-    x.style.display = "none";
-  }
-}
-
-var openbtn = document.getElementById("open");
-if (openbtn){
-  var closebtn = document.getElementById("close");
-  openbtn.style.display = 'none';
-
-  function openSideNav() {
-      navbar = document.getElementById("sidenav")
-      navbar.style.visibility = "visible";
-      main = document.getElementById("main")
-      if ($(window).width() < 900) {
-        navbar.style.height = "100%";
-        main.style.marginLeft = "0";
-      }
-      else {
-        navbar.style.height = "1000px";
-        main.style.marginLeft = "200px";
-      }
-      navbar.style.opacity = "1";
-  	  openbtn.style.display = 'none';
-      closebtn.style.display = '';
-  }
-
-  if ($(window).width() > 900){
-    openSideNav()
-  }
-  else {
-    closeSideNav()
-  }
-
-  function closeSideNav() {
-      navbar = document.getElementById("sidenav")
-      main = document.getElementById("main")
-      navbar.style.visibility = "hidden";
-      navbar.style.opacity = "0";
-      navbar.style.height = "0";
-      if ($(window).width() > 900) {
-        main.style.marginLeft = "0px";
-      }
-      openbtn.style.display = '';
-      closebtn.style.display = 'none';
-    }
-}
-</script>
 </div>
+<script type="text/javascript" src="${static_dir}/benchmark.js"></script>
 </body>
 </html>


### PR DESCRIPTION
As discussed to resolve #229, for local rendering only, this adds a select box at the left of the bench result's name (or just below depending on the available space) and a trash icon below the table.

![Capture d’écran de 2021-11-15 09-36-42](https://user-images.githubusercontent.com/57089823/141749661-969b6ddf-64ae-46c9-a0e0-794b67e6081f.png)

If selected, then the trash icon displays the path of several files that are inside the `outputs` folder:
- the selected `.csv` datasets,
- the selected `.html` associated generated pages,
- the cached json file (so the next time we call `benchopt plot --all .` for example the deleted benchs are not presented in the results table).

![Capture d’écran de 2021-11-15 09-36-50](https://user-images.githubusercontent.com/57089823/141751707-ee883e40-ec71-433e-a6f4-a33608053a63.png)

Then, one can simply click on `copy to clipboard` and paste the command in the terminal from the `outputs` folder.
For the current time, there is also a `hide row` button that will hide the selected rows (until the page is refreshed as it is static) but it can be useful to avoid clutter if we open the results in multiple tabs. 

PS: this also separates the JS for the table page from the html. The only thing to adapt in the future would be the paths of the files (available as `data-csv` and `data-html` attributes of the checkboxes) when the user does not use `benchopt plot` but `generate-results` or a local `make render` (open issue #230).