### PR TITLE
FIX rename histogram as bar chart

### DIFF
--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -47,7 +47,7 @@ DEFAULT_BENCHMARK_CONFIG = {
 
     plots =
         suboptimality_curve
-        histogram
+        bar_chart
 """
 
 

--- a/benchopt/constants.py
+++ b/benchopt/constants.py
@@ -2,5 +2,5 @@ PLOT_KINDS = {
     'objective_curve': 'plot_objective_curve',
     'suboptimality_curve': 'plot_suboptimality_curve',
     'relative_suboptimality_curve': 'plot_relative_suboptimality_curve',
-    'histogram': 'plot_histogram'
+    'bar_chart': 'plot_bar_chart'
 }

--- a/benchopt/plotting/__init__.py
+++ b/benchopt/plotting/__init__.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 from ..constants import PLOT_KINDS
 from .helpers import get_plot_id
-from .plot_histogram import plot_histogram  # noqa: F401
+from .plot_bar_chart import plot_bar_chart  # noqa: F401
 from .plot_objective_curve import plot_objective_curve  # noqa: F401
 from .plot_objective_curve import plot_suboptimality_curve  # noqa: F401
 from .plot_objective_curve import plot_relative_suboptimality_curve  # noqa: F401 E501
@@ -13,7 +13,7 @@ from .generate_html import plot_benchmark_html
 
 def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
                    html=True):
-    """Plot convergence curve and histogram for a given benchmark.
+    """Plot convergence curve and bar chart for a given benchmark.
 
     Parameters
     ----------
@@ -36,7 +36,7 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
     Returns
     -------
     figs : list
-        The matplotlib figures for convergence curve and histogram
+        The matplotlib figures for convergence curve and bar chart
         for each dataset.
     """
     config_kinds = benchmark.get_setting('plots')
@@ -71,11 +71,11 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
                             f"Requesting invalid plot '{kind}'."
                             f"Should be in:\n{PLOT_KINDS}"
                         )
-                    # For now only plot histogram and suboptimality for
+                    # For now only plot bar chart and suboptimality for
                     # objective_value for which we monitor convergence
                     # XXX - find a better solution
                     if obj_col != "objective_value" and (
-                            kind == "histogram" or "subopt" in kind):
+                            kind == "bar_chart" or "subopt" in kind):
                         continue
                     plot_func = globals()[PLOT_KINDS[kind]]
                     try:

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 from mako.template import Template
 
 from ..constants import PLOT_KINDS
-from .plot_histogram import plot_histogram  # noqa: F401
+from .plot_bar_chart import plot_bar_chart  # noqa: F401
 from .plot_objective_curve import plot_objective_curve  # noqa: F401
 from .plot_objective_curve import plot_suboptimality_curve  # noqa: F401
 from .plot_objective_curve import plot_relative_suboptimality_curve  # noqa: F401 E501
@@ -61,7 +61,7 @@ def generate_plot_benchmark(df, kinds, fname, fig_dir, benchmark_name):
     Returns
     -------
     dict
-        The figures for convergence curves and histograms
+        The figures for convergence curves and bar charts
         for each dataset.
     """
     dataset_names = df['data_name'].unique()
@@ -88,7 +88,7 @@ def generate_plot_benchmark(df, kinds, fname, fig_dir, benchmark_name):
                 plot_func = globals()[PLOT_KINDS[k]]
                 try:
                     fig = plot_func(df_obj, obj_col=obj_col, plotly=True)
-                    if PLOT_KINDS[k] == "plot_histogram":
+                    if PLOT_KINDS[k] == "plot_bar_chart":
                         fig.update_layout(autosize=False,
                                           width=900,
                                           height=650)

--- a/benchopt/plotting/plot_bar_chart.py
+++ b/benchopt/plotting/plot_bar_chart.py
@@ -6,8 +6,8 @@ from .helpers_compat import get_figure, _make_bars
 PLOTLY_GRAY = (.8627, .8627, .8627)
 
 
-def plot_histogram(df, obj_col='objective_value', plotly=False):
-    """Plot histogram for a given benchmark and dataset.
+def plot_bar_chart(df, obj_col='objective_value', plotly=False):
+    """Plot bar chart for a given benchmark and dataset.
 
     Parameters
     ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -47,7 +47,7 @@ For benchmark settings, they are grouped in a section with the same name as the 
     [benchmark_bench]
     plots =
         suboptimality_curve
-        histogram
+        bar_chart
         objective_curve
 
 


### PR DESCRIPTION
What's currently referred to as histograms in the result plots are actually bar charts (or bar plots). This pull request replaces "histogram" with "bar chart" everywhere.