### PR TITLE
ENH add safe_import_context.import_from to import from benchmark/utils

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -282,7 +282,7 @@ class BaseObjective(ParametrizedNameMixin):
 
     @abstractmethod
     def set_data(self, **data):
-        """Store the info on the data to be able to compute the objective.
+        """Store the info on a dataset to be able to compute the objective.
 
         Parameters
         ----------

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -282,14 +282,46 @@ class BaseObjective(ParametrizedNameMixin):
 
     @abstractmethod
     def set_data(self, **data):
+        """Store the info on the data to be able to compute the objective.
+
+        Parameters
+        ----------
+        **data: dict
+            Extra parameters of the objective. This dictionary is retrieved
+            by calling ``data = Dataset.get_data()``.
+        """
         ...
 
     @abstractmethod
     def to_dict(self):
+        """Return the objective parameters for the solver.
+
+        Returns
+        -------
+        objective_dict: dict
+            Parameters of the objective that will be given to the solver when
+            calling ``Solver.set_objective(**objective_dict)``.
+        """
         ...
 
     @abstractmethod
     def compute(self, beta):
+        """Compute the value of the objective given the current estimate beta.
+
+        Parameters
+        ----------
+        beta : ndarray or tuple of ndarray
+            The current estimate of the parameters being optimized.
+
+        Returns
+        -------
+        objective_value : float or dict {'name': float}
+            The value(s) of the objective function. If a dictionary is
+            returned, it should at least contain a key `value` associated to a
+            scalar value which will be used to detect convergence. With a
+            dictionary, multiple metric values can be stored at once instead
+            of runnning each separately.
+        """
         ...
 
     def __call__(self, beta):

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .config import get_setting
 from .base import BaseSolver, BaseDataset
 from .utils.colorify import colorify, YELLOW
+from .utils.safe_import import set_benchmark
 from .utils.dynamic_modules import _load_class_from_module
 from .utils.parametrized_name_mixin import product_param
 from .utils.parametrized_name_mixin import _list_all_parametrized_names
@@ -21,6 +22,8 @@ class Benchmark:
     def __init__(self, benchmark_dir):
         self.benchmark_dir = Path(benchmark_dir)
         self.name = self.benchmark_dir.resolve().name
+
+        set_benchmark(self.benchmark_dir)
 
         try:
             self.get_benchmark_objective()
@@ -60,7 +63,9 @@ class Benchmark:
                 "Did not find an `objective` module in benchmark."
             )
 
-        return _load_class_from_module(module_filename, "Objective")
+        return _load_class_from_module(
+            module_filename, "Objective", benchmark_dir=self.benchmark_dir
+        )
 
     def _list_benchmark_classes(self, base_class):
         """Load all classes with the same name from a benchmark's subpackage.
@@ -84,7 +89,9 @@ class Benchmark:
         submodule_files = package.glob('*.py')
         for module_filename in submodule_files:
             # Get the class
-            cls = _load_class_from_module(module_filename, class_name)
+            cls = _load_class_from_module(
+                module_filename, class_name, benchmark_dir=self.benchmark_dir
+            )
             if issubclass(cls, base_class):
                 classes.append(cls)
             else:

--- a/benchopt/utils/dynamic_modules.py
+++ b/benchopt/utils/dynamic_modules.py
@@ -6,12 +6,19 @@ import importlib
 from pathlib import Path
 
 
-def _get_module_from_file(module_filename):
+def _get_module_from_file(module_filename, benchmark_dir=None):
     """Load a module from the name of the file"""
     module_filename = Path(module_filename)
-    package_name = '.'.join(
-        ['benchopt_benchmarks', *module_filename.with_suffix('').parts[-3:]]
-    )
+    if benchmark_dir is not None:
+        module_filename = module_filename.resolve()
+        benchmark_dir = Path(benchmark_dir).resolve().parent
+        package_name = module_filename.relative_to(benchmark_dir)
+        package_name = package_name.with_suffix('').parts
+    else:
+        package_name = module_filename.with_suffix('').parts[-3:]
+    if package_name[-1] == '__init__':
+        package_name = package_name[:-1]
+    package_name = '.'.join(['benchopt_benchmarks', *package_name])
 
     module = sys.modules.get(package_name, None)
     if module is None:
@@ -19,12 +26,12 @@ def _get_module_from_file(module_filename):
             package_name, module_filename
         )
         module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
         sys.modules[package_name] = module
+        spec.loader.exec_module(module)
     return module
 
 
-def _load_class_from_module(module_filename, class_name):
+def _load_class_from_module(module_filename, class_name, benchmark_dir=None):
     """Load a class from a module_filename.
 
     This helper also stores info necessary for DependenciesMixing to check the
@@ -36,6 +43,9 @@ def _load_class_from_module(module_filename, class_name):
         Path to the file defining the module to load the class from.
     class_name : str
         Name of the class to load
+    benchmark_dir : str or Path or None
+        Path to the benchmark_dir. If provided, will be used to set the package
+        name relative to it.
 
     Returns
     -------
@@ -43,7 +53,7 @@ def _load_class_from_module(module_filename, class_name):
         The klass requested from the given module.
     """
     module_filename = Path(module_filename)
-    module = _get_module_from_file(module_filename)
+    module = _get_module_from_file(module_filename, benchmark_dir)
     klass = getattr(module, class_name)
 
     # Store the info to easily reload the class

--- a/benchopt/utils/dynamic_modules.py
+++ b/benchopt/utils/dynamic_modules.py
@@ -10,6 +10,7 @@ def _get_module_from_file(module_filename, benchmark_dir=None):
     """Load a module from the name of the file"""
     module_filename = Path(module_filename)
     if benchmark_dir is not None:
+        # Use a package starting from the benchmark root folder.
         module_filename = module_filename.resolve()
         benchmark_dir = Path(benchmark_dir).resolve().parent
         package_name = module_filename.relative_to(benchmark_dir)

--- a/benchopt/utils/safe_import.py
+++ b/benchopt/utils/safe_import.py
@@ -24,7 +24,23 @@ def set_benchmark(benchmark_dir):
 
 
 class safe_import_context:
-    """Do not fail on ImportError and catch import warnings"""
+    """Context used to manage import in benchmarks.
+
+    This context allows to avoid errors on ImportError, to be able to report
+    that a solver/dataset is not installed.
+
+    Moreover, this context also allows to skip the import when simply listing
+    all solvers, for benchmark's installation or auto completion. Note that all
+    costly imports should be protected with this import for benchopt to perform
+    best.
+
+    This context is also used to import module dynamically from the ``utils``
+    folder of a benchmark, using the
+    :func:`~benchopt.safe_import_context.import_from` method.
+    See :ref:`benchmark_utils_import` for a detailed explanation of this part.
+
+    Finally, this context also catches import warnings.
+    """
 
     def __init__(self):
         self.failed_import = False
@@ -48,6 +64,25 @@ class safe_import_context:
         raise SkipWithBlock()
 
     def import_from(self, module_name, obj=None):
+        """Dynamically import a module from BENCHMARK_DIR/utils.
+
+        Parameters
+        ----------
+        module_name: str
+            Name of the module to import. It can be a module with a simple
+            ``*.py`` file, or a more complex package with a ``__init__.py``
+            file. The naming convention for import is the same, with submodules
+            separated with ``.``. The module is imported directly from the
+            BENCHMARK_DIR/utils/ folder.
+        obj: str or None
+            If ``obj`` is provided, the module is imported and only the
+            attribute named ``obj`` from this module is returned.
+
+        Returns
+        -------
+        module or obj: object
+            Module or object imported dynamically.
+        """
         module_path = BENCHMARK_DIR / 'utils' / module_name.replace('.', '/')
         if not module_path.exists():
             module_path = module_path.with_suffix('.py')

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -93,9 +93,14 @@ First, all code that need to be imported should be placed under
             ├── __init__.py  # some solver
             └── submodule1.py  # some solver
 
-Then, these modules and packages can be imported using the method :func:`benchopt.safe_import_context.import_from`. This method
+Then, these modules and packages can be imported using the method
+:func:`benchopt.safe_import_context.import_from`. This method
 takes as input the name of the module as a string and optionally
-the name of the object to load. It can be used as
+the name of the object to load. The imported package can
+either be a simple ``*.py`` file or a more complex package
+with a ``__init__.py`` file. The naming convention for import
+is the same as for regular import, with submodules
+separated with ``.``.
 
 .. code-block::
 

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -1,0 +1,107 @@
+.. _how:
+
+Advanced functionnalities in a benchmark
+=========================================
+
+This page intends to list some advanced functionnality
+to make it easier to use the benchmark.
+
+.. _skiping_solver:
+
+Skipping a solver for a given problem
+-------------------------------------
+
+Some solvers might not be able to run with all the datasets present
+in a benchmark. This is typically the case when some datasets are
+represented using sparse data or for datasets that are too large.
+
+In this cases, a solver can be skipped at runtime, depending on the
+characteristic of the objective. In order to define for which cases
+a solver should be skip, the user needs to implement a method
+:func:`~benchopt.BaseSolver.skip` in the solver class that will take
+the input as the :func:`~benchopt.BaseSolver.set_objective` method.
+This method should return a boolean value that evaluate to ``True``
+if the solver should be skipped, and a string giving the reason of
+why the solver is skipped, for display purposes. For instance,
+for a solver where the objective is set with keys `X, y, reg`,
+we get
+
+.. code-block::
+
+    class Solver(BaseSolver):
+        ...
+        def skip(self, X, y, reg):
+            from scipy import sparse
+
+            if sparse.issparse(X):
+                return True, "solver does not support sparse data X."
+
+            if reg == 0:
+                return True, "solver does not work with reg=0"
+
+            return False, None
+
+
+
+.. _sampling_strategy:
+
+Changing the strategy to grow the :code:`stop_val`
+--------------------------------------------------
+
+By default, the number of iterations or the variation of the tolerance
+between  two evaluations of the objective is exponential. However, in
+some cases, this exponential growth might hide some effects, or might
+not be adapted to a given solver.
+
+The way this value is changed can be specified for each solver by
+implementing the ``get_next`` method in the ``Solver`` class.
+This method takes as input the previous value where the objective
+function have been logged, and output the next one. For instance,
+if a solver needs to be evaluated every 10 iterations, we would have
+
+.. code-block::
+
+    class Solver(BaseSolver):
+        ...
+        def get_next(self, stop_val):
+            return stop_val + 10
+
+
+
+.. _benchmark_utils_import:
+
+Reusing some code in a benchmark
+--------------------------------
+
+In some situations, multiple solvers need to have access to the same
+functions. As a benchmark is not structured as proper python packages
+but imported dynamically to avoid installation issues, we resort to
+a special way of importing modules and functions defined for a benchmark.
+
+First, all code that need to be imported should be placed under
+``BENCHMARK_DIR/utils/``, as described here:
+
+.. code-block::
+
+    my_benchmark/
+    ├── objective.py  # contains the definition of the objective
+    ├── datasets/
+    ├── solvers/
+    └── utils/
+        ├── helper1.py  # some helper
+        └─── helper_module  # some solver
+            ├── __init__.py  # some solver
+            └── submodule1.py  # some solver
+
+Then, these modules and packages can be imported using the method :func:`benchopt.safe_import_context.import_from`. This method
+takes as input the name of the module as a string and optionally
+the name of the object to load. It can be used as
+
+.. code-block::
+
+    from benchopt import safe_import_context
+
+    with safe_import_context() as import_ctx:
+        helper1 = import_ctx.import_from('helper1')
+        func1 = import_ctx.import_from('helper1', 'func1')
+        func2 = import_ctx.import_from('helper_module.submodule1', 'func2')

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -210,6 +210,7 @@ Contents
    how
    publish
    config
+   advanced
    whats_new
    Fork benchopt on Github <https://github.com/benchopt/benchopt>
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -37,6 +37,10 @@ API
 - 'stop_strategy' attribute is replaced by 'stopping_strategy' to harmonize
   with 'stopping_criterion', by `Benoît Malézieux`_ (:gh:`274`).
 
+- Add `import_from` method in `safe_import_context` to allow importing common
+  files and packages without install from `BENCHMARK_DIR/utils`,
+  by `Thomas Moreau`_ (:gh:`286`).
+
 .. _changes_1_1:
 
 Version 1.1 - 22-04-2021


### PR DESCRIPTION
This PR adds a method in the `import_ctx` to be able to dynamically load modules from the `utils` subfolder of the benchmark.
The idea is to be able to call the method `import_from` of `import_ctx`, which handles the import in a dynamic way.

```python
from benchopt import safe_import_context

with safe_import_context() as import_ctx:
    alpha_max = import_ctx.import_from('alpha_max')  # Import a module
    get_alpha_max = import_ctx.import_from(  # Import  a func from a module
        'alpha_max', 'get_alpha_max'
    )
```

Here, the file `alpha_max.py` with a function `get_alpha_max` should be available in the `BENCHMARK_DIR/utils` folder.

Fixes #279 

