### PR TITLE
[FIX] Safe exit cuda

### DIFF
--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -30,7 +30,14 @@ def get_cuda_version():
     if which("nvidia-smi") is None:
         return None
     command = ["nvidia-smi", "-q", "-x"]
-    out = subprocess.check_output(command).strip().decode("utf-8")
+    try:
+        out = subprocess.check_output(command).strip().decode("utf-8")
+    except subprocess.CalledProcessError:
+        import warnings
+        warnings.warn(
+            "Could not run `nvidia-smi -q -x` command."
+        )
+        return None
     try:
         version = re.search('<cuda_version>(.*)</cuda_version>', out).group(1)
         name = re.search('<product_name>(.*)</product_name>', out).group(1)

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -35,7 +35,7 @@ def get_cuda_version():
     except subprocess.CalledProcessError:
         import warnings
         warnings.warn(
-            "Could not run `nvidia-smi -q -x` command."
+            "`nvidia-smi` has failed. Please check NVIDIA driver install."
         )
         return None
     try:


### PR DESCRIPTION
Fixes #395 with a first try/except on `nvidia-smi` command check output.