### PR TITLE
BUG In solver test switched `set_objective` to `_set_objective` to ensure skipping happens

### DIFF
--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -165,7 +165,9 @@ def test_solver(benchmark, solver_class):
     objective.set_dataset(dataset)
 
     solver = solver_class.get_instance()
-    solver._set_objective(objective)
+    skip, reason = solver._set_objective(objective)
+    if skip:
+        pytest.skip(reason)
 
     is_convex = getattr(objective, "is_convex", True)
 

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -167,7 +167,10 @@ def test_solver(benchmark, solver_class):
     solver = solver_class.get_instance()
     skip, reason = solver._set_objective(objective)
     if skip:
-        pytest.skip(reason)
+        raise ValueError(
+            'Solver should be skipped for the simulated dataset'
+            f'because of reason: {reason}'
+        )
 
     is_convex = getattr(objective, "is_convex", True)
 

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -165,7 +165,7 @@ def test_solver(benchmark, solver_class):
     objective.set_dataset(dataset)
 
     solver = solver_class.get_instance()
-    solver.set_objective(**objective.to_dict())
+    solver._set_objective(objective)
 
     is_convex = getattr(objective, "is_convex", True)
 


### PR DESCRIPTION
This has the unwanted side effect of potentially skipping some solvers depending on the simulated dataset configuration.

I will propose a follow-up PR to fix this.