### PR TITLE
Raise FutureWarning instead of DeprecationWarning if stop_strategy is used

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -57,7 +57,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
             warnings.warn(
                 "'stop_strategy' attribute is deprecated, "
                 "use 'stopping_strategy' instead",
-                DeprecationWarning
+                FutureWarning
             )
             return self.stop_strategy
         elif hasattr(self, 'stopping_strategy'):


### PR DESCRIPTION
Raise Future and not Deprecation warning in the `base.py` file (cf @mathurinm  #281)