### PR TITLE
API deprecate -p shortcut in favor of -o for Objective

### DIFF
--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -99,10 +99,9 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
         plot=True, html=True, pdb=False, do_profile=False,
         env_name='False', old_objective_filters=None):
     if len(old_objective_filters):
-        print("should warn but nothing is printed")
         warnings.warn(
             'Using the -p option is deprecated, use -o instead',
-            DeprecationWarning
+            FutureWarning,
         )
         objective_filters = old_objective_filters
 

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -1,4 +1,5 @@
 import click
+import warnings
 from pathlib import Path
 
 from benchopt.benchmark import Benchmark
@@ -27,10 +28,13 @@ main = click.Group(
 )
 @click.argument('benchmark', type=click.Path(exists=True),
                 shell_complete=complete_benchmarks)
-@click.option('--objective-filter', '-p', 'objective_filters',
+@click.option('--objective-filter', '-o', 'objective_filters',
               metavar='<objective_filter>', multiple=True, type=str,
               help="Filter the objective based on its parametrized name. This "
               "can be used to only include one set of parameters.")
+@click.option('--old_objective-filter', '-p', 'old_objective_filters',
+              multiple=True, type=str,
+              help="Deprecated alias for --objective_filters/-o.")
 @click.option('--solver', '-s', 'solver_names',
               metavar="<solver_name>", multiple=True, type=str,
               help="Include <solver_name> in the benchmark. By default, all "
@@ -93,7 +97,14 @@ main = click.Group(
 def run(benchmark, solver_names, forced_solvers, dataset_names,
         objective_filters, max_runs, n_repetitions, timeout,
         plot=True, html=True, pdb=False, do_profile=False,
-        env_name='False'):
+        env_name='False', old_objective_filters=None):
+    if old_objective_filters is not None:
+        print("should warn but nothing is printed")
+        warnings.warn(
+            'Using the -p option is deprecated, use -o instead',
+            DeprecationWarning
+        )
+        objective_filters = old_objective_filters
 
     from benchopt.runner import run_benchmark
 

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -98,7 +98,7 @@ def run(benchmark, solver_names, forced_solvers, dataset_names,
         objective_filters, max_runs, n_repetitions, timeout,
         plot=True, html=True, pdb=False, do_profile=False,
         env_name='False', old_objective_filters=None):
-    if old_objective_filters is not None:
+    if len(old_objective_filters):
         print("should warn but nothing is printed")
         warnings.warn(
             'Using the -p option is deprecated, use -o instead',

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -104,7 +104,7 @@ class TestRunCmd:
     def test_benchopt_run(self):
         with CaptureRunOutput() as out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
-                 '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-p',
+                 '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-o',
                  SELECT_ONE_OBJECTIVE], 'benchopt', standalone_mode=False)
 
         out.check_output('Simulated', repetition=1)
@@ -120,7 +120,7 @@ class TestRunCmd:
             with pytest.raises(SystemExit, match='False'):
                 run([str(DUMMY_BENCHMARK_PATH), '--env-name', test_env_name,
                      '-d', SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD,
-                     '-n', '1', '-r', '1', '-p', SELECT_ONE_OBJECTIVE,
+                     '-n', '1', '-r', '1', '-o', SELECT_ONE_OBJECTIVE,
                      '--no-plot'], 'benchopt', standalone_mode=False)
 
         out.check_output(f'conda activate {test_env_name}')
@@ -136,7 +136,7 @@ class TestRunCmd:
         with CaptureRunOutput() as out:
             run_cmd = [str(DUMMY_BENCHMARK_PATH),
                        '-d', SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD,
-                       '-n', '1', '-r', '1', '-p', SELECT_ONE_OBJECTIVE,
+                       '-n', '1', '-r', '1', '-o', SELECT_ONE_OBJECTIVE,
                        '--profile', '--no-plot']
             run(run_cmd, 'benchopt', standalone_mode=False)
 
@@ -144,8 +144,8 @@ class TestRunCmd:
         out.check_output("File: .*benchopt/tests/test_benchmarks/"
                          "dummy_benchmark/solvers/python_pgd.py", repetition=1)
         out.check_output(r'\s+'.join([
-                "Line #", "Hits", "Time", "Per Hit", "% Time", "Line Contents"
-            ]), repetition=1)
+            "Line #", "Hits", "Time", "Per Hit", "% Time", "Line Contents"
+        ]), repetition=1)
         out.check_output(r"def run\(self, n_iter\):", repetition=1)
 
     def test_benchopt_caching(self):
@@ -154,7 +154,7 @@ class TestRunCmd:
         n_rep = 2
         run_cmd = [str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
                    '-s', SELECT_ONE_PGD, '-n', '1', '-r', str(n_rep),
-                   '-p', SELECT_ONE_OBJECTIVE, '--no-plot']
+                   '-o', SELECT_ONE_OBJECTIVE, '--no-plot']
 
         # Make a first run that should be put in cache
         with CaptureRunOutput() as out:
@@ -265,7 +265,7 @@ class TestPlotCmd:
         "Make sure at least one result file is available"
         with SuppressStd() as out:
             run([str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
-                 '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-p',
+                 '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-o',
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -22,17 +22,22 @@ Changelog
   the previous one, by `Thomas Moreau`_ (:gh:`176`)
 
 - Now all values returned by ``Objective.compute`` are included in reports,
-  by `Thomas Moreau`_ and `Alexandre Gramfort`_ (gh:`200`).
+  by `Thomas Moreau`_ and `Alexandre Gramfort`_ (:gh:`200`).
 
 API
 ~~~
 
 - When returning a dict, ``Objective.compute`` should at least include
   ``value`` key instead of ``objective_value``, by `Thomas Moreau`_ and
-  `Alexandre Gramfort`_ (gh:`200`).
+  `Alexandre Gramfort`_ (:gh:`200`).
 
 - 'stop_strategy' attribute is replaced by 'stopping_strategy' to harmonize
-  with 'stopping_criterion', by `Benoît Malézieux`_ (gh:`274`).
+  with 'stopping_criterion', by `Benoît Malézieux`_ (:gh:`274`).
+
+CLI
+~~~
+
+- Replace ``-p`` flag by ``-o`` for Objective, by `Mathurin Massias`_ (:gh:`281`).
 
 .. _changes_1_1:
 
@@ -66,7 +71,7 @@ API
 ~~~
 
 - ``Objective.compute`` can now return a dictionary with multiple outputs to
-  monitor several metrics at once, by `Thomas Moreau`_ (gh:`84`).
+  monitor several metrics at once, by `Thomas Moreau`_ (:gh:`84`).
 
 - ``Solver.skip`` can now be used to skip objectives that are incompatible
   for the Solver, by `Thomas Moreau`_ (:gh:`113`).


### PR DESCRIPTION
fixes #225 
I have an issue, the warnings are captured even with BENCHOPT_DEBUG=1, I think they should not because the user won't be notified of the deprecation.

It remains to adapt the test if you agree with this @tomMoral @agramfort 