### PR TITLE
fix for objective and solvers returning list of arrays

### DIFF
--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -232,7 +232,7 @@ def _test_solver_one_objective(solver, objective):
             if isinstance(beta_hat, np.ndarray):
                 eps = 1e-5 * np.random.randn(*beta_hat.shape)
                 val_eps = objective(beta_hat + eps)['objective_value']
-            else: # assume list of arrays is returned
+            else:  # assume list of arrays is returned
                 val_eps = objective(
                     [b + 1e-5 * np.random.randn(*b.shape) for b in beta_hat])
 

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -229,7 +229,12 @@ def _test_solver_one_objective(solver, objective):
     if is_convex:
         val_star = objective(beta_hat)['objective_value']
         for _ in range(100):
-            eps = 1e-5 * np.random.randn(*beta_hat.shape)
-            val_eps = objective(beta_hat + eps)['objective_value']
+            if isinstance(beta_hat, np.ndarray):
+                eps = 1e-5 * np.random.randn(*beta_hat.shape)
+                val_eps = objective(beta_hat + eps)['objective_value']
+            else: # assume list of arrays is returned
+                val_eps = objective(
+                    [b + 1e-5 * np.random.randn(*b.shape) for b in beta_hat])
+
             diff = val_eps - val_star
             assert diff >= 0


### PR DESCRIPTION
In the NMF benchmark beta is a list of two arrays of different shapes, so the current test code fails
https://github.com/cohenjer/benchmark-nmf/blob/main/solvers/apg.py#L33

https://github.com/cohenjer/benchmark-nmf/blob/main/solvers/apg.py#L59

https://github.com/cohenjer/benchmark-nmf/runs/7410359135?check_suite_focus=true#step:6:451


@cohenjer