### PR TITLE
Get cuda info without nvcc

### DIFF
--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -37,8 +37,8 @@ def _get_cuda_version():
         return f"{name}: cuda_{version}"
     except AttributeError:
         import warnings
-        warngings.warn("Found `nvidia-smi` but could not parse cuda version "
-                                  "or device name.")
+        warnings.warn("Found `nvidia-smi` but could not parse cuda version "
+                      "or device name.")
         return None
 
 

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -25,7 +25,7 @@ def _get_processor_name():
     return out
 
 
-def _get_cuda_version():
+def get_cuda_version():
     "Return GPU name and CUDA version."
     if which("nvidia-smi") is None:
         return None
@@ -96,7 +96,7 @@ def get_sys_info():
     )
 
     # Info on dependency libs
-    info["version-cuda"] = _get_cuda_version()
+    info["version-cuda"] = get_cuda_version()
     info["version-numpy"] = (np.__version__, _get_numpy_libs())
     info["version-scipy"] = scipy.__version__
 

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -26,13 +26,14 @@ def _get_processor_name():
 
 
 def _get_cuda_version():
-    "Return CUDA version."
-    if which("nvcc") is None:
+    "Return GPU name and CUDA version."
+    if which("nvidia-smi") is None:
         return None
-    command = ["nvcc", "--version"]
+    command = ["nvidia-smi", "-q", "-x"]
     out = subprocess.check_output(command).strip().decode("utf-8")
-    out = out.splitlines()[-1]  # take only last line
-    return out
+    version = re.search('<cuda_version>(.*)</cuda_version>', out).group(1)
+    name = re.search('<product_name>(.*)</product_name>', out).group(1)
+    return f"{name}: cuda_{version}"
 
 
 def _get_numpy_libs():

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -37,8 +37,9 @@ def get_cuda_version():
         return f"{name}: cuda_{version}"
     except AttributeError:
         import warnings
-        warnings.warn("Found `nvidia-smi` but could not parse cuda version "
-                      "or device name.")
+        warnings.warn(
+            "Could not parse cuda version or device name from `nvidia-smi`."
+         )
         return None
 
 

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -31,9 +31,15 @@ def _get_cuda_version():
         return None
     command = ["nvidia-smi", "-q", "-x"]
     out = subprocess.check_output(command).strip().decode("utf-8")
-    version = re.search('<cuda_version>(.*)</cuda_version>', out).group(1)
-    name = re.search('<product_name>(.*)</product_name>', out).group(1)
-    return f"{name}: cuda_{version}"
+    try:
+        version = re.search('<cuda_version>(.*)</cuda_version>', out).group(1)
+        name = re.search('<product_name>(.*)</product_name>', out).group(1)
+        return f"{name}: cuda_{version}"
+    except AttributeError:
+        import warnings
+        warngings.warn("Found `nvidia-smi` but could not parse cuda version "
+                                  "or device name.")
+        return None
 
 
 def _get_numpy_libs():


### PR DESCRIPTION
Fixes #378 and Fixes #163 by collection GPU name and cuda version
This doesn't use `pynvml` (which is "a wrapper around NVML library" that does, more quickly, what the smi thinner wrapper `nvidia-smi -q -x` does)
