### PR TITLE
ENH indent CLI output

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -399,7 +399,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                 objective = objective_class.get_instance(**obj_parameters)
                 if not is_matched(str(objective), objective_filters):
                     continue
-                print_normalize(f"|--{objective}")
+                print_normalize(f" |--{objective}")
                 objective.set_dataset(dataset)
 
                 for solver_class in solver_classes:

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -431,7 +431,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                                 f"{tag} {colorify('skip', YELLOW)}"
                             )
                             if reason is not None:
-                                print(f'  Reason: {reason}')
+                                print(f'    Reason: {reason}')
                             continue
 
                         # Get meta

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -399,7 +399,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                 objective = objective_class.get_instance(**obj_parameters)
                 if not is_matched(str(objective), objective_filters):
                     continue
-                print_normalize(f" |--{objective}")
+                print_normalize(f"  |--{objective}")
                 objective.set_dataset(dataset)
 
                 for solver_class in solver_classes:
@@ -414,7 +414,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                             continue
 
                         # Get the solver's name
-                        tag = colorify(f"  |----{solver}:")
+                        tag = colorify(f"    |--{solver}:")
 
                         # check if the module caught a failed import
                         if not solver.is_installed(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -414,7 +414,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                             continue
 
                         # Get the solver's name
-                        tag = colorify(f"|----{solver}:")
+                        tag = colorify(f"  |----{solver}:")
 
                         # check if the module caught a failed import
                         if not solver.is_installed(
@@ -431,7 +431,7 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
                                 f"{tag} {colorify('skip', YELLOW)}"
                             )
                             if reason is not None:
-                                print(f'Reason: {reason}')
+                                print(f'  Reason: {reason}')
                             continue
 
                         # Get meta


### PR DESCRIPTION
It's hard to distinguish when we're moving to another dataset:
![image](https://user-images.githubusercontent.com/8993218/161070864-f59f9816-19c5-4430-8444-672e2405a491.png)

This PR indents the solver names by 2 spaces for easier visualization of the separation:
![image](https://user-images.githubusercontent.com/8993218/161073093-886aaa41-a20b-4fd9-b677-445be8eb339f.png)
