### PR TITLE
DOC rm fit_intercept in logreg L2 example

### DIFF
--- a/examples/plot_run_benchmark.py
+++ b/examples/plot_run_benchmark.py
@@ -23,7 +23,7 @@ try:
                                     'lightning'],
         dataset_names=['Simulated*n_samples=200,n_features=500*'],
         objective_filters=[
-            'L2 Logistic Regression[fit_intercept=False,lmbd=1.0]'],
+            'L2 Logistic Regression[lmbd=1.0]'],
         max_runs=100, timeout=20, n_repetitions=15,
         plot_result=False, show_progress=True
     )


### PR DESCRIPTION
https://github.com/benchopt/benchmark_logreg_l2/pull/27 removed this parameter from the benchmark, which broke the doc.

This is a fix