### PR TITLE
click 8.1 update autocomplete

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -180,7 +180,7 @@ def print_info(cls_name_list, cls_list, env_name=None, verbose=False):
     "for a given benchmark."
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=complete_benchmarks)
+                shell_complete=complete_benchmarks)
 @click.option('--solver', '-s', 'solver_names',
               metavar="<solver_name>", multiple=True, type=str,
               help="Display information about <solver_name>. "
@@ -375,7 +375,7 @@ def get(ctx, name):
     hidden=True
 )
 @click.argument('benchmark', type=click.Path(exists=True),
-                autocompletion=complete_benchmarks)
+                shell_complete=complete_benchmarks)
 @click.argument('module_filename', nargs=1, type=Path)
 @click.argument('base_class_name', nargs=1, type=str)
 def check_install(benchmark, module_filename, base_class_name):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     scipy
     pandas
     matplotlib
-    click>=8.0
+    click>=8.1
     joblib
     pygithub
     mako

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     scipy
     pandas
     matplotlib
-    click>=8.1
+    click>=8.0
     joblib
     pygithub
     mako


### PR DESCRIPTION
`click` 8.1.0 is out today, and they dropped the `autocompletion` parameter support in favor of the `shell_complete` one.
cf [their changelog](https://click.palletsprojects.com/en/8.1.x/changes/) 