### PR TITLE
Disable garbage collection during timing

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,4 +1,5 @@
 import time
+import gc
 
 from datetime import datetime
 
@@ -67,9 +68,11 @@ def run_one_resolution(objective, solver, meta, stop_val):
     if DEBUG:
         print(f"DEBUG - Calling solver {solver} with stop val: {stop_val}")
 
+    gc.disable()
     t_start = time.perf_counter()
     solver.run(stop_val)
     delta_t = time.perf_counter() - t_start
+    gc.enable()
     beta_hat_i = solver.get_result()
     objective_dict = objective(beta_hat_i)
 


### PR DESCRIPTION
It seems to me like it would make sense to disable garbage collection before timing the run of a solver. 

Let's say you want to benchmark ten different solvers. Then it's likely that during the run of some of these solvers, garbage collection will be initiated. So, for instance, it's possible that garbage collection will occur during the runs for solvers 4 and 10, inflating the timings for these runs.

The usual argument against disabling garbage collection is that methods that consume lots of resources should be punished for that during timing, but the problem with that argument is that there's no guarantee that the heavy resource usage caused by say, solver 9, will actually end up causing garbage collection during that exact run and instead happen during the run of solver 10.

The only downside as I see it here is that we're not handling garbage collection for other languages called through python.