### PR TITLE
FIX private attr to store dataset in objective

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -350,7 +350,7 @@ class BaseObjective(ParametrizedNameMixin):
     # Save the dataset object used to get the objective data so we can avoid
     # hashing the data directly.
     def set_dataset(self, dataset):
-        self.dataset = dataset
+        self._dataset = dataset
         _, data = dataset._get_data()
         return self.set_data(**data)
 
@@ -368,4 +368,4 @@ class BaseObjective(ParametrizedNameMixin):
     def __reduce__(self):
         module_hash = get_file_hash(self._module_filename)
         return self._reconstruct, (self._module_filename, module_hash,
-                                   self._parameters, self.dataset)
+                                   self._parameters, self._dataset)


### PR DESCRIPTION
We encountered an issue with hashing/pickling a user defined `Objective` where an attribute `dataset` was created in `set_data`.
This was due to the fact that it overrided the original dataset object.
To avoid this, moving to a private attribute, as it is done for other classes such as `Solver._objective`.