### PR TITLE
CLN fix print length

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -8,7 +8,8 @@ from .utils.sys_info import get_sys_info
 from .utils.pdb_helpers import exception_handler
 
 from .utils.colorify import colorify
-from .utils.colorify import LINE_LENGTH, RED, GREEN, YELLOW
+from .utils.colorify import print_normalize
+from .utils.colorify import RED, GREEN, YELLOW
 
 # Get config values
 from .config import DEBUG
@@ -317,7 +318,7 @@ def run_one_solver(benchmark, objective, solver, meta, max_runs, n_repetitions,
         else:
             final_status = colorify('done', GREEN)
 
-        print(f"{tag} {final_status}".ljust(LINE_LENGTH))
+        print_normalize(f"{tag} {final_status}")
     return curve
 
 
@@ -385,11 +386,12 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
             dataset = dataset_class.get_instance(**dataset_parameters)
             if not is_matched(str(dataset), dataset_names):
                 continue
-            print(f"{dataset}".ljust(LINE_LENGTH))
+            print_normalize(f"{dataset}")
             if not dataset.is_installed(
                     raise_on_not_installed=RAISE_INSTALL_ERROR):
-                print(colorify(f"Dataset {dataset} is not installed.", RED)
-                      .ljust(LINE_LENGTH))
+                print_normalize(
+                    colorify(f"Dataset {dataset} is not installed.", RED)
+                )
                 continue
 
             dimension, data = dataset._get_data()
@@ -397,7 +399,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                 objective = objective_class.get_instance(**obj_parameters)
                 if not is_matched(str(objective), objective_filters):
                     continue
-                print(f"|--{objective}".ljust(LINE_LENGTH))
+                print_normalize(f"|--{objective}")
                 objective.set_dataset(dataset)
 
                 for solver_class in solver_classes:
@@ -419,14 +421,15 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                                 raise_on_not_installed=RAISE_INSTALL_ERROR
                         ):
                             status = colorify("not installed", RED)
-                            print(f"{tag} {status}".ljust(LINE_LENGTH))
+                            print_normalize(f"{tag} {status}")
                             continue
 
                         # Set objective an skip if necessary.
                         skip, reason = solver._set_objective(objective)
                         if skip:
-                            print(f"{tag} {colorify('skip', YELLOW)}"
-                                  .ljust(LINE_LENGTH))
+                            print_normalize(
+                                f"{tag} {colorify('skip', YELLOW)}"
+                            )
                             if reason is not None:
                                 print(f'Reason: {reason}')
                             continue
@@ -453,7 +456,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
     import pandas as pd
     df = pd.DataFrame(run_statistics)
     if df.empty:
-        print(colorify('No output produced.', RED).ljust(LINE_LENGTH))
+        print_normalize(colorify('No output produced.', RED))
         raise SystemExit(1)
 
     # Save output in CSV file in the benchmark folder

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -3,7 +3,7 @@ import math
 
 
 from .config import DEBUG
-from .utils.colorify import LINE_LENGTH
+from .utils.colorify import print_normalize
 
 
 # Possible stop strategies
@@ -231,10 +231,9 @@ class StoppingCriterion():
         if self.progress_str is not None:
             if isinstance(progress, float):
                 progress = f'{progress:6.1%}'
-            print(
-                self.progress_str.format(progress=progress)
-                .ljust(LINE_LENGTH) + '\r',
-                end='', flush=True
+            print_normalize(
+                self.progress_str.format(progress=progress),
+                endline=False
             )
 
     def check_convergence(self, cost_curve):

--- a/benchopt/utils/colorify.py
+++ b/benchopt/utils/colorify.py
@@ -1,7 +1,8 @@
 "Helper function for colored terminal outputs"
+import shutil
 
 
-LINE_LENGTH = 100
+MIN_LINE_LENGTH = 20
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(30, 38)
 
 
@@ -18,4 +19,18 @@ def colorify(message, color=BLUE):
     color_message : str
         The colored message to be displayed in terminal.
     """
-    return ("\033[1;%dm" % color) + message + "\033[0m"
+    return f"\033[1;{color}m" + message + "\033[0m"
+
+
+def print_normalize(msg, endline=True):
+    """Format the output to have the length of the terminal."""
+    line_length = max(
+        MIN_LINE_LENGTH, shutil.get_terminal_size((100, 24)).columns
+    )
+    n_colors = msg.count('\033') // 2
+    msg = msg.ljust(line_length + n_colors * 11)
+
+    if endline:
+        print(msg)
+    else:
+        print(msg + '\r', end='', flush=True)

--- a/benchopt/utils/pdb_helpers.py
+++ b/benchopt/utils/pdb_helpers.py
@@ -2,7 +2,8 @@
 from contextlib import contextmanager
 
 from .colorify import colorify
-from .colorify import LINE_LENGTH, RED, YELLOW
+from .colorify import RED, YELLOW
+from .colorify import print_normalize
 
 
 # Get config values
@@ -24,11 +25,11 @@ def exception_handler(tag=None, pdb=False):
         yield
     except KeyboardInterrupt:
         status = colorify("interrupted", YELLOW)
-        print(f"\r{tag} {status}".ljust(LINE_LENGTH))
+        print_normalize(f"\r{tag} {status}")
         raise SystemExit(1)
     except BaseException:
         status = colorify("error", RED)
-        print(f"{tag} {status}".ljust(LINE_LENGTH))
+        print_normalize(f"{tag} {status}")
 
         if pdb:
             # Use ipdb if it is available and default to pdb otherwise.


### PR DESCRIPTION
Try to fix the length of the output.
What is missing is actually try to reduce the size of the name of the solver if the console is too small.

An idea would be to `truncate` the parameters with ellipsis: `|---solver[p=1,...] xx% (X / X reps)`