### PR TITLE
FIX detection of csv files when plotting with option --all

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -220,12 +220,20 @@ class Benchmark:
             if filename == 'all':
                 result_filename = all_result_files
 
-        if result_filename.suffix == ".csv":
-            print(colorify(
-                "WARNING: CSV files are deprecated."
-                "Please use Parquet files instead.",
-                YELLOW
-            ))
+        if isinstance(result_filename, list):
+            if any(fname.suffix == ".csv" for fname in result_filename):
+                print(colorify(
+                    "WARNING: CSV files are deprecated."
+                    "Please use Parquet files instead.",
+                    YELLOW
+                ))
+        else:
+            if result_filename.suffix == ".csv":
+                print(colorify(
+                    "WARNING: CSV files are deprecated."
+                    "Please use Parquet files instead.",
+                    YELLOW
+                ))
 
         return result_filename
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -221,19 +221,17 @@ class Benchmark:
                 result_filename = all_result_files
 
         if isinstance(result_filename, list):
-            if any(fname.suffix == ".csv" for fname in result_filename):
-                print(colorify(
-                    "WARNING: CSV files are deprecated."
-                    "Please use Parquet files instead.",
-                    YELLOW
-                ))
+            is_csv_file = any(fname.suffix == ".csv"
+                              for fname in result_filename)
         else:
-            if result_filename.suffix == ".csv":
-                print(colorify(
-                    "WARNING: CSV files are deprecated."
-                    "Please use Parquet files instead.",
-                    YELLOW
-                ))
+            is_csv_file = result_filename.suffix == ".csv"
+
+        if is_csv_file:
+            print(colorify(
+                "WARNING: CSV files are deprecated."
+                "Please use Parquet files instead.",
+                YELLOW
+            ))
 
         return result_filename
 


### PR DESCRIPTION
When running `benchopt plot --all`, the variable `result_filename` is a list and so hasn't a `suffix` attribute. This PR handle this case.