### PR TITLE
ENH add option for positive simulated data in make_correlated_data

### DIFF
--- a/benchopt/datasets/simulated.py
+++ b/benchopt/datasets/simulated.py
@@ -7,7 +7,8 @@ from ..utils.checkers import check_random_state
 
 def make_correlated_data(
         n_samples=100, n_features=50, n_tasks=1, rho=0.6, snr=3,
-        w_true=None, density=0.2, X_density=1, random_state=None):
+        w_true=None, density=0.2, X_density=1, random_state=None,
+        pos_data=False):
     r"""Generate a linear regression with decaying correlation for the design
     matrix :math:`\rho^{|i-j|}`.
 
@@ -51,6 +52,8 @@ def make_correlated_data(
         make the randomness deterministic.
     X_density: float in ]0, 1]
         Proportion of elements of X which are non-zero.
+    pos_data: boolean
+        Generate non-negative data (both design matrix and observation vector)
 
     Returns
     -------
@@ -101,6 +104,10 @@ def make_correlated_data(
     else:
         if w_true.ndim == 1:
             w_true = w_true[:, None]
+
+    if pos_data:
+        X = abs(X)
+        w_true = abs(w_true)
 
     Y = X @ w_true
     noise = rng.randn(n_samples, n_tasks)

--- a/benchopt/datasets/simulated.py
+++ b/benchopt/datasets/simulated.py
@@ -52,7 +52,7 @@ def make_correlated_data(
         make the randomness deterministic.
     X_density: float in ]0, 1]
         Proportion of elements of X which are non-zero.
-    pos_data: boolean
+    positive: bool
         Generate non-negative data (both design matrix and observation vector)
 
     Returns

--- a/benchopt/datasets/simulated.py
+++ b/benchopt/datasets/simulated.py
@@ -8,7 +8,7 @@ from ..utils.checkers import check_random_state
 def make_correlated_data(
         n_samples=100, n_features=50, n_tasks=1, rho=0.6, snr=3,
         w_true=None, density=0.2, X_density=1, random_state=None,
-        pos_data=False):
+        positive=False):
     r"""Generate a linear regression with decaying correlation for the design
     matrix :math:`\rho^{|i-j|}`.
 

--- a/benchopt/datasets/simulated.py
+++ b/benchopt/datasets/simulated.py
@@ -105,9 +105,9 @@ def make_correlated_data(
         if w_true.ndim == 1:
             w_true = w_true[:, None]
 
-    if pos_data:
-        X = abs(X)
-        w_true = abs(w_true)
+    if positive:
+        X = np.abs(X)
+        w_true = np.abs(w_true)
 
     Y = X @ w_true
     noise = rng.randn(n_samples, n_tasks)

--- a/benchopt/datasets/tests/test_dataset_simulated.py
+++ b/benchopt/datasets/tests/test_dataset_simulated.py
@@ -81,6 +81,14 @@ def test_correlated_sparse_X(X_density):
                 rtol=0.05)
 
 
+@pytest.mark.parametrize('positive', [True, False])
+def test_correlated_positive(positive):
+    X, y, w_true = make_correlated_data(positive=positive)
+
+    # check that X and w_true have only non-negative entries
+    assert np.all(X>=0) and np.all(w_true>=0)
+
+
 @pytest.mark.parametrize('param_name, p_range', [
     ('rho', [0, 1]), ('density', [0, 1]), ('snr', [0, np.inf])
 ])


### PR DESCRIPTION
This feature is necessary for the NNLS benchmark (see benchopt/benchmark_nnls#12)