### PR TITLE
FIX create config file with mode 600 in cli set()

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -17,9 +17,9 @@ from benchopt.cli.completion import complete_datasets
 from benchopt.cli.completion import complete_solvers
 from benchopt.utils.conda_env_cmd import list_conda_envs
 from benchopt.config import get_global_config_file
+from benchopt.config import GLOBAL_CONFIG_FILE_MODE
 from benchopt.utils.dynamic_modules import _load_class_from_module
 from benchopt.utils.shell_cmd import _run_shell_in_conda_env
-
 from benchopt.utils.terminal_output import colorify
 from benchopt.utils.terminal_output import RED, GREEN, TICK, CROSS
 
@@ -145,7 +145,7 @@ def check_conda_env(env_name, benchmark_name=None):
         default_conda_env, conda_envs = list_conda_envs()
 
         # If env_name is False (default), check availability
-        # in the current environement.
+        # in the current environment.
         if env_name == 'False':
             # check if any current conda environment
             if default_conda_env is not None:
@@ -399,7 +399,7 @@ def set(ctx, name, values, append=False):
     benchmark_name = ctx.obj['benchmark_name']
     if not config.exists():
         config.parent.mkdir(exist_ok=True, parents=True)
-        config.touch()
+        config.touch(mode=GLOBAL_CONFIG_FILE_MODE)
 
     if append:
         current_value = get_setting(


### PR DESCRIPTION
Closes #336 @zaccharieramzi could you delete `.config/benchopt.ini`, call `benchopt config set conda_cmd mamba` and see if the file has the proper mode now?