### PR TITLE
added link to template in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ such as for
 `l1-regularized logistic regression <https://github.com/benchopt/benchmark_logreg_l1>`_.
 
 
-Learn how to `write a benchmark on our documentation <https://benchopt.github.io/how.html>`_.
+Learn how to `write a benchmark on our documentation <https://benchopt.github.io/how.html>`_ and use `our template <https://github.com/benchopt/template_benchmark>`_ to kickstart it.
 
 Install
 --------


### PR DESCRIPTION
I would find it convenient to have a link to the template directly in the readme.
I didn't open an issue given this is a very short PR, but feel free to ask me one.