### PR TITLE
ENH add benchopt archive cmd to share the benchmarks

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -1,5 +1,6 @@
 import click
 import pprint
+import tarfile
 from pathlib import Path
 from collections.abc import Iterable
 import warnings
@@ -21,6 +22,12 @@ from benchopt.utils.shell_cmd import _run_shell_in_conda_env
 
 from benchopt.utils.terminal_output import colorify
 from benchopt.utils.terminal_output import RED, GREEN, TICK, CROSS
+
+
+ARCHIVE_ELEMENTS = [
+    'README*', '*.yml', 'objective.py',
+    'solvers/*', 'datasets/*', 'utils/**'
+]
 
 helpers = click.Group(
     name='Helpers',
@@ -68,6 +75,46 @@ def clean(benchmark, token=None, filename='all'):
     # Delete cache files
     print("Clear joblib cache")
     benchmark.mem.clear(warn=False)
+
+
+def clean_archive(info):
+    if "__pycache__" in info.name:
+        return None
+
+    # reset the username and info in the archive
+    info.uid = info.gid = 0
+    info.uname = info.gname = "benchopt"
+
+    return info
+
+
+@helpers.command(
+    help="Create an archive of the benchmark that can easily be shared."
+)
+@click.argument('benchmark', default=Path.cwd(), type=click.Path(exists=True),
+                shell_complete=complete_benchmarks)
+@click.option('--with-outputs',
+              is_flag=True,
+              help="If this flag is set, also store the outputs of the "
+              "benchmark in the archive.")
+def archive(benchmark, with_outputs):
+
+    benchmark = Benchmark(benchmark)
+    bench_dir = benchmark.benchmark_dir
+
+    to_archive = ARCHIVE_ELEMENTS
+    if with_outputs:
+        to_archive = to_archive + ['outputs/*']
+
+    archive_name = f"{benchmark.name}.tar.gz"
+    print(f"Creating {archive_name}...", end='', flush=True)
+    with tarfile.open(archive_name, "w:gz") as tar:
+        for elem_pattern in to_archive:
+            for sub_elem in bench_dir.glob(elem_pattern):
+                print(sub_elem)
+                tar.add(sub_elem, sub_elem.relative_to(bench_dir.parent),
+                        filter=clean_archive)
+    print("done")
 
 
 def check_conda_env(env_name, benchmark_name=None):


### PR DESCRIPTION
This add a `benchopt archive` command  in the CLI (name of the command is discutable).
It creates a `.tar.gz` file with all needed to run the benchmark:

- README
- objective.py
- solvers
- datasets
- utils
- yml config files

If using `--with-outputs`, it will also archive the contents of the `outputs` folder.

For now, there is no `--anonymous` but we could imagine passing a file of patterns to replace with `XXX` with the names of authors and institution if needed (this looks like an overkill for now).

Let me know if you think this is good enough or if I should change some stuff.