### PR TITLE
ENH improve install of julia deps

### DIFF
--- a/doc/how.rst
+++ b/doc/how.rst
@@ -250,7 +250,11 @@ It uses the Julia code in:
 .. literalinclude:: ../benchmarks/benchmark_lasso/solvers/julia_pgd.jl
     :language: julia
 
-Note that it is also possible to automatize ``julia`` dependencies installation using the class attribute ``julia_requirements`` as a list of package names. The string in this list are directly passed to ``Pkg.add``. In case it is necessary to install dependencies from a GitHub repository, one can use the following format: ``PkgName::https://github.com/org/Pkg#branch_name``. This will be processed to recover both the url and the package name. This is necessary to allow ``benchopt`` to check if the ``PkgName`` is installed in the targeted environment.
+.. admonition:: Installing Julia dependencies
+
+  Note that it is also possible to install ``julia`` dependencies using ``benchopt install`` with the class attribute ``julia_requirements``. This attribute should be a list of package names, whose string are directly passed to ``Pkg.add``.
+
+  In case it is necessary to install dependencies from a GitHub repository, one can use the following format: ``PkgName::https://github.com/org/Pkg.jl#branch_name``. This will be processed to recover both the url and the package name. Note that the ``branch_name`` is optional. Using the ``::`` to specify the ``PkgName`` is necessary to allow ``benchopt`` to check if it is installed in the targeted environment.
 
 .. _source_solvers:
 

--- a/doc/how.rst
+++ b/doc/how.rst
@@ -250,6 +250,8 @@ It uses the Julia code in:
 .. literalinclude:: ../benchmarks/benchmark_lasso/solvers/julia_pgd.jl
     :language: julia
 
+Note that it is also possible to automatize ``julia`` dependencies installation using the class attribute ``julia_requirements`` as a list of package names. The string in this list are directly passed to ``Pkg.add``. In case it is necessary to install dependencies from a GitHub repository, one can use the following format: ``PkgName::https://github.com/org/Pkg#branch_name``. This will be processed to recover both the url and the package name. This is necessary to allow ``benchopt`` to check if the ``PkgName`` is installed in the targeted environment.
+
 .. _source_solvers:
 
 Solver from source


### PR DESCRIPTION
This allows to easily install julia dependencies from a github repo, using:

```python
class Solver(JuliaSolver):

    julia_requirements = ["pkg_name::https://url.to/package#branch"]
```

tested for the following benchmark: benchopt/benchmark_logreg_l2#29