### PR TITLE
Rename BenchOpt to Benchopt

### DIFF
--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -8,7 +8,7 @@ from benchopt.cli.completion import get_output_files
 
 process_results = click.Group(
     name='Process Results',
-    help="Utilities to process benchmark outputs produced by benchOpt."
+    help="Utilities to process benchmark outputs produced by benchopt."
 )
 
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -371,7 +371,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
         by the objective is not the same for all parameters, the missing data
         is set to `NaN`.
     """
-    print("BenchOpt is running")
+    print("Benchopt is running")
 
     # Load the objective class for this benchmark and the datasets
     objective_class = benchmark.get_benchmark_objective()

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -11,11 +11,11 @@ class DependenciesMixin:
     # be in {None, 'conda', 'shell'}. The API reads:
     #
     # - 'conda': The class should have an attribute `requirements`.
-    #          BenchOpt will conda install `$requirements`, except for entries
+    #          Benchopt will conda install `$requirements`, except for entries
     #          starting with `pip:` which will be installed with `pip` in the
     #          conda env.
     #
-    # - 'shell': The solver should have attribute `install_script`. BenchOpt
+    # - 'shell': The solver should have attribute `install_script`. Benchopt
     #           will run `install_script` in a shell and provide the conda
     #           env directory as an argument. The command should then be
     #           installed in the `bin` folder of the env and can be imported

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ html_theme_options = {
         ("Write a benchmark", "how"),
         ("Results", "https://benchopt.github.io/results", True),
         ("What's new", "whats_new"),
-        ("GitHub", "https://github.com/benchopt/benchOpt", True)
+        ("GitHub", "https://github.com/benchopt/benchopt", True)
     ],
     # 'bootswatch_theme': "united",
     # 'bootswatch_theme': "sandstone",

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -31,7 +31,7 @@ For benchmark config files, they are usually located in the benchmark folder wit
 Config File Structure
 ---------------------
 
-The config files for benchOpt follow the Microsoft Windows INI files structure. The global setting are grouped in a ``[benchopt]`` section:
+The config files for benchopt follow the Microsoft Windows INI files structure. The global setting are grouped in a ``[benchopt]`` section:
 
 .. code-block:: ini
 

--- a/doc/how.rst
+++ b/doc/how.rst
@@ -21,7 +21,7 @@ structure. For example
         └── solver2.py  # some solver
 
 Examples of actual benchmarks are available in the
-`benchOpt organisation <https://github.com/benchopt/>`_ such
+`benchopt organisation <https://github.com/benchopt/>`_ such
 as for `Ordinary Least Square (OLS) <https://github.com/benchopt/benchmark_ols>`_,
 `Lasso <https://github.com/benchopt/benchmark_lasso>`_ or
 `L1-regularized logistic regression <https://github.com/benchopt/benchmark_logreg_l1>`_.
@@ -99,7 +99,7 @@ Sometimes one wants to test the solvers for variants of the same dataset.
 For example, one may want to change the dataset size, the noise level, etc.
 To be able to specify parameters to get a dataset, you can use a class
 attribute called ``parameters``. This parameter must be a dictionary
-whose keys are passed to the ``__init__`` of the dataset class. Then BenchOpt
+whose keys are passed to the ``__init__`` of the dataset class. Then Benchopt
 will automatically allow you to test all combinations of parameters.
 
 .. literalinclude:: ../benchopt/tests/test_benchmarks/dummy_benchmark/datasets/simulated.py
@@ -147,7 +147,7 @@ This ``stop_strategy`` can be:
       compute and store the objective and return ``False`` once the computations
       should stop.
 
-BenchOpt supports different types of solvers:
+Benchopt supports different types of solvers:
 
    - :ref:`python_solvers`
    - :ref:`r_solvers`
@@ -175,7 +175,7 @@ Here is an example in the same situation as above:
   :pyobject: Solver.run
 
 If your Python solver requires some packages such as `Numba <https://numba.pydata.org/>`_,
-BenchOpt allows you to list some requirements. The necessary packages should be available
+Benchopt allows you to list some requirements. The necessary packages should be available
 via `conda <https://docs.conda.io/en/latest/>`_ or
 `pip <https://packaging.python.org/guides/tool-recommendations/>`_.
 
@@ -195,7 +195,7 @@ not `conda-forge <https://conda-forge.org/>`_. See example:
 
 .. note::
 
-    Specifying the dependencies is necessary if you let BenchOpt
+    Specifying the dependencies is necessary if you let benchopt
     manage the creation of a dedicated environment. If you want to
     use your local environment the list of dependencies is
     not relevant. See :ref:`cli_documentation`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,9 @@
-BenchOpt: Benchmark repository for optimization
+Benchopt: Benchmark repository for optimization
 ===============================================
 
 |Test Status| |Python 3.6+| |codecov|
 
-BenchOpt is a package to make the comparison of optimizations algorithms simple, transparent and reproducible.
+Benchopt is a package to make the comparison of optimizations algorithms simple, transparent and reproducible.
 
 It is written in Python but is available with
 `many programming languages <auto_examples/plot_run_benchmark_python_R_julia.html>`_.
@@ -12,11 +12,11 @@ So far it has been tested with `Python <https://www.python.org/>`_,
 and compiled binaries written in C/C++ available via a terminal
 command.
 If a solver can be installed via
-`conda <https://docs.conda.io/en/latest/>`_, it should just work in BenchOpt!
+`conda <https://docs.conda.io/en/latest/>`_, it should just work in benchopt!
 
-BenchOpt is used through a command line as documented
+Benchopt is used through a command line as documented
 in the :ref:`cli_documentation`.
-Once BenchOpt is installed, running and replicating an optimization benchmark is **as simple as doing**:
+Once benchopt is installed, running and replicating an optimization benchmark is **as simple as doing**:
 
 .. code-block::
 
@@ -48,7 +48,7 @@ And to get the **latest development version**, you can use:
 
 .. code-block::
 
-    $ pip install -U https://github.com/benchopt/benchOpt/archive/master.zip
+    $ pip install -U https://github.com/benchopt/benchopt/archive/master.zip
 
 This will install the command line tool to run the benchmark. Then, existing
 benchmarks can be retrieved from GitHub or created locally. To discover which
@@ -195,9 +195,9 @@ See `benchmark_* repositories on GitHub <https://github.com/benchopt/>`_ for mor
 Benchmark results
 -----------------
 
-All the public benchmark results are available at `BenchOpt Benchmarks results <https://benchopt.github.io/results/>`_.
+All the public benchmark results are available at `Benchopt Benchmarks results <https://benchopt.github.io/results/>`_.
 
-**Publish results**: You can directly publish the result of a run of ``benchopt`` on `BenchOpt Benchmarks results <https://benchopt.github.io/results/>`_. You can have a look at this page to :ref:`publish_doc`.
+**Publish results**: You can directly publish the result of a run of ``benchopt`` on `Benchopt Benchmarks results <https://benchopt.github.io/results/>`_. You can have a look at this page to :ref:`publish_doc`.
 
 Contents
 ========
@@ -211,14 +211,14 @@ Contents
    publish
    config
    whats_new
-   Fork BenchOpt on Github <https://github.com/benchopt/benchopt>
+   Fork benchopt on Github <https://github.com/benchopt/benchopt>
 
-.. |Test Status| image:: https://github.com/benchopt/benchOpt/actions/workflows/test.yml/badge.svg
-   :target: https://github.com/benchopt/benchOpt/actions/workflows/test.yml
+.. |Test Status| image:: https://github.com/benchopt/benchopt/actions/workflows/test.yml/badge.svg
+   :target: https://github.com/benchopt/benchopt/actions/workflows/test.yml
 .. |Python 3.6+| image:: https://img.shields.io/badge/python-3.6%2B-blue
    :target: https://www.python.org/downloads/release/python-360/
-.. |codecov| image:: https://codecov.io/gh/benchopt/benchOpt/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/benchopt/benchOpt
+.. |codecov| image:: https://codecov.io/gh/benchopt/benchopt/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/benchopt/benchopt
 
 .. |Build Status OLS| image:: https://github.com/benchopt/benchmark_ols/workflows/Tests/badge.svg
    :target: https://github.com/benchopt/benchmark_ols/actions

--- a/doc/publish.rst
+++ b/doc/publish.rst
@@ -3,12 +3,12 @@
 Publish benchmark results
 =========================
 
-BenchOpt allows you to publish your benchmark results to
-the `BenchOpt Benchmarks website <https://benchopt.github.io/results/>`_
+Benchopt allows you to publish your benchmark results to
+the `Benchopt Benchmarks website <https://benchopt.github.io/results/>`_
 with one command ``benchopt publish``.
 
 The ``publish`` command will send your results to GitHub by opening
-a pull-request on the `BenchOpt results repository <https://github.com/benchopt/results>`_.
+a pull-request on the `Benchopt results repository <https://github.com/benchopt/results>`_.
 Once the pull-request is merged it will appear automatically online.
 
 Workflow example:
@@ -48,6 +48,6 @@ Then create a token named ``benchopt``, ticking the **repo** box as shown below:
    :align: center
 
 Then click on ``generate token`` and copy this token of 40 characters in a
-secure location. Note that the token can be stored in a config file for BenchOpt
+secure location. Note that the token can be stored in a config file for benchopt
 using ``benchopt config set github_token <TOKEN>``. More info on config files can
 be found in :ref:`config_doc`.

--- a/doc/sphinxext/gh_substitutions.py
+++ b/doc/sphinxext/gh_substitutions.py
@@ -9,7 +9,7 @@ from docutils.parsers.rst.roles import set_classes
 
 def gh_role(name, rawtext, pr_number, lineno, inliner, options={}, content=[]):
     """Link to a GitHub pull request."""
-    ref = f'https://github.com/benchopt/benchOpt/pull/{pr_number}'
+    ref = f'https://github.com/benchopt/benchopt/pull/{pr_number}'
     set_classes(options)
     node = reference(rawtext, '#' + pr_number, refuri=ref, **options)
     return [node], []

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -105,7 +105,7 @@ CLI
 BUG
 ~~~
 
-- Throw a warning when BenchOpt version in conda env does not match the one of
+- Throw a warning when benchopt version in conda env does not match the one of
   calling ``benchopt``, by `Thomas Moreau`_ (:gh:`83`).
 
 - Fix Lapack issue with R code, by `Tanguy Lefort`_ (:gh:`97`).


### PR DESCRIPTION
closes #249 

I have used `Benchopt` when it's at the start of a sentence, and `benchopt` otherwise