### PR TITLE
Compress data

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -177,36 +177,42 @@ class Benchmark:
         ----------
         filename : str
             Select a specific file from the benchmark. If None, this will
-            select the most recent CSV file in the benchmark output folder.
+            select the most recent result file in the benchmark output folder.
         """
         # List all result files
         output_folder = self.get_output_folder()
-        all_csv_files = output_folder.glob("*.csv")
-        all_csv_files = sorted(
-            all_csv_files, key=lambda t: t.stat().st_mtime
+        all_result_files = output_folder.glob("*.(csv|parquet)")
+        all_result_files = sorted(
+            all_result_files, key=lambda t: t.stat().st_mtime
         )
 
         if filename is not None and filename != 'all':
-            result_filename = (output_folder / filename).with_suffix('.csv')
+            result_path = (output_folder / filename)
+            result_filename = result_path.with_suffix('.parquet')
+
+            if not result_filename.exists():
+                result_filename = result_path.with_suffix('.csv')
+
             if not result_filename.exists():
                 if Path(filename).exists():
                     result_filename = Path(filename)
                 else:
-                    all_csv_files = '\n- '.join([
-                        str(s) for s in all_csv_files
+                    all_result_files = '\n- '.join([
+                        str(s) for s in all_result_files
                     ])
                     raise FileNotFoundError(
                         f"Could not find result file {filename}. Available "
-                        f"result files are:\n- {all_csv_files}"
+                        f"result files are:\n- {all_result_files}"
                     )
         else:
-            if len(all_csv_files) == 0:
+            if len(all_result_files) == 0:
                 raise RuntimeError(
-                    f"Could not find any CSV result files in {output_folder}."
+                    "Could not find any Parquet nor"
+                    f"CSV result files in {output_folder}."
                 )
-            result_filename = all_csv_files[-1]
+            result_filename = all_result_files[-1]
             if filename == 'all':
-                result_filename = all_csv_files
+                result_filename = all_result_files
 
         return result_filename
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -181,7 +181,7 @@ class Benchmark:
         """
         # List all result files
         output_folder = self.get_output_folder()
-        all_result_files = output_folder.glob("*.[csv][parquet]")
+        all_result_files = list(output_folder.glob("*.parquet")) + list(output_folder.glob("*.csv"))
         all_result_files = sorted(
             all_result_files, key=lambda t: t.stat().st_mtime
         )
@@ -191,7 +191,6 @@ class Benchmark:
             result_filename = result_path.with_suffix('.parquet')
 
             if not result_filename.exists():
-                print('CSV files are deprecated. Please use Parquet files instead.')
                 result_filename = result_path.with_suffix('.csv')
 
             if not result_filename.exists():
@@ -214,6 +213,10 @@ class Benchmark:
             result_filename = all_result_files[-1]
             if filename == 'all':
                 result_filename = all_result_files
+                
+        
+        if result_filename.suffix == ".csv":
+            print('CSV files are deprecated. Please use Parquet files instead.')
 
         return result_filename
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -217,9 +217,11 @@ class Benchmark:
                 result_filename = all_result_files
 
         if result_filename.suffix == ".csv":
-            print(
-                'CSV files are deprecated. Please use Parquet files instead.'
-            )
+            print(colorify(
+                "WARNING: CSV files are deprecated."
+                "Please use Parquet files instead.",
+                YELLOW
+            ))
 
         return result_filename
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -181,7 +181,9 @@ class Benchmark:
         """
         # List all result files
         output_folder = self.get_output_folder()
-        all_result_files = list(output_folder.glob("*.parquet")) + list(output_folder.glob("*.csv"))
+        all_result_files = list(
+            output_folder.glob("*.parquet")
+        ) + list(output_folder.glob("*.csv"))
         all_result_files = sorted(
             all_result_files, key=lambda t: t.stat().st_mtime
         )
@@ -213,10 +215,11 @@ class Benchmark:
             result_filename = all_result_files[-1]
             if filename == 'all':
                 result_filename = all_result_files
-                
-        
+
         if result_filename.suffix == ".csv":
-            print('CSV files are deprecated. Please use Parquet files instead.')
+            print(
+                'CSV files are deprecated. Please use Parquet files instead.'
+            )
 
         return result_filename
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -181,7 +181,7 @@ class Benchmark:
         """
         # List all result files
         output_folder = self.get_output_folder()
-        all_result_files = output_folder.glob("*.(csv|parquet)")
+        all_result_files = output_folder.glob("*.csv") + output_folder.glob("*.parquet")
         all_result_files = sorted(
             all_result_files, key=lambda t: t.stat().st_mtime
         )

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -181,7 +181,7 @@ class Benchmark:
         """
         # List all result files
         output_folder = self.get_output_folder()
-        all_result_files = output_folder.glob("*.csv") + output_folder.glob("*.parquet")
+        all_result_files = output_folder.glob("*.[csv][parquet]")
         all_result_files = sorted(
             all_result_files, key=lambda t: t.stat().st_mtime
         )

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -191,6 +191,7 @@ class Benchmark:
             result_filename = result_path.with_suffix('.parquet')
 
             if not result_filename.exists():
+                print('CSV files are deprecated. Please use Parquet files instead.')
                 result_filename = result_path.with_suffix('.csv')
 
             if not result_filename.exists():

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -207,7 +207,7 @@ class Benchmark:
         else:
             if len(all_result_files) == 0:
                 raise RuntimeError(
-                    "Could not find any Parquet nor"
+                    "Could not find any Parquet nor "
                     f"CSV result files in {output_folder}."
                 )
             result_filename = all_result_files[-1]

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,7 +86,7 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in output_folder.glob('*.csv') + output_folder.glob('*.parquet')
+        p.resolve().relative_to(cwd) for p in output_folder.glob("*.[csv][parquet]")
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,7 +86,9 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in list(output_folder.glob("*.parquet")) + list(output_folder.glob("*.csv"))
+        p.resolve().relative_to(cwd) for p in list(
+            output_folder.glob("*.parquet")
+        ) + list(output_folder.glob("*.csv"))
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,9 +86,8 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in list(
-            output_folder.glob("*.parquet")
-        ) + list(output_folder.glob("*.csv"))
+        p.resolve().relative_to(cwd) for ext in ['csv', 'parquet']
+        for p in output_folder.glob(f"*.{ext}")
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,7 +86,9 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in output_folder.glob('*.csv')
+        p.resolve().relative_to(cwd) for p in output_folder.glob(
+            '*.(csv|parquet)'
+        )
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,9 +86,7 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in output_folder.glob(
-            '*.(csv|parquet)'
-        )
+        p.resolve().relative_to(cwd) for p in output_folder.glob('*.csv') + output_folder.glob('*.parquet')
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,7 +86,7 @@ def complete_output_files(ctx, param, incomplete):
     # autocompletion with relative paths
     cwd = Path().resolve()
     candidates = [
-        p.resolve().relative_to(cwd) for p in output_folder.glob("*.[csv][parquet]")
+        p.resolve().relative_to(cwd) for p in list(output_folder.glob("*.parquet")) + list(output_folder.glob("*.csv"))
     ]
     return propose_from_list(candidates, incomplete)
 

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -54,7 +54,7 @@ def clean(benchmark, token=None, filename='all'):
         rm_folder(output_folder)
     else:
         was_removed = False
-        for ext in [".csv", ".html"]:
+        for ext in [".csv", ".html", ".parquet"]:
             if ext == ".html":
                 to_remove = output_folder / f"{benchmark.name}_{filename}"
             else:
@@ -66,10 +66,10 @@ def clean(benchmark, token=None, filename='all'):
                 file.unlink()
             json_path = output_folder / "cache_run_list.json"
             if was_removed and json_path.exists():
-                print(f"Removing {filename}.csv entry from {json_path}")
+                print(f"Removing {filename}.{ext} entry from {json_path}")
                 with open(json_path, "r") as cache_run:
                     json_file = json.load(cache_run)
-                json_file.pop(f"{filename}.csv", None)
+                json_file.pop(f"{filename}.{ext}", None)
                 with open(json_path, "w") as cache_run:
                     json.dump(json_file, cache_run)
     # Delete cache files

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -159,12 +159,14 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               "named <env_name>. To install the required solvers and "
               "datasets, see the command `benchopt install`.")
 @click.option("--output", default="None", type=str,
-              help="Filename for the csv output. If given, the results will "
-              "be stored at <BENCHMARK>/outputs/<filename>.csv, "
+              help="Filename for the result output. "
+              "If given, the results will "
+              "be stored at <BENCHMARK>/outputs/<filename>.parquet, "
               "if another result file has the same name, a number is happened "
-              "to distinguish them (ex: <BENCHMARK>/outputs/<filename>_1.csv)."
+              "to distinguish them "
+              "(ex: <BENCHMARK>/outputs/<filename>_1.parquet)."
               " If not provided, the output will be saved as "
-              "<BENCHMARK>/outputs/benchopt_run_<timestamp>.csv."
+              "<BENCHMARK>/outputs/benchopt_run_<timestamp>.parquet."
               )
 def run(config_file=None, **kwargs):
     if config_file is not None:

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -130,3 +130,30 @@ def generate_results(patterns=(), benchmarks=(), root=None, display=True):
     plot_benchmark_html_all(
         patterns=patterns, benchmarks=benchmarks, root=root, display=display
     )
+
+
+@process_results.command(
+    help="Convert a result file of type parquet into the requested type."
+)
+@click.argument('parquet_file',
+                default=Path.cwd(),
+                type=click.Path(exists=True))
+@click.option('--to', '-t', 'requested_formats',
+              metavar="<to>", multiple=True, type=str,
+              help="Choose the conversion format (CSV, JSON, Excel, etc.).")
+def convert(parquet_file, requested_formats):
+    import os
+    import pandas as pd
+    # remove parquet file extension
+    filename = os.path.splitext(parquet_file)[0]
+    accepted_types = ['csv', 'json', 'html']
+    methods = {}
+    for accepted in accepted_types:
+        methods[accepted] = "to_" + accepted
+
+    df = pd.read_parquet(parquet_file)
+    for requested_format in requested_formats:
+        print(f"Formatting results to {requested_format} ...")
+        getattr(df, methods[requested_format])(
+            f"{filename}.{requested_format}"
+        )

--- a/benchopt/cli/process_results.py
+++ b/benchopt/cli/process_results.py
@@ -130,30 +130,3 @@ def generate_results(patterns=(), benchmarks=(), root=None, display=True):
     plot_benchmark_html_all(
         patterns=patterns, benchmarks=benchmarks, root=root, display=display
     )
-
-
-@process_results.command(
-    help="Convert a result file of type parquet into the requested type."
-)
-@click.argument('parquet_file',
-                default=Path.cwd(),
-                type=click.Path(exists=True))
-@click.option('--to', '-t', 'requested_formats',
-              metavar="<to>", multiple=True, type=str,
-              help="Choose the conversion format (CSV, JSON, Excel, etc.).")
-def convert(parquet_file, requested_formats):
-    import os
-    import pandas as pd
-    # remove parquet file extension
-    filename = os.path.splitext(parquet_file)[0]
-    accepted_types = ['csv', 'json', 'html']
-    methods = {}
-    for accepted in accepted_types:
-        methods[accepted] = "to_" + accepted
-
-    df = pd.read_parquet(parquet_file)
-    for requested_format in requested_formats:
-        print(f"Formatting results to {requested_format} ...")
-        getattr(df, methods[requested_format])(
-            f"{filename}.{requested_format}"
-        )

--- a/benchopt/plotting/__init__.py
+++ b/benchopt/plotting/__init__.py
@@ -49,7 +49,11 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
 
     else:
         # Load the results.
-        df = pd.read_parquet(fname)
+        if fname.suffix == '.parquet':
+            df = pd.read_parquet(fname)
+        else:
+            df = pd.read_csv(fname)
+        
         obj_cols = [
             k for k in df.columns
             if k.startswith('objective_') and k != 'objective_name'

--- a/benchopt/plotting/__init__.py
+++ b/benchopt/plotting/__init__.py
@@ -53,7 +53,7 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
             df = pd.read_parquet(fname)
         else:
             df = pd.read_csv(fname)
-        
+
         obj_cols = [
             k for k in df.columns
             if k.startswith('objective_') and k != 'objective_name'

--- a/benchopt/plotting/__init__.py
+++ b/benchopt/plotting/__init__.py
@@ -49,7 +49,7 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
 
     else:
         # Load the results.
-        df = pd.read_csv(fname)
+        df = pd.read_parquet(fname)
         obj_cols = [
             k for k in df.columns
             if k.startswith('objective_') and k != 'objective_name'

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -38,12 +38,12 @@ SYS_INFO = {
 
 
 def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
-    """Generate figures from a list of csv files.
+    """Generate figures from a list of result files.
 
     Parameters
     ----------
     fnames : list of Path
-        list of csv files containing the benchmark results.
+        list of result files containing the benchmark results.
     kinds : list of str
         List of the kind of plots that will be generated. This needs to be a
         sub-list of PLOT_KINDS.keys().
@@ -67,10 +67,15 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
     for fname in fnames:
         print(f"Processing {fname}")
 
-        df = pd.read_csv(fname)
+        if fname.with_suffix('.parquet').exists():
+            df = pd.read_parquet(fname)
+        else:
+            df = pd.read_csv(fname.with_suffix('.csv'))
+
         datasets = list(df['data_name'].unique())
         sysinfo = get_sysinfo(df)
-        # Copy CSV if necessary and give a relative path for HTML page access
+        # Copy result file if necessary
+        # and give a relative path for HTML page access
         if copy:
             fname_in_output = out_dir / f"{benchmark_name}_{fname.name}"
             shutil.copy(fname, fname_in_output)
@@ -95,6 +100,7 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         result['page'] = (
             f"{benchmark_name}_"
             f"{result['fname_short'].replace('.csv', '.html')}"
+            f"{result['fname_short'].replace('.parquet', '.html')}"
         )
 
         # JSON
@@ -212,17 +218,11 @@ def get_sysinfo(df):
 
     def get_val(df, key):
         if key in df:
-            if key == 'platform':
-                return (
-                    str(df["platform"].unique()[0]) +
-                    str(df["platform-release"].unique()[0]) + "-" +
-                    str(df["platform-architecture"].unique()[0])
-                )
-            else:
-                val = df[key].unique()[0]
-                if not pd.isnull(val):
-                    return str(val)
-                return ''
+            df['version-numpy'] = df['version-numpy'].astype(str)
+            val = df[key].unique()[0]
+            if not pd.isnull(val):
+                return str(val)
+            return ''
         else:
             return ''
     sysinfo = {
@@ -476,7 +476,7 @@ def plot_benchmark_html_all(patterns=(), benchmarks=(), root=None,
 
         fnames = []
         for p in patterns:
-            fnames += (benchmark / 'outputs').glob(f"{p}.csv")
+            fnames += (benchmark / 'outputs').glob(f"{p}.parquet")
         fnames = sorted(set(fnames))
         results = get_results(
             fnames, PLOT_KINDS.keys(), root_html, benchmark.name, copy=True

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -97,10 +97,8 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         results.append(result)
 
     for result in results:        
-        if fname.suffix == '.csv':
-            html_file_name = f"{result['fname_short'].replace('.csv', '.html')}"
-        else:
-            html_file_name = f"{result['fname_short'].replace('.parquet', '.html')}"
+        html_file_name = f"{result['fname_short'].replace('.csv', '.html')}"
+        html_file_name = f"{html_file_name.replace('.parquet', '.html')}"
             
         result['page'] = (
             f"{benchmark_name}_"
@@ -487,7 +485,7 @@ def plot_benchmark_html_all(patterns=(), benchmarks=(), root=None,
 
         fnames = []
         for p in patterns:
-            fnames += (benchmark / 'outputs').glob(f"{p}.parquet")
+            fnames += list((benchmark / 'outputs').glob(f"{p}.parquet")) + list((benchmark / 'outputs').glob(f"{p}.csv"))
         fnames = sorted(set(fnames))
         results = get_results(
             fnames, PLOT_KINDS.keys(), root_html, benchmark.name, copy=True

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -96,10 +96,10 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         )
         results.append(result)
 
-    for result in results:        
+    for result in results:
         html_file_name = f"{result['fname_short'].replace('.csv', '.html')}"
         html_file_name = f"{html_file_name.replace('.parquet', '.html')}"
-            
+
         result['page'] = (
             f"{benchmark_name}_"
             f"{html_file_name}"
@@ -485,7 +485,9 @@ def plot_benchmark_html_all(patterns=(), benchmarks=(), root=None,
 
         fnames = []
         for p in patterns:
-            fnames += list((benchmark / 'outputs').glob(f"{p}.parquet")) + list((benchmark / 'outputs').glob(f"{p}.csv"))
+            fnames += list(
+                (benchmark / 'outputs').glob(f"{p}.parquet")
+            ) + list((benchmark / 'outputs').glob(f"{p}.csv"))
         fnames = sorted(set(fnames))
         results = get_results(
             fnames, PLOT_KINDS.keys(), root_html, benchmark.name, copy=True

--- a/benchopt/plotting/html/static/benchmark.js
+++ b/benchopt/plotting/html/static/benchmark.js
@@ -136,7 +136,7 @@ function trashIconDialog() {
   allChecked = document.querySelectorAll("input[name=checkfiles]:checked");
   delCmd = "rm \\\n <br />"; // n and br for html and copy to clipboard
   for (check of allChecked) {
-    delCmd += $(check).attr("data-csv") + " \\\n <br />";
+    delCmd += $(check).attr("data-result") + " \\\n <br />";
     delCmd += $(check).attr("data-html") + " \\\n <br />";
   }
   delCmd += "cache_run_list.json"; // add the cache file

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -90,7 +90,7 @@
         %>
         ${fname}
       </a>
-      <input type="checkbox" name="checkfiles" data-csv="${result['fname']}" data-html="${result['page']}" style="display:none;">
+      <input type="checkbox" name="checkfiles" data-result="${result['fname']}" data-html="${result['page']}" style="display:none;">
     </td>
     <td class="datasets">
     <ul style="list-style-type: none; margin-top: 0;">

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -279,8 +279,8 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
     pdb : bool
         It pdb is set to True, open a debugger on error.
     output_name : str
-        Filename for the csv output. If given, the results will
-        be stored at <BENCHMARK>/outputs/<filename>.csv.
+        Filename for the parquet output. If given, the results will
+        be stored at <BENCHMARK>/outputs/<filename>.parquet.
 
     Returns
     -------
@@ -326,15 +326,15 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
         output.savefile_status()
         raise SystemExit(1)
 
-    # Save output in CSV file in the benchmark folder
+    # Save output in parquet file in the benchmark folder
     timestamp = datetime.now().strftime('%Y-%m-%d_%Hh%Mm%S')
     output_dir = benchmark.get_output_folder()
     if output_name == "None":
-        save_file = output_dir / f'benchopt_run_{timestamp}.csv'
+        save_file = output_dir / f'benchopt_run_{timestamp}.parquet'
     else:
-        save_file = output_dir / f"{output_name}.csv"
+        save_file = output_dir / f"{output_name}.parquet"
         save_file = uniquify_results(save_file)
-    df.to_csv(save_file)
+    df.to_parquet(save_file)
     output.savefile_status(save_file=save_file)
 
     if plot_result:

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -61,12 +61,12 @@ class CaptureRunOutput(object):
 
         # Make sure to delete all the result that created by the run command.
         self.result_files = re.findall(
-            r'Saving result in: (.*\.csv)', self.output
+            r'Saving result in: (.*\.(csv|parquet))', self.output
         )
         if len(self.result_files) >= 1:
             for result_file in self.result_files:
                 result_path = Path(result_file)
-                result_path.unlink()  # remove csv file
+                result_path.unlink()  # remove result file
                 result_dir = result_path.parents[0]
                 stem = result_path.stem
                 for html_file in result_dir.glob(f'*{stem}*.html'):

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -61,7 +61,7 @@ class CaptureRunOutput(object):
 
         # Make sure to delete all the result that created by the run command.
         self.result_files = re.findall(
-            r'Saving result in: (.*\.csv|.*\.parquet)', self.output
+            r'Saving result in: (.*\.parquet)', self.output
         )
         if len(self.result_files) >= 1:
             for result_file in self.result_files:

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -61,7 +61,7 @@ class CaptureRunOutput(object):
 
         # Make sure to delete all the result that created by the run command.
         self.result_files = re.findall(
-            r'Saving result in: (.*\.(csv|parquet))', self.output
+            r'Saving result in: (.*\.csv|.*\.parquet)', self.output
         )
         if len(self.result_files) >= 1:
             for result_file in self.result_files:

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -301,7 +301,7 @@ class TestRunCmd:
             run(command, 'benchopt', standalone_mode=False)
 
         result_files = re.findall(
-            r'Saving result in: (.*\.(csv|parquet))', out.output
+            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
         )
         names = [Path(result_file).stem for result_file in result_files]
         assert names[0] == 'unique_name' and names[1] == 'unique_name_1'
@@ -420,7 +420,7 @@ class TestPlotCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_files = re.findall(
-            r'Saving result in: (.*\.(csv|parquet))', out.output
+            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
         )
         assert len(result_files) == 1, out.output
         result_file = result_files[0]
@@ -517,7 +517,7 @@ class TestGenerateResultCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_files = re.findall(
-            r'Saving result in: (.*\.(csv|parquet))', out.output
+            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
         )
         assert len(result_files) == 2, out.output
         cls.result_files = result_files
@@ -565,7 +565,7 @@ class TestArchiveCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_file = re.findall(
-            r'Saving result in: (.*\.(csv|parquet))', out.output
+            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
         )
         assert len(result_file) == 1, out.output
         cls.result_file = result_file[0]

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -300,7 +300,9 @@ class TestRunCmd:
             run(command, 'benchopt', standalone_mode=False)
             run(command, 'benchopt', standalone_mode=False)
 
-        result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
+        result_files = re.findall(
+            r'Saving result in: (.*\.(csv|parquet))', out.output
+        )
         names = [Path(result_file).stem for result_file in result_files]
         assert names[0] == 'unique_name' and names[1] == 'unique_name_1'
 
@@ -417,7 +419,9 @@ class TestPlotCmd:
                  '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-o',
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
-        result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
+        result_files = re.findall(
+            r'Saving result in: (.*\.(csv|parquet))', out.output
+        )
         assert len(result_files) == 1, out.output
         result_file = result_files[0]
         cls.result_file = result_file
@@ -512,7 +516,9 @@ class TestGenerateResultCmd:
                  '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-o',
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
-        result_files = re.findall(r'Saving result in: (.*\.csv)', out.output)
+        result_files = re.findall(
+            r'Saving result in: (.*\.(csv|parquet))', out.output
+        )
         assert len(result_files) == 2, out.output
         cls.result_files = result_files
 
@@ -558,7 +564,9 @@ class TestArchiveCmd:
                  '-s', SELECT_ONE_PGD, '-n', '2', '-r', '1', '-o',
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
-        result_file = re.findall(r'Saving result in: (.*\.csv)', out.output)
+        result_file = re.findall(
+            r'Saving result in: (.*\.(csv|parquet))', out.output
+        )
         assert len(result_file) == 1, out.output
         cls.result_file = result_file[0]
 

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -301,7 +301,7 @@ class TestRunCmd:
             run(command, 'benchopt', standalone_mode=False)
 
         result_files = re.findall(
-            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
+            r'Saving result in: (.*\.parquet)', out.output
         )
         names = [Path(result_file).stem for result_file in result_files]
         assert names[0] == 'unique_name' and names[1] == 'unique_name_1'
@@ -420,7 +420,7 @@ class TestPlotCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_files = re.findall(
-            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
+            r'Saving result in: (.*\.parquet)', out.output
         )
         assert len(result_files) == 1, out.output
         result_file = result_files[0]
@@ -517,7 +517,7 @@ class TestGenerateResultCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_files = re.findall(
-            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
+            r'Saving result in: (.*\.parquet)', out.output
         )
         assert len(result_files) == 2, out.output
         cls.result_files = result_files
@@ -565,7 +565,7 @@ class TestArchiveCmd:
                  SELECT_ONE_OBJECTIVE, '--no-plot'], 'benchopt',
                 standalone_mode=False)
         result_file = re.findall(
-            r'Saving result in: (.*\.csv|.*\.parquet)', out.output
+            r'Saving result in: (.*\.parquet)', out.output
         )
         assert len(result_file) == 1, out.output
         cls.result_file = result_file[0]

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -26,6 +26,8 @@ CLI
   files for sharing with others or as supplementary materials for papers.
   By `Thomas Moreau`_ (:gh:`408`).
 
+- Now the result data are saved in the Parquet format. The use of CSV file is deprecated.
+  By `Melvine Nargeot`_ (:gh:`433`).
 
 API
 ~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
     plotly>=4.12
     pyyaml
     line-profiler
+    pyarrow
+    fastparquet
 project_urls =
     Documentation = https://benchopt.github.io/
     Source = https://github.com/benchopt/benchopt

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ install_requires =
     pyyaml
     line-profiler
     pyarrow
-    fastparquet
 project_urls =
     Documentation = https://benchopt.github.io/
     Source = https://github.com/benchopt/benchopt


### PR DESCRIPTION
Parquet files are smaller than CSV files. So we change the CSV output by a Parquet file output.
Compatibility with previous CSV files is kept.

There is a new cli command to convert Parquet files to CSV file (or html or json) : 

`$ benchopt convert [parquet_file] --to [requested_format]`

TODO:
- [x] Choose between pyarrow and fastparquet packages
- [x] Test that everything works as expected with previous CSV files