### PR TITLE
FIX deprecation warnings in test_cli

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -24,7 +24,7 @@ helpers = click.Group(
     options_metavar=''
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 def clean(benchmark, token=None, filename=None):
 
     benchmark = Benchmark(benchmark)
@@ -53,7 +53,7 @@ def sys_info():
 )
 @click.option('--benchmark', '-b', metavar='<benchmark>',
               type=click.Path(exists=True), default=None,
-              autocompletion=get_benchmark)
+              shell_complete=get_benchmark)
 @click.pass_context
 def config(ctx, benchmark, token=None, filename=None):
     ctx.ensure_object(dict)

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -36,7 +36,7 @@ main = click.Group(
               help="Include <solver_name> in the benchmark. By default, all "
               "solvers are included. When `-s` is used, only listed solvers"
               " are included. To include multiple solvers, "
-              "use multiple `-s` options.", autocompletion=get_solvers)
+              "use multiple `-s` options.", shell_complete=get_solvers)
 @click.option('--force-solver', '-f', 'forced_solvers',
               metavar="<solver_name>", multiple=True, type=str,
               help="Force the re-run for <solver_name>. This "

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -26,7 +26,7 @@ main = click.Group(
     "conda environment, see the command `benchopt install`."
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 @click.option('--objective-filter', '-p', 'objective_filters',
               metavar='<objective_filter>', multiple=True, type=str,
               help="Filter the objective based on its parametrized name. This "
@@ -42,14 +42,14 @@ main = click.Group(
               help="Force the re-run for <solver_name>. This "
               "avoids caching effect when adding a solver. "
               "To select multiple solvers, use multiple `-f` options.",
-              autocompletion=get_solvers)
+              shell_complete=get_solvers)
 @click.option('--dataset', '-d', 'dataset_names',
               metavar="<dataset_name>", multiple=True, type=str,
               help="Run the benchmark on <dataset_name>. By default, all "
               "datasets are included. When `-d` is used, only listed datasets"
               " are included. Note that <dataset_name> can be a regexp. "
               "To include multiple datasets, use multiple `-d` options.",
-              autocompletion=get_datasets)
+              shell_complete=get_datasets)
 @click.option('--max-runs', '-n',
               metavar="<int>", default=100, show_default=True, type=int,
               help='Maximal number of runs for each solver. This corresponds '
@@ -86,7 +86,7 @@ main = click.Group(
               "benchopt_<BENCHMARK>.")
 @click.option('--env-name', 'env_name',
               metavar="<env_name>", type=str, default='False',
-              autocompletion=get_conda_envs,
+              shell_complete=get_conda_envs,
               help="Run the benchmark in the conda environment "
               "named <env_name>. To install the required solvers and "
               "datasets, see the command `benchopt install`.")
@@ -180,7 +180,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
     help="Install the requirements (solvers/datasets) for a benchmark."
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 @click.option('--force', '-f',
               is_flag=True,
               help="If this flag is set, the reinstallation of "
@@ -191,14 +191,14 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
               "By default, all solvers are included. "
               "When `-s` is used, only listed estimators are included. "
               "To include multiple solvers, use multiple `-s` options.",
-              autocompletion=get_solvers)
+              shell_complete=get_solvers)
 @click.option('--dataset', '-d', 'dataset_names',
               metavar="<dataset_name>", multiple=True, type=str,
               help="Install the dataset <dataset_name>. By default, all "
               "datasets are included. When `-d` is used, only listed datasets "
               "are included. Note that <dataset_name> can be a regexp. "
               "To include multiple datasets, use multiple `-d` options.",
-              autocompletion=get_datasets)
+              shell_complete=get_datasets)
 @click.option('--env', '-e', 'env_name',
               flag_value='True', type=str, default='False',
               help="Install all requirements in a dedicated "
@@ -207,7 +207,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
               "solver dependencies and datasets are installed in it.")
 @click.option('--env-name', 'env_name',
               metavar="<env_name>", type=str, default='False',
-              autocompletion=get_conda_envs,
+              shell_complete=get_conda_envs,
               help="Install the benchmark requirements in the "
               "conda environment named <env_name>. If it does not exist, "
               "it will be created by this command.")
@@ -286,9 +286,9 @@ def install(benchmark, solver_names, dataset_names, force=False,
     context_settings=dict(ignore_unknown_options=True)
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 @click.option('--env-name', type=str, default=None, metavar='NAME',
-              autocompletion=get_conda_envs,
+              shell_complete=get_conda_envs,
               help='Environment to run the test in. If it is not provided '
               'a temporary one is created for the test.')
 @click.argument('pytest_args', nargs=-1, type=click.UNPROCESSED)

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -21,9 +21,9 @@ def get_plot_kinds(ctx, args, incomplete):
     help="Plot the result from a previously run benchmark."
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 @click.option('--filename', '-f', type=str, default=None,
-              autocompletion=get_output_files,
+              shell_complete=get_output_files,
               help="Specify the file to select in the benchmark. If it is "
               "not specified, take the latest one in the benchmark output "
               "folder.")
@@ -32,7 +32,7 @@ def get_plot_kinds(ctx, args, incomplete):
               help="Specify the type of figure to plot:\n\n* " +
               "\n\n* ".join([f"``{name}``: {func.__doc__.splitlines()[0]}"
                              for name, func in PLOT_KINDS.items()]),
-              autocompletion=get_plot_kinds)
+              shell_complete=get_plot_kinds)
 @click.option('--display/--no-display', default=True,
               help="Whether or not to display the plot on the screen.")
 @click.option('--html/--no-html', default=True,
@@ -70,11 +70,11 @@ def plot(benchmark, filename=None, kinds=('suboptimality_curve',),
     "this command."
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=get_benchmark)
+                shell_complete=get_benchmark)
 @click.option('--token', '-t', type=str, default=None,
               help="Github token to access the result repo.")
 @click.option('--filename', '-f', type=str, default=None,
-              autocompletion=get_output_files,
+              shell_complete=get_output_files,
               help="Specify the file to publish in the benchmark. If it is "
               "not specified, take the latest one in the benchmark output "
               "folder.")
@@ -105,7 +105,7 @@ def publish(benchmark, token=None, filename=None):
 )
 @click.option('--benchmark', '-b', 'benchmarks', metavar="<bench>",
               multiple=True, type=click.Path(exists=True),
-              autocompletion=get_benchmark,
+              shell_complete=get_benchmark,
               help="Folders containing benchmarks to include.")
 @click.option('--pattern', '-k', 'patterns',
               metavar="<pattern>", multiple=True, type=str,

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -67,7 +67,7 @@ def create_conda_env(
             f"Conda env {env_name} already exists. Checking setup ... ",
             end='', flush=True
         )
-        env_version, _ = get_benchopt_version_in_env(env_name)
+        env_version, editable_install = get_benchopt_version_in_env(env_name)
         if env_version is None:
             print()
             raise RuntimeError(
@@ -76,7 +76,7 @@ def create_conda_env(
                 "by either using the --recreate option or installing benchopt "
                 f"in conda env {env_name}."
             )
-        if benchopt.__version__ != env_version:
+        if benchopt.__version__ != env_version and not editable_install:
             print()
             warnings.warn(
                 f"The local version of benchopt ({benchopt.__version__}) and "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=42,<58.5",
+  "setuptools>=42",
   "wheel",
   "setuptools_scm>=6.2"
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     scipy
     pandas
     matplotlib
-    click
+    click>=0.8
     joblib
     pygithub
     mako


### PR DESCRIPTION
Deprecations reported in #182 :

- [x] `autocompletion` -> `shell_complete`
- [ ] `Creating a LegacyVersion has been deprecated and will be removed in the next major release`
- [x] User warning on editable config.