### PR TITLE
FIX import error in utils displayed

### DIFF
--- a/benchopt/utils/dynamic_modules.py
+++ b/benchopt/utils/dynamic_modules.py
@@ -29,8 +29,8 @@ def _get_module_from_file(module_filename, benchmark_dir=None):
             package_name, module_filename
         )
         module = importlib.util.module_from_spec(spec)
-        sys.modules[package_name] = module
         spec.loader.exec_module(module)
+        sys.modules[package_name] = module
     return module
 
 


### PR DESCRIPTION
The import error for files in a benchmark `utils` were not displayed, which leaded to cryptic errors:
![image](https://user-images.githubusercontent.com/3321081/186610857-09d28eb1-ecff-48c6-b2d0-87b6cdf53b46.png)

This PR makes it much clearer:
![image](https://user-images.githubusercontent.com/3321081/186610692-2b585f3c-685b-47f1-bb86-087179643837.png)

closes #436 