### PR TITLE
TST make test more permissive for complex benchmarks

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -351,8 +351,29 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin):
     # hashing the data directly.
     def set_dataset(self, dataset):
         self._dataset = dataset
-        _, data = dataset._get_data()
+        self._dimension, data = dataset._get_data()
         return self.set_data(**data)
+
+    def get_one_beta(self):
+        """Return one point in which the objective function can be evaluated.
+
+        This method is mainly for testing purposes, to check that the return
+        computation and the return type of `Objective.compute`. It should
+        return an object that can be passed to compute.
+
+        By default, if `Dataset.get_data` returns a shape, this function will
+        return an array full of 0. It can be overriden to provide a different
+        point. When `Dataset.get_data` returns "object", this method must be
+        overwritten.
+        """
+        if self._dimension == 'object':
+            raise NotImplementedError(
+                "If solvers return objects, `Objective.get_one_beta` should "
+                "be overriden to return an object compatible with `compute`."
+            )
+
+        import numpy as np
+        return np.zeros(self._dimension)
 
     # Reduce the pickling and hashing burden by only pickling class parameters.
     @staticmethod

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -17,21 +17,22 @@ def test_benchmark_objective(benchmark, dataset_simu):
     dimension, data = dataset._get_data()
     objective.set_data(**data)
 
-    # check that the reported dimension is correct and that the result of
-    # the objective function is a dictionary containing a scalar value for
-    # `objective_value`.
-    beta_hat = np.zeros(dimension)
-    objective_dict = objective(beta_hat)
+    if dimension is not None:
+        # check that the reported dimension is correct and that the result of
+        # the objective function is a dictionary containing a scalar value for
+        # `objective_value`.
+        beta_hat = np.zeros(dimension)
+        objective_dict = objective(beta_hat)
 
-    assert 'objective_value' in objective_dict, (
-        'When the output of objective is a dict, it should at least contain '
-        'a value associated to `objective_value` which will be used to detect '
-        'the convergence of the algorithm.'
-    )
-    assert np.isscalar(objective_dict['objective_value']), (
-        "The output of the objective function should be a scalar, or a dict "
-        "containing a scalar associated to `objective_value`."
-    )
+        assert 'objective_value' in objective_dict, (
+            "When the output of objective is a dict, it should at least "
+            "contain a value associated to `objective_value` which will be "
+            "used to detect the convergence of the algorithm."
+        )
+        assert np.isscalar(objective_dict['objective_value']), (
+            "The output of the objective function should be a scalar, or a "
+            "dict containing a scalar associated to `objective_value`."
+        )
 
 
 def test_dataset_class(benchmark, dataset_class):
@@ -76,14 +77,15 @@ def test_dataset_get_data(benchmark, dataset_class):
 
     dimension, data = res
 
-    assert isinstance(dimension, tuple), (
+    assert isinstance(dimension, (tuple, type(None))), (
         "First output of get_data should be an integer or a tuple of integers."
         f" Got {dimension}."
     )
-    assert all(isinstance(d, numbers.Integral) for d in dimension), (
-        "First output of get_data should be an integer or a tuple of integers."
-        f" Got {dimension}."
-    )
+    if dimension is not None:
+        assert all(isinstance(d, numbers.Integral) for d in dimension), (
+            "First output of get_data should be an integer or a tuple of "
+            f"integers. Got {dimension}."
+        )
     assert isinstance(data, dict), (
         f"Second output of get_data should be a dict. Got {data}."
     )
@@ -184,12 +186,13 @@ def test_solver(benchmark, solver_class):
 
     beta_hat_i = solver.get_result()
 
-    assert beta_hat_i.shape == dimension
+    if dimension is not None:
+        assert beta_hat_i.shape == dimension
 
-    if getattr(objective, "is_convex", True):
-        val_star = objective(beta_hat_i)['objective_value']
-        for _ in range(100):
-            eps = 1e-5 * np.random.randn(*dimension)
-            val_eps = objective(beta_hat_i + eps)['objective_value']
-            diff = val_eps - val_star
-            assert diff >= 0
+        if getattr(objective, "is_convex", True):
+            val_star = objective(beta_hat_i)['objective_value']
+            for _ in range(100):
+                eps = 1e-5 * np.random.randn(*dimension)
+                val_eps = objective(beta_hat_i + eps)['objective_value']
+                diff = val_eps - val_star
+                assert diff >= 0

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -14,8 +14,7 @@ def test_benchmark_objective(benchmark, dataset_simu):
     objective = objective_class.get_instance()
 
     dataset = dataset_simu.get_instance()
-    dimension, data = dataset._get_data()
-    objective.set_data(**data)
+    objective.set_dataset(dataset)
 
     # check that the reported dimension is correct and that the result of
     # the objective function is a dictionary containing a scalar value for


### PR DESCRIPTION
For some benchmark, the return of the solver is not a simple `np.array` but a complex object.
For those, the test are too restrictive. I propose to skip part of the test when the dataset return `dimension = 'object'`.

Also, some algorithms do not converge quickly. thus `test_solver` can be very long/slow.
I will try to mitigate this in the PR.

- [x] skip dimension tests
- [x] mitigate slow `test_solver`