### PR TITLE
Load results script if not found

### DIFF
--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -135,7 +135,11 @@
 
     <a class="backtotop" title="Back to top" href="#top"><i class="fas fa-level-up-alt"></i></a>
 
-    <script type="text/javascript" src="${static_dir}/result.js"></script>
+    <script type="text/javascript" src="${static_dir}/result.js" onerror="
+    let resultjs = document.createElement('script');
+    resultjs.setAttribute('src', 'https://benchopt.github.io/results/static/result.js');
+    document.body.appendChild(resultjs);
+    "></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fixes #291 by loading the JS file from `results` website if directory not found.

**NB:** We can't directly load the JS file from the `plotting` directory of the benchopt repo as Github prevented this use in 2013 