### PR TITLE
PLT - add visualization of objective as function of ``stop_val``

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -182,12 +182,12 @@ def shape_solvers_for_html(df, objective_column):
         df_filtered = df_filtered.dropna(subset=[objective_column])
 
         q1, q9 = compute_quantiles(df_filtered)
+        groupby_stop_val_median = df_filtered.groupby('stop_val').median()
         solver_data[solver] = {
             'scatter': {
-                'x': df_filtered.groupby('stop_val')['time']
-                                .median().tolist(),
-                'y': df_filtered.groupby('stop_val')[objective_column]
-                                .median().tolist(),
+                'x': groupby_stop_val_median['time'].tolist(),
+                'y': groupby_stop_val_median[objective_column].tolist(),
+                'stop_val': groupby_stop_val_median.index.tolist(),
                 'q1': q1.tolist(),
                 'q9': q9.tolist(),
             },

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -185,6 +185,17 @@ def shape_solvers_for_html(df, objective_column):
         color, marker = get_solver_style(solver)
 
         stopping_strategy = df_filtered['stopping_strategy'].unique()
+
+        if len(stopping_strategy) != 1:
+            found_stopping_strategies = ', '.join(
+                f"`{item}`" for item in stopping_strategy)
+
+            raise Exception(
+                "Solver can be run using only one stopping strategy. "
+                f"Expected one stopping strategy "
+                f"but found {found_stopping_strategies}"
+            )
+
         stopping_strategy = stopping_strategy[0]
 
         solver_data[solver] = {

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -183,7 +183,10 @@ def shape_solvers_for_html(df, objective_column):
         q1, q9 = compute_quantiles(df_filtered)
         groupby_stop_val_median = df_filtered.groupby('stop_val').median()
         color, marker = get_solver_style(solver)
-        stopping_strategy = df_filtered['stopping_strategy'][0]
+
+        stopping_strategy = df_filtered['stopping_strategy'].unique()
+        stopping_strategy = stopping_strategy[0]
+
         solver_data[solver] = {
             'scatter': {
                 'x': groupby_stop_val_median['time'].tolist(),

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -183,6 +183,7 @@ def shape_solvers_for_html(df, objective_column):
         q1, q9 = compute_quantiles(df_filtered)
         groupby_stop_val_median = df_filtered.groupby('stop_val').median()
         color, marker = get_solver_style(solver)
+        stopping_strategy = df_filtered['stopping_strategy'][0]
         solver_data[solver] = {
             'scatter': {
                 'x': groupby_stop_val_median['time'].tolist(),
@@ -195,7 +196,8 @@ def shape_solvers_for_html(df, objective_column):
                 **computeBarChartData(df, objective_column, solver)
             },
             'color': color,
-            'marker': marker
+            'marker': marker,
+            'stopping_strategy': stopping_strategy
         }
 
     return solver_data

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -188,7 +188,8 @@ def shape_solvers_for_html(df, objective_column):
 
         if len(stopping_strategy) != 1:
             found_stopping_strategies = ', '.join(
-                f"`{item}`" for item in stopping_strategy)
+                f"`{item}`" for item in stopping_strategy
+            )
 
             raise Exception(
                 "Solver can be run using only one stopping strategy. "

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -136,7 +136,7 @@ const getScatterCurves = () => {
       legendgroup: solver,
       hovertemplate: solver + ' <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
       visible: isVisible(solver) ? true : 'legendonly',
-      x: data(solver).scatter.x,
+      x: (!state().xaxis_with_iteration) ? data(solver).scatter.x :  [...Array(data(solver).scatter.x.length).keys()],
       y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
     });
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -153,18 +153,14 @@ const getScatterCurves = () => {
       y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
     });
 
+    // skip plotting quantiles if xaxis is not time
+    // as stop_val are predefined and hence deterministic 
+    if(xaxisType !== "time") {
+      return
+    }
+
     if (state().with_quantiles) {
       // Add shaded area for each solver, with proper style and visibility.
-
-      solverStoppingStrategy = data(solver)['stopping_strategy'];
-
-      // plot only solvers that were stopped using xaxis type
-      // plot all solver if xaxis type is `time`
-      if(xaxisType !== "time" && solverStoppingStrategy !== xaxisType) {
-        return
-      }
-
-      scatterXaxisProperties = xaxisType === "time" ? ['q1', 'q9'] : ['stop_val', 'stop_val'];
   
       curves.push({
         type: 'scatter',
@@ -177,7 +173,7 @@ const getScatterCurves = () => {
         legendgroup: solver,
         hovertemplate: '(%{x:.1e},%{y:.1e}) <extra></extra>',
         visible: isVisible(solver) ? true : 'legendonly',
-        x: data(solver).scatter[scatterXaxisProperties[0]],
+        x: data(solver).scatter['q1'],
         y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
       }, {
         type: 'scatter',
@@ -191,7 +187,7 @@ const getScatterCurves = () => {
         legendgroup: solver,
         hovertemplate: '(%{x:.1e},%{y:.1e}) <extra></extra>',
         visible: isVisible(solver) ? true : 'legendonly',
-        x: data(solver).scatter[scatterXaxisProperties[1]],
+        x: data(solver).scatter['q9'],
         y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
       });
     }

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -121,7 +121,19 @@ const getScatterCurves = () => {
   const curves = [];
 
   // For each solver, add the median curve with proper style and visibility.
+  xaxisType = state().xaxis_type
+
   getSolvers().forEach(solver => {
+    solverStoppingStrategy = data(solver)['stopping_strategy'];
+
+    // plot only solvers that were stopped using xaxis type
+    // plot all solver if xaxis type is `time`
+    if(xaxisType !== "time" && solverStoppingStrategy !== xaxisType) {
+      return
+    }
+
+    ScatterXaxisProperty = xaxisType === "time" ? 'x' : 'stop_val';
+
     curves.push({
       type: 'scatter',
       name: solver,
@@ -136,12 +148,23 @@ const getScatterCurves = () => {
       legendgroup: solver,
       hovertemplate: solver + ' <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
       visible: isVisible(solver) ? true : 'legendonly',
-      x: data(solver).scatter['x'],
+      x: data(solver).scatter[ScatterXaxisProperty],
       y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
     });
 
     if (state().with_quantiles) {
       // Add shaded area for each solver, with proper style and visibility.
+
+      solverStoppingStrategy = data(solver)['stopping_strategy'];
+
+      // plot only solvers that were stopped using xaxis type
+      // plot all solver if xaxis type is `time`
+      if(xaxisType !== "time" && solverStoppingStrategy !== xaxisType) {
+        return
+      }
+
+      scatterXaxisProperties = xaxisType === "time" ? ['q1', 'q9'] : ['stop_val', 'stop_val'];
+  
       curves.push({
         type: 'scatter',
         mode: 'lines',
@@ -153,7 +176,7 @@ const getScatterCurves = () => {
         legendgroup: solver,
         hovertemplate: '(%{x:.1e},%{y:.1e}) <extra></extra>',
         visible: isVisible(solver) ? true : 'legendonly',
-        x: data(solver).scatter.q1,
+        x: data(solver).scatter[scatterXaxisProperties[0]],
         y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
       }, {
         type: 'scatter',
@@ -167,7 +190,7 @@ const getScatterCurves = () => {
         legendgroup: solver,
         hovertemplate: '(%{x:.1e},%{y:.1e}) <extra></extra>',
         visible: isVisible(solver) ? true : 'legendonly',
-        x: data(solver).scatter.q9,
+        x: data(solver).scatter[scatterXaxisProperties[1]],
         y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
       });
     }

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -121,6 +121,7 @@ const getScatterCurves = () => {
   const curves = [];
 
   // For each solver, add the median curve with proper style and visibility.
+  let timeOrStopVal = (state().xaxis_with_stop_val) ? 'stop_val' : 'x';
   getSolvers().forEach(solver => {
     curves.push({
       type: 'scatter',
@@ -136,7 +137,7 @@ const getScatterCurves = () => {
       legendgroup: solver,
       hovertemplate: solver + ' <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
       visible: isVisible(solver) ? true : 'legendonly',
-      x: (!state().xaxis_with_iteration) ? data(solver).scatter.x :  [...Array(data(solver).scatter.x.length).keys()],
+      x: data(solver).scatter[timeOrStopVal] ,
       y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
     });
 
@@ -343,6 +344,7 @@ const getScale = () => {
 }
 
 const getScatterChartLayout = () => {
+  let withStopVal = state().xaxis_with_stop_val;
   const layout = {
     autosize: !isSmallScreen(),
     modebar: {
@@ -362,7 +364,7 @@ const getScatterChartLayout = () => {
     },
     xaxis: {
       type: getScale().xaxis,
-      title: 'Time [sec]',
+      title: withStopVal ? 'Stop value': 'Time [sec]',
       tickformat: '.1e',
       tickangle: -45,
       gridcolor: '#ffffff',

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -32,6 +32,7 @@ const NON_CONVERGENT_COLOR = 'rgba(0.8627, 0.8627, 0.8627)'
 const setState = (partialState) => {
   window.state = {...state(), ...partialState};
   displayScatterElements(!isBarChart());
+  updateXaxis();
   makePlot();
   makeLegend();
 }
@@ -121,7 +122,7 @@ const getScatterCurves = () => {
   const curves = [];
 
   // For each solver, add the median curve with proper style and visibility.
-  xaxisType = state().xaxis_type
+  let xaxisType = state().xaxis_type || "time";
 
   getSolvers().forEach(solver => {
     solverStoppingStrategy = data(solver)['stopping_strategy'];
@@ -644,6 +645,32 @@ const createLegendItem = (solver, color, symbolNumber) => {
   item.appendChild(textContainer);
 
   return item;
+}
+
+
+function updateXaxis() {
+  let selection = document.getElementById("change_xaxis_type");
+  selection.innerHTML = "";
+
+  let xaxisType = state()["xaxis_type"];
+  let options = new Set(['time']);
+
+  // get solvers run for selected (dataset, objective, objective colum)
+  // and select their unique stopping strategies
+  let solvers = data()['solvers'];
+  Object.values(solvers).forEach(solver => options.add(solver['stopping_strategy']));
+
+  // create xaxis type options
+  options.forEach(option => {
+    element = document.createElement('option');
+    element.setAttribute('value', option);
+    element.innerText = option;
+
+    selection.append(element);
+  });
+
+  // set selected value
+  selection.value = options.has(xaxisType) ? xaxisType : "time";
 }
 
 /**

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -121,7 +121,6 @@ const getScatterCurves = () => {
   const curves = [];
 
   // For each solver, add the median curve with proper style and visibility.
-  let timeOrStopVal = (state().xaxis_with_stop_val) ? 'stop_val' : 'x';
   getSolvers().forEach(solver => {
     curves.push({
       type: 'scatter',
@@ -137,7 +136,7 @@ const getScatterCurves = () => {
       legendgroup: solver,
       hovertemplate: solver + ' <br> (%{x:.1e},%{y:.1e}) <extra></extra>',
       visible: isVisible(solver) ? true : 'legendonly',
-      x: data(solver).scatter[timeOrStopVal] ,
+      x: data(solver).scatter['x'],
       y: useTransformer(data(solver).scatter.y, 'y', data().transformers),
     });
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -32,7 +32,13 @@ const NON_CONVERGENT_COLOR = 'rgba(0.8627, 0.8627, 0.8627)'
 const setState = (partialState) => {
   window.state = {...state(), ...partialState};
   displayScatterElements(!isBarChart());
-  updateXaxis();
+
+  // TODO: `listIdXaxisSelection` to be removed after 
+  // implementing responsiveness through breakpoints 
+  // and removing content duplication between big screen and mobile
+  let listIdXaxisSelection = ["change_xaxis_type", "change_xaxis_type_mobile"];
+  listIdXaxisSelection.forEach(idXaxisSelection => updateXaxis(idXaxisSelection))
+
   makePlot();
   makeLegend();
 }
@@ -645,8 +651,8 @@ const createLegendItem = (solver, color, symbolNumber) => {
 }
 
 
-function updateXaxis() {
-  let selection = document.getElementById("change_xaxis_type");
+function updateXaxis(idXaxisTypeSelection) {
+  let selection = document.getElementById(idXaxisTypeSelection);
   selection.innerHTML = "";
 
   let xaxisType = state()["xaxis_type"];

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -122,7 +122,7 @@ const getScatterCurves = () => {
   const curves = [];
 
   // For each solver, add the median curve with proper style and visibility.
-  let xaxisType = state().xaxis_type || "time";
+  let xaxisType = state().xaxis_type;
 
   getSolvers().forEach(solver => {
     solverStoppingStrategy = data(solver)['stopping_strategy'];
@@ -363,7 +363,8 @@ const getScale = () => {
 }
 
 const getScatterChartLayout = () => {
-  let withStopVal = state().xaxis_with_stop_val;
+  let xaxisType = state().xaxis_type;
+
   const layout = {
     autosize: !isSmallScreen(),
     modebar: {
@@ -383,8 +384,8 @@ const getScatterChartLayout = () => {
     },
     xaxis: {
       type: getScale().xaxis,
-      title: withStopVal ? 'Stop value': 'Time [sec]',
-      tickformat: '.1e',
+      title: xaxisType === "time" ? "Time [sec]": xaxisType,
+      tickformat: xaxisType === "time" ? '.1e': '',
       tickangle: -45,
       gridcolor: '#ffffff',
       zeroline : false,

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -135,11 +135,11 @@ const getScatterCurves = () => {
 
     // plot only solvers that were stopped using xaxis type
     // plot all solver if xaxis type is `time`
-    if(xaxisType !== "time" && solverStoppingStrategy !== xaxisType) {
+    if(xaxisType !== "Time" && solverStoppingStrategy !== xaxisType) {
       return
     }
 
-    ScatterXaxisProperty = xaxisType === "time" ? 'x' : 'stop_val';
+    ScatterXaxisProperty = xaxisType === "Time" ? 'x' : 'stop_val';
 
     curves.push({
       type: 'scatter',
@@ -161,7 +161,7 @@ const getScatterCurves = () => {
 
     // skip plotting quantiles if xaxis is not time
     // as stop_val are predefined and hence deterministic 
-    if(xaxisType !== "time") {
+    if(xaxisType !== "Time") {
       return
     }
 
@@ -390,8 +390,8 @@ const getScatterChartLayout = () => {
     },
     xaxis: {
       type: getScale().xaxis,
-      title: xaxisType === "time" ? "Time [sec]": xaxisType,
-      tickformat: xaxisType === "time" ? '.1e': '',
+      title: xaxisType === "Time" ? "Time [sec]": xaxisType,
+      tickformat:  ["Time", "Tolerance"].includes(xaxisType) ? '.1e': '',
       tickangle: -45,
       gridcolor: '#ffffff',
       zeroline : false,
@@ -656,7 +656,7 @@ function updateXaxis(idXaxisTypeSelection) {
   selection.innerHTML = "";
 
   let xaxisType = state()["xaxis_type"];
-  let options = new Set(['time']);
+  let options = new Set(['Time']);
 
   // get solvers run for selected (dataset, objective, objective colum)
   // and select their unique stopping strategies
@@ -673,7 +673,7 @@ function updateXaxis(idXaxisTypeSelection) {
   });
 
   // set selected value
-  selection.value = options.has(xaxisType) ? xaxisType : "time";
+  selection.value = options.has(xaxisType) ? xaxisType : "Time";
 }
 
 /**

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -93,9 +93,9 @@
                             </label>
                         </div>
                         <div class="flex items-center justify-between mt-8 px-8">
-                            <div class="block text-sm font-medium text-white">Iterations</div>
+                            <div class="block text-sm font-medium text-white">Stopping criterion</div>
                             <label class="block switch">
-                                <input id="xaxis_with_iteration" type="checkbox" checked onchange="setState({xaxis_with_iteration: this.checked})"">
+                                <input id="xaxis_with_stop_val" type="checkbox" onchange="setState({xaxis_with_stop_val: this.checked})"">
                                 <span class="slider round"></span>
                             </label>
                         </div>
@@ -386,7 +386,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
-                    'xaxis_with_iteration':  document.getElementById('xaxis_with_iteration').checked,
+                    'xaxis_with_stop_val':  document.getElementById('xaxis_with_stop_val').checked,
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -85,22 +85,20 @@
                                 </select>
                             </div>
                         </div>
+                        <div id="xaxis-type-form-group" class="mt-8 px-8">
+                            <label for="change_scaling" class="block text-sm font-medium text-white">X-axis</label>
+                            <div class="mt-1 rounded-md shadow-sm">
+                                <select id="change_xaxis_type" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
+                                   <!-- options will be added dynamically -->
+                                </select>
+                            </div>
+                        </div>
                         <div class="flex items-center justify-between mt-8 px-8">
                             <div class="block text-sm font-medium text-white">Quantiles</div>
                             <label class="block switch">
                                 <input id="change_shades" type="checkbox" checked onchange="setState({with_quantiles: this.checked})">
                                 <span class="slider round"></span>
                             </label>
-                        </div>
-                        <div id="xaxis-type-form-group" class="mt-8 px-8">
-                            <label for="change_scaling" class="block text-sm font-medium text-white">X axis type</label>
-                            <div class="mt-1 rounded-md shadow-sm">
-                                <select id="change_xaxis_type" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
-                                    <option value="time">Time</option>
-                                    <option value="iteration">Iteration</option>
-                                    <option value="tolerance">Tolerance</option>
-                                </select>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -395,7 +395,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
-                    'xaxis_type':  document.getElementById('change_xaxis_type').value || "time",
+                    'xaxis_type':  document.getElementById('change_xaxis_type').value || "Time",
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -225,6 +225,14 @@
                                     </select>
                                 </div>
                             </div>
+                            <div id="xaxis-type-form-group" class="mt-8 px-8">
+                                <label for="change_scaling" class="block text-sm font-medium text-white">X-axis</label>
+                                <div class="mt-1 rounded-md shadow-sm">
+                                    <select id="change_xaxis_type_mobile" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
+                                       <!-- options will be added dynamically -->
+                                    </select>
+                                </div>
+                            </div>
                             <div class="flex items-center justify-between mt-8 px-8">
                                 <div class="block text-sm font-medium text-white">Quantiles</div>
                                 <label class="block switch">

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -92,6 +92,13 @@
                                 <span class="slider round"></span>
                             </label>
                         </div>
+                        <div class="flex items-center justify-between mt-8 px-8">
+                            <div class="block text-sm font-medium text-white">Iterations</div>
+                            <label class="block switch">
+                                <input id="xaxis_with_iteration" type="checkbox" checked onchange="setState({xaxis_with_iteration: this.checked})"">
+                                <span class="slider round"></span>
+                            </label>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -379,6 +386,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
+                    'xaxis_with_iteration':  document.getElementById('xaxis_with_iteration').checked,
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -92,12 +92,15 @@
                                 <span class="slider round"></span>
                             </label>
                         </div>
-                        <div class="flex items-center justify-between mt-8 px-8">
-                            <div class="block text-sm font-medium text-white">Stopping criterion</div>
-                            <label class="block switch">
-                                <input id="xaxis_with_stop_val" type="checkbox" onchange="setState({xaxis_with_stop_val: this.checked})"">
-                                <span class="slider round"></span>
-                            </label>
+                        <div id="xaxis-type-form-group" class="mt-8 px-8">
+                            <label for="change_scaling" class="block text-sm font-medium text-white">X axis type</label>
+                            <div class="mt-1 rounded-md shadow-sm">
+                                <select id="change_xaxis_type" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
+                                    <option value="time">Time</option>
+                                    <option value="iteration">Iteration</option>
+                                    <option value="tolerance">Tolerance</option>
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -386,7 +389,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
-                    'xaxis_with_stop_val':  document.getElementById('xaxis_with_stop_val').checked,
+                    'xaxis_type':  document.getElementById('change_xaxis_type').value,
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -387,7 +387,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
-                    'xaxis_type':  document.getElementById('change_xaxis_type').value,
+                    'xaxis_type':  document.getElementById('change_xaxis_type').value || "time",
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -180,6 +180,13 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
 
     states = []
     run_statistics = []
+
+    # get stopping strategy
+    # for plotting purpose consider 'callback' as 'iteration'
+    stopping_strategy = solver._solver_strategy
+    if stopping_strategy == 'callback':
+        stopping_strategy = 'iteration'
+
     for rep in range(n_repetitions):
 
         output.set(rep=rep)
@@ -189,7 +196,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
-            stopping_strategy=solver._solver_strategy
+            stopping_strategy=stopping_strategy
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -189,6 +189,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
+            stopping_strategy=solver._solver_strategy
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -196,7 +196,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
-            stopping_strategy=stopping_strategy
+            stopping_strategy=stopping_strategy.capitalize()
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(


### PR DESCRIPTION
This adds a toggle to enable visualizing the objectives as function `stop_val`, namely ``n_iter``.

[Link to a dummy benchmark ](https://badr-moufad.github.io/share-benchmarks/stop_val_plot/validate-plotting-stop-val_benchopt_run_2022-11-09_20h57m17.html) to preview the feature. (credit to @mathurinm for the idea of the benchmark).
A link to the [benchmark repo ](https://github.com/Badr-MOUFAD/validate-plotting-stop-val) to reproduce.

-----------------------

PR related to #287 