### PR TITLE
update legacy docker image in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: cimg/python:3.8.1
+      - image: cimg/python:3.8.1-browsers
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.8.1
+      - image: cimg/python:3.8.1-browsers
     steps:
       - attach_workspace:
           at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
             echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
             if [[ $(cat merge.txt) != "" ]]; then
               echo "Merging $(cat merge.txt)";
-              git remote add upstream git://github.com/benchopt/benchopt.git;
+              git remote add upstream https://github.com/benchopt/benchopt.git;
               git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
               git fetch upstream main;
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: cimg/python:3.8.1-buster
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: cimg/python:3.8.1-buster
     steps:
       - attach_workspace:
           at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: cimg/python:3.8.1-browsers
+      - image: cimg/python:3.8.11-browsers
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.8.1-browsers
+      - image: cimg/python:3.8.11-browsers
     steps:
       - attach_workspace:
           at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: cimg/python:3.8.1-buster
+      - image: cimg/python:3.8.1
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.8.1-buster
+      - image: cimg/python:3.8.1
     steps:
       - attach_workspace:
           at: /tmp/build


### PR DESCRIPTION
We got a warning on circle
![image](https://user-images.githubusercontent.com/8993218/159293546-b20ac3a9-aba6-4d7a-818c-c9507b9820db.png)


Fix from:
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034