### PR TITLE
FIX non-diverging negative losses

### DIFF
--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -186,7 +186,7 @@ class StoppingCriterion():
         n_eval = len(cost_curve) - 1
         objective_value = cost_curve[-1]['objective_value']
         delta_objective = self._prev_objective_value - objective_value
-        delta_objective /= cost_curve[0]['objective_value']
+        delta_objective /= abs(cost_curve[0]['objective_value'])
         self._prev_objective_value = objective_value
 
         # default value for is_flat
@@ -344,7 +344,7 @@ class SufficientDescentCriterion(StoppingCriterion):
         # Compute the current objective
         objective_value = cost_curve[-1]['objective_value']
         delta_objective = self._objective_value - objective_value
-        delta_objective /= cost_curve[0]['objective_value']
+        delta_objective /= abs(cost_curve[0]['objective_value'])
         self._objective_value = objective_value
 
         # Store only the last ``patience`` values for progress
@@ -419,7 +419,7 @@ class SufficientProgressCriterion(StoppingCriterion):
         # Compute the current objective and update best value
         objective_value = cost_curve[-1]['objective_value']
         delta_objective = self._best_objective_value - objective_value
-        delta_objective /= cost_curve[0]['objective_value']
+        delta_objective /= abs(cost_curve[0]['objective_value'])
         self._best_objective_value = min(
             objective_value, self._best_objective_value
         )


### PR DESCRIPTION
This should fix the issue from benchopt/benchmark_jointdiag#4.

The issue is that we rescale the delta by `loss[0]` so for negative losses this reverses the dynamic. I added some absolute value to avoid this.
Let me know if this fixes the issue.