### PR TITLE
FIX - remove debugging print left from PR#461

### DIFF
--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -195,7 +195,6 @@ class StoppingCriterion():
         delta_objective = self._prev_objective - objective
         delta_objective /= abs(cost_curve[0][self.key_to_monitor])
         self._prev_objective = objective
-        print(delta_objective)
 
         # default value for is_flat
         is_flat = False


### PR DESCRIPTION
Following the merge of #461, a print used for debugging slipped through to the code base.

Example of logs that one gets when running a benchmark
```shell
Simulated[a=2,b=-5]                                                                                                                                                                                   
  |--Affine[with_exp=True]                                                                                                                                                                            
1.484131591025766e+102piness=very-dump]: initialization (1 / 1 reps)                                                                                                                                  
0.8646647167633873[dumpiness=very-dump]:   0.0% (1 / 1 reps)                                                                                                                                          
0.11701964434787851dumpiness=very-dump]:   4.0% (1 / 1 reps)                                                                                                                                          
0.015836886712067823umpiness=very-dump]:   8.0% (1 / 1 reps)                                                                                                                                          
0.0021432895487638465mpiness=very-dump]:  12.0% (1 / 1 reps)                                                                                                                                          
0.00032931841554918365piness=very-dump]:  16.0% (1 / 1 reps)     
```