### PR TITLE
FIX preface root folder ignores with slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,9 @@ __pycache__
 benchopt_front_page_convergence.pdf
 
 # Package directory
-html/
-build/
-dist/
+/html/
+/build/
+/dist/
 
 # Benchmarks&results cloned for running tests/examples
 /benchmarks/


### PR DESCRIPTION
I believe that the ignore patterns in the `.gitignore` should be prefaced with slashes (so that they only refer to folders in the root directory). Otherwise they also ignore, for instance, `benchopt/plotting/html`, which I don't think is intended (particularly not since all the files in that folder are actually being tracked).