### PR TITLE
Use timeit instead of time

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,4 +1,4 @@
-import time
+import timeit
 from datetime import datetime
 
 from .utils import product_param
@@ -66,9 +66,8 @@ def run_one_resolution(objective, solver, meta, stop_val):
     if DEBUG:
         print(f"DEBUG - Calling solver {solver} with stop val: {stop_val}")
 
-    t_start = time.perf_counter()
-    solver.run(stop_val)
-    delta_t = time.perf_counter() - t_start
+    delta_t = timeit.timeit('solver.run(stop_val)', number=1)
+
     beta_hat_i = solver.get_result()
     objective_dict = objective(beta_hat_i)
 


### PR DESCRIPTION
Benchopt currently uses the time module, but I believe a better option is to use timeit instead. See https://stackoverflow.com/questions/17579357/time-time-vs-timeit-timeit and https://docs.python.org/2/library/timeit.html#timeit.default_timer for context, but basically what `timeit.timeit()` does is to disable garbage collection when timing, which makes for more consistent benchmarking since garbage collection will be scheduled intermittently throughout benchmarking and affect timings inconsistently between runs.

This is not completely uncontroversial, because I think methods that are leaner, i.e. waste less resources, will trigger garbage collection less often, but this seems like a minor issue to me since most of the time garbage collection will just happen for completely unrelated reasons.

This of course won't affect garbage collection on the R side (and I'm unsure about how cython works in this regard).