### PR TITLE
ENH change plotted quantiles to (q3, q7)

### DIFF
--- a/benchopt/plotting/plot_objective_curve.py
+++ b/benchopt/plotting/plot_objective_curve.py
@@ -80,11 +80,11 @@ def plot_objective_curve(df, obj_col='objective_value', plotly=False,
         df_ = df[df['solver_name'] == solver_name]
         curve = df_.groupby('stop_val').median()
 
-        q1 = df_.groupby('stop_val')['time'].quantile(.1)
-        q9 = df_.groupby('stop_val')['time'].quantile(.9)
+        q3 = df_.groupby('stop_val')['time'].quantile(.3)
+        q7 = df_.groupby('stop_val')['time'].quantile(.7)
 
         fill_between_x(
-            fig, curve['time'], q1, q9, curve[obj_col], color=CMAP(i % CMAP.N),
+            fig, curve['time'], q3, q7, curve[obj_col], color=CMAP(i % CMAP.N),
             marker=markers[i % len(markers)], label=solver_name, plotly=plotly
         )
 


### PR DESCRIPTION
This PR proposes to use (q3, q7) instead of (q1, q9) in the plots.

For some fast benchmarks, computational time can vary a lot between runs, and the log-plots are highly visually affected by some unfortunate outliers. Using quantiles closer to the median would alleviate this issue by providing a more robust estimate of the computational times.

In a Gaussian distribution with zero-mean and unit standard deviation, the range [-0.5, 0.5] corresponds to the percentiles [30.8, 69.2], so the range (q3, q7) does seem a reasonable choice to me.