### PR TITLE
Math style correction in doc

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -144,7 +144,7 @@ Some available benchmarks
 
 .. math::
 
-  \min_{w, \sigma} {\sum_{i=1}^n \left(\sigma + H_{\epsilon}\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \lambda {||w||_2}^2}
+  \min_{w, \sigma} {\sum_{i=1}^n \left(\sigma + H_{\epsilon}\left(\frac{X_{i}w - y_{i}}{\sigma}\right)\sigma\right) + \lambda {\|w\|_2}^2}
 
 where
 


### PR DESCRIPTION
Correcting same math typo as in the Huber example, for nice display in the doc.

Could be interesting (if the number of benchmarks objective become large) to have an automated way to go from the benchmarks to the docs...
but I have no idea if this is possible.