### PR TITLE
DOC: use less solvers, use suboptimality

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,10 +25,10 @@ optimization benchmark should be **as simple as doing**:
     $ benchopt run --env ./benchmark_logreg_l2
 
 Running these commands will fetch the benchmark files, install the benchmark
-requirements in a dedicated environment `benchop_benchmark_logreg_l2` and
+requirements in a dedicated environment `benchopt_benchmark_logreg_l2` and
 give you a benchmark plot on l2-regularized logistic regression:
 
-.. figure:: auto_examples/images/sphx_glr_plot_run_benchmark_001.png
+.. figure:: auto_examples/images/sphx_glr_plot_run_benchmark_003.png
    :target: how.html
    :align: center
    :scale: 80%

--- a/examples/plot_run_benchmark.py
+++ b/examples/plot_run_benchmark.py
@@ -19,7 +19,8 @@ BENCHMARK_PATH = (
 
 try:
     save_file = run_benchmark(
-        Benchmark(BENCHMARK_PATH), ['sklearn', 'lightning'],
+        Benchmark(BENCHMARK_PATH), ['sklearn[liblinear]', 'sklearn[saga]',
+                                    'sklearn[newton-cg]', 'lightning'],
         dataset_names=['Simulated*n_samples=200,n_features=500*'],
         max_runs=100, timeout=20, n_repetitions=3,
         plot_result=False, show_progress=False


### PR DESCRIPTION
The first figure that users see when they land on the doc page is a bit "heavy" in my opinion, so I removed some solvers, and use a suboptimality plot:
Before:
![image](https://user-images.githubusercontent.com/8993218/143216135-02ba463a-de26-47cd-b272-4ab30ec360dc.png)

After (on my computer, I'll wait to see the results on CI):
![image](https://user-images.githubusercontent.com/8993218/143216207-c8bdd8d6-c407-4a81-b211-d62cbfcfa698.png)
