### PR TITLE
Trim infinite values for HTML plotting

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -131,10 +131,6 @@ def shape_objectives_columns_for_html(df, dataset, objective):
         if c.startswith('objective_') and c != 'objective_name'
     ]
 
-    # remove infinite values
-    df.replace([np.inf, -np.inf], np.nan, inplace=True)
-    df.dropna(subset=columns, inplace=True)
-
     for column in columns:
         df_filtered = df.query(
             "data_name == @dataset & objective_name == @objective"
@@ -158,6 +154,11 @@ def shape_solvers_for_html(df, objective_column):
     solver_data = {}
     for solver in df['solver_name'].unique():
         df_filtered = df.query("solver_name == @solver")
+
+        # remove infinite values
+        df_filtered = df_filtered.replace([np.inf, -np.inf], np.nan)
+        df_filtered = df_filtered.dropna(subset=[objective_column])
+
         q1, q9 = compute_quantiles(df_filtered)
         solver_data[solver] = {
             'scatter': {


### PR DESCRIPTION
This PR trims infinite values.

Some dataset have infinite value in their objective_columns. The points that have the coordinates like (x, infinite) are not displayed. Such points continue to be counted in the xlim. So if these points are far on the x-axis then they will enlarge the xlim without being seen. This has the effect of reducing the size of the other curves on the x-axis.

Example : [Logreg L2](https://benchopt.github.io/results/benchmark_logreg_l2_benchmark_logreg_l2_benchopt_run_2021-03-18_02h11m46.html)