### PR TITLE
Support exp notation in CLI parameters

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -555,7 +555,7 @@ def _extract_parameters(string):
         string = string.replace(match, str(hash(match)))
 
     # Second, add quotes to all variable names (foo -> 'foo').
-    # Accepts dots and dashes within names.
+    # Accepts dots and dashes within names.
     string = re.sub(r"[a-zA-Z][a-zA-Z0-9._-]*", r"'\g<0>'", string)
 
     # Third, change back the hashes to their original names.

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -544,9 +544,13 @@ def _extract_parameters(string):
     import ast
     original = string
 
-    # First, replace all quoted names with their hashes, to avoid modification.
+    # First, replace some expressions with their hashes, to avoid modification.
+    # - all quoted names
     all_matches = re.findall(r"'[^'\"]*'", string)
     all_matches += re.findall(r'"[^\'"]*"', string)
+    # - numbers of the form "1e-3"
+    all_matches += re.findall(  
+        r"(?<![a-zA-Z])[+-]?[0-9]+[.]?[0-9]*[eE][-+]?[0-9]+", string)
     for match in all_matches:
         string = string.replace(match, str(hash(match)))
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -544,8 +544,8 @@ def _extract_parameters(string):
     import ast
     original = string
 
-    # First, replace some expressions with their hashes, to avoid modification.
-    # - all quoted names
+    # First, replace some expressions with their hashes, to avoid modification:
+    # - quoted names
     all_matches = re.findall(r"'[^'\"]*'", string)
     all_matches += re.findall(r'"[^\'"]*"', string)
     # - numbers of the form "1e-3"
@@ -555,11 +555,13 @@ def _extract_parameters(string):
         string = string.replace(match, str(hash(match)))
 
     # Second, add quotes to all variable names (foo -> 'foo').
+    # Accepts dots and dashes within names.
     string = re.sub(r"[a-zA-Z][a-zA-Z0-9._-]*", r"'\g<0>'", string)
 
     # Third, change back the hashes to their original names.
     for match in all_matches:
         string = string.replace(str(hash(match)), match)
+
     # Prepare the sequence for AST parsing.
     # Sequences with "=" are made into a dict expression {'foo': 'bar'}.
     # Sequences without "=" are made into a list expression ['foo', 'bar'].

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -549,7 +549,7 @@ def _extract_parameters(string):
     all_matches = re.findall(r"'[^'\"]*'", string)
     all_matches += re.findall(r'"[^\'"]*"', string)
     # - numbers of the form "1e-3"
-    all_matches += re.findall(  
+    all_matches += re.findall(
         r"(?<![a-zA-Z])[+-]?[0-9]+[.]?[0-9]*[eE][-+]?[0-9]+", string)
     for match in all_matches:
         string = string.replace(match, str(hash(match)))

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -548,9 +548,9 @@ def _extract_parameters(string):
     # - quoted names
     all_matches = re.findall(r"'[^'\"]*'", string)
     all_matches += re.findall(r'"[^\'"]*"', string)
-    # - numbers of the form "1e-3"
+    # - numbers of the form "1e-3" (but not names like "foo1e3")
     all_matches += re.findall(
-        r"(?<![a-zA-Z])[+-]?[0-9]+[.]?[0-9]*[eE][-+]?[0-9]+", string)
+        r"(?<![a-zA-Z0-9_])[+-]?[0-9]+[.]?[0-9]*[eE][-+]?[0-9]+", string)
     for match in all_matches:
         string = string.replace(match, str(hash(match)))
 

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -220,6 +220,7 @@ def test_extract_parameters():
     assert _extract_parameters("1, 2, 3") == [1, 2, 3]
     assert _extract_parameters("1e1, -.1e-3, 12.e+1") == [10.0, -0.0001, 120.0]
     assert _extract_parameters("foo42e1, bar1.0e4") == ["foo42e1", "bar1.0e4"]
+    assert _extract_parameters("foo_4e2, bar.1e3") == ["foo_4e2", "bar.1e3"]
 
     assert _extract_parameters("42, True, foo") == [42, True, "foo"]
     assert _extract_parameters("42, (1, 2, 3)") == [42, (1, 2, 3)]

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -220,7 +220,7 @@ def test_extract_parameters():
     assert _extract_parameters("1, 2, 3") == [1, 2, 3]
     assert _extract_parameters("1e1, -.1e-3, 12.e+1") == [10.0, -0.0001, 120.0]
     assert _extract_parameters("foo42e1, bar1.0e4") == ["foo42e1", "bar1.0e4"]
-    assert _extract_parameters("foo_4e2, bar.1e3") == ["foo_4e2", "bar.1e3"]
+    assert _extract_parameters("foo_4e2, bar01e3") == ["foo_4e2", "bar01e3"]
 
     assert _extract_parameters("42, True, foo") == [42, True, "foo"]
     assert _extract_parameters("42, (1, 2, 3)") == [42, (1, 2, 3)]

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -218,6 +218,8 @@ def test_extract_parameters():
     assert _extract_parameters("foo-bar") == ["foo-bar"]
     assert _extract_parameters("foo.bar") == ["foo.bar"]
     assert _extract_parameters("1, 2, 3") == [1, 2, 3]
+    assert _extract_parameters("1e1, -.1e-3, 12.e+1") == [10.0, -0.0001, 120.0]
+    assert _extract_parameters("foo42e1, bar1.0e4") == ["foo42e1", "bar1.0e4"]
 
     assert _extract_parameters("42, True, foo") == [42, True, "foo"]
     assert _extract_parameters("42, (1, 2, 3)") == [42, (1, 2, 3)]


### PR DESCRIPTION
Support "solver[parameter=1e-5]" in CLI. (follow-up of #362).