### PR TITLE
[WIP] ENH - automatic generation of cookiecutter code

### DIFF
--- a/bench_cookiecutter/datasets/dataset.py
+++ b/bench_cookiecutter/datasets/dataset.py
@@ -1,0 +1,16 @@
+from benchopt import BaseDataset
+from benchopt import safe_import_context
+
+with safe_import_context() as import_ctx:
+    # your dependencies here
+    pass
+
+
+class Dataset(BaseDataset):
+    name = "{name}"
+
+    def __init__(self):
+        pass
+
+    def get_data(self):
+        return dict()

--- a/bench_cookiecutter/objective.py
+++ b/bench_cookiecutter/objective.py
@@ -1,0 +1,21 @@
+from benchopt import BaseObjective, safe_import_context
+
+with safe_import_context() as import_ctx:
+    # your dependencies here
+    pass
+
+
+class Objective(BaseObjective):
+    name = "{name}"
+
+    def __init__(self):
+        pass
+
+    def set_data(self):
+        pass
+
+    def compute(self):
+        return dict()
+
+    def to_dict(self):
+        return dict()

--- a/bench_cookiecutter/solvers/solver.py
+++ b/bench_cookiecutter/solvers/solver.py
@@ -19,4 +19,4 @@ class Solver(BaseSolver):
         pass
 
     def get_result(self):
-        return  # output of your solver
+        return

--- a/bench_cookiecutter/solvers/solver.py
+++ b/bench_cookiecutter/solvers/solver.py
@@ -1,0 +1,22 @@
+from benchopt import BaseSolver
+from benchopt import safe_import_context
+
+with safe_import_context() as import_ctx:
+    # your dependencies here
+    pass
+
+
+class Solver(BaseSolver):
+    name = "{name}"
+
+    def __init__(self):
+        pass
+
+    def set_objective(self):
+        pass
+
+    def run(self, stop_value):
+        pass
+
+    def get_result(self):
+        return  # output of your solver

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -1,3 +1,4 @@
+from email.policy import default
 import yaml
 import click
 import warnings
@@ -283,6 +284,38 @@ def run(config_file=None, **kwargs):
     raise SystemExit(_run_shell_in_conda_env(
         cmd, env_name=env_name, capture_stdout=False
     ) != 0)
+
+
+@main.command(help="wanna some help")
+@click.argument('dir_path', default="./")
+@click.option('--template', '-t', 'template')
+@click.option('--name', '-n', 'file_name')
+def cookiecutter(dir_path, template, file_name):
+    from github import Github
+    import os
+
+    assert template in ('solver', 'objective', 'dataset')
+
+    template_path = f"bench_cookiecutter/"
+    if template != 'objective':
+        template_path += f"{template}s/{template}.py"
+    else:
+        template_path += f"{template}.py"
+
+    benchopt_repo = Github().get_repo("Badr-MOUFAD/benchopt")
+    template_content = benchopt_repo.get_contents(
+        path=template_path,
+        ref='cookiecutter'  # this will be come 'main' after merge
+    )
+
+    relative_path = os.path.join(dir_path, f"{file_name}.py")
+    with open(relative_path, 'x') as f:
+        f.write(
+            template_content
+            .decoded_content
+            .decode('utf-8')
+            .format(name=file_name)
+        )
 
 
 @main.command(

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -1,4 +1,3 @@
-from email.policy import default
 import yaml
 import click
 import warnings
@@ -286,13 +285,13 @@ def run(config_file=None, **kwargs):
     ) != 0)
 
 
-@main.command(help="wanna some help")
+@main.command(help="wanna some help?")
 @click.argument('dir_path', default="./")
 @click.option('--template', '-t', 'template')
 @click.option('--name', '-n', 'file_name')
 def cookiecutter(dir_path, template, file_name):
-    from github import Github
     import os
+    from github import Github
 
     assert template in ('solver', 'objective', 'dataset')
 


### PR DESCRIPTION
When writing benchmarks, I found it pretty repetitive to layout the structure of benchmarks (i.e. datasets, solvers) over and over again. Indeed, all the defined solvers and datasets follow the same logic.

Based on that, I suggest, through this PR, adding a command into the CLI to automatically generate cookie-cutter code for solvers, datasets, and why not the entire benchmark directory.

I made a small demo, you can generate the template for adding a new solver by running:
```shell
benchopt cookiecutter . --template solver --name some_given_solver 
```
The same thing can be achieved for a new dataset.

If this idea sounds good to you, here are the next steps:
- [ ] implement cookiecutter for the entire benchmark directory
- [ ] handle exceptions and add docs (namely the ``help``)
- [ ] Add/explain this new feature into documentation

