### PR TITLE
ENH min benchopt version

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -48,6 +48,7 @@ class Benchmark:
         try:
             objective = self.get_benchmark_objective()
             self.pretty_name = objective.name
+            self.min_version = getattr(objective, 'min_benchopt_version', None)
         except RuntimeError:
             raise click.BadParameter(
                 f"The folder '{benchmark_dir}' does not contain "

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -200,6 +200,16 @@ def run(config_file=None, **kwargs):
     # Create the Benchmark object
     benchmark = Benchmark(benchmark)
 
+    if benchmark.min_version is not None:
+        from packaging.version import parse
+        from benchopt import __version__
+        if parse(__version__) < parse(benchmark.min_version):
+            raise RuntimeError(
+                "benchopt version is too old to run this benchmark. "
+                "Please update benchopt with `pip install -U benchopt` "
+                "for this benchmark."
+            )
+
     # If env_name is False, the flag `--local` has been used (default) so
     # run in the current environment.
     if env_name == 'False':
@@ -391,7 +401,6 @@ def install(
 
     # Check that the dataset/solver patterns match actual dataset
     benchmark = Benchmark(benchmark)
-    print(f"Installing '{benchmark.name}' requirements")
     benchmark.validate_dataset_patterns(dataset_names)
     benchmark.validate_solver_patterns(solver_names)
 
@@ -406,6 +415,7 @@ def install(
             "'benchopt install'."
         )
 
+    print(f"Installing '{benchmark.name}' requirements")
     # If env_name is False (default), installation in the current environment.
     if env_name == 'False':
         env_name = None

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -203,7 +203,10 @@ def run(config_file=None, **kwargs):
     if benchmark.min_version is not None:
         from packaging.version import parse
         from benchopt import __version__
-        if parse(__version__) < parse(benchmark.min_version):
+
+        # Avoid dev versions
+        normalized_version = parse(parse(__version__).base_version)
+        if normalized_version < parse(benchmark.min_version):
             raise RuntimeError(
                 f"benchopt version {__version__} is too old to run this  "
                 f"benchmark, version {benchmark.min_version} is required. "

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -205,7 +205,8 @@ def run(config_file=None, **kwargs):
         from benchopt import __version__
         if parse(__version__) < parse(benchmark.min_version):
             raise RuntimeError(
-                "benchopt version is too old to run this benchmark. "
+                f"benchopt version {__version__} is too old to run this  "
+                f"benchmark, version {benchmark.min_version} is required. "
                 "Please update benchopt with `pip install -U benchopt` "
                 "for this benchmark."
             )

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -9,6 +9,7 @@ from benchopt.utils.stream_redirection import SuppressStd
 # Default benchmark
 TEST_BENCHMARK_DIR = Path(__file__).parent / 'test_benchmarks'
 DUMMY_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'dummy_benchmark'
+FUTURE_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'future_benchmark'
 REQUIREMENT_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'requirement_benchmark'
 
 # Pattern to select specific datasets or solvers.

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -9,8 +9,8 @@ from benchopt.utils.stream_redirection import SuppressStd
 # Default benchmark
 TEST_BENCHMARK_DIR = Path(__file__).parent / 'test_benchmarks'
 DUMMY_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'dummy_benchmark'
-FUTURE_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'future_benchmark'
 REQUIREMENT_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'requirement_benchmark'
+FUTURE_BENCHMARK_PATH = TEST_BENCHMARK_DIR / 'future_benchmark'
 
 # Pattern to select specific datasets or solvers.
 SELECT_ONE_SIMULATED = r'simulated[n_features=200,rho=0]'
@@ -22,14 +22,12 @@ try:
 except Exception:
     DUMMY_BENCHMARK = None
 try:
-    REQUIREMENT_BENCHMARK = Benchmark(REQUIREMENT_BENCHMARK_PATH)
     TEST_OBJECTIVE = DUMMY_BENCHMARK.get_benchmark_objective()
     TEST_SOLVER = [s for s in DUMMY_BENCHMARK.get_solvers()
                    if s.name == "Test-Solver"][0]
     TEST_DATASET = [d for d in DUMMY_BENCHMARK.get_datasets()
                     if d.name == "Test-Dataset"][0]
 except Exception:
-    REQUIREMENT_BENCHMARK = None
     TEST_OBJECTIVE = None
     TEST_SOLVER = None
     TEST_DATASET = None

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -1,7 +1,12 @@
 import pytest
 
 from benchopt.cli.main import run
+from benchopt.tests import CaptureRunOutput
+from benchopt.tests import SELECT_ONE_PGD
+from benchopt.tests import SELECT_ONE_SIMULATED
+from benchopt.tests import SELECT_ONE_OBJECTIVE
 from benchopt.tests import DUMMY_BENCHMARK
+from benchopt.tests import DUMMY_BENCHMARK_PATH
 from benchopt.tests import FUTURE_BENCHMARK_PATH
 from benchopt.utils.dynamic_modules import _load_class_from_module
 
@@ -40,3 +45,12 @@ def test_benchopt_min_version():
     # Make sure that importing template_dataset raises an error.
     with pytest.raises(RuntimeError, match="pip install -U"):
         run([str(FUTURE_BENCHMARK_PATH)], 'benchopt', standalone_mode=False)
+
+    with CaptureRunOutput() as out:
+        run([
+            str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
+            '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-o',
+            SELECT_ONE_OBJECTIVE, '--no-plot'
+        ], 'benchopt', standalone_mode=False)
+
+    out.check_output('Simulated', repetition=1)

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -1,6 +1,8 @@
 import pytest
 
+from benchopt.cli.main import run
 from benchopt.tests import DUMMY_BENCHMARK
+from benchopt.tests import FUTURE_BENCHMARK_PATH
 from benchopt.utils.dynamic_modules import _load_class_from_module
 
 
@@ -32,3 +34,9 @@ def test_template_solver():
     # Make sure that this error is not raised when listing all solvers from
     # the benchmark.
     DUMMY_BENCHMARK.get_solvers()
+
+
+def test_benchopt_min_version():
+    # Make sure that importing template_dataset raises an error.
+    with pytest.raises(RuntimeError, match="pip install -U"):
+        run([str(FUTURE_BENCHMARK_PATH)], 'benchopt', standalone_mode=False)

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -42,11 +42,11 @@ def test_template_solver():
 
 
 def test_benchopt_min_version():
-    # Make sure that importing template_dataset raises an error.
     with pytest.raises(RuntimeError, match="pip install -U"):
         run([str(FUTURE_BENCHMARK_PATH)], 'benchopt', standalone_mode=False)
 
     with CaptureRunOutput() as out:
+        # check than benchmark with low requirement runs
         run([
             str(DUMMY_BENCHMARK_PATH), '-l', '-d', SELECT_ONE_SIMULATED,
             '-f', SELECT_ONE_PGD, '-n', '1', '-r', '1', '-o',

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -9,7 +9,7 @@ class Objective(BaseObjective):
     name = "Dummy Sparse Regression"
 
     # Make sure we can run with the current version
-    min_benchopt_version = "0.0.0dev1001"
+    min_benchopt_version = "0.0.0"
     parameters = {
         'reg': [0.05, .1, .5]
     }

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -8,6 +8,8 @@ with safe_import_context() as import_ctx:
 class Objective(BaseObjective):
     name = "Dummy Sparse Regression"
 
+    # Make sure we can run with the current version
+    min_benchopt_version = "1.0.0dev1001"
     parameters = {
         'reg': [0.05, .1, .5]
     }

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -9,7 +9,7 @@ class Objective(BaseObjective):
     name = "Dummy Sparse Regression"
 
     # Make sure we can run with the current version
-    min_benchopt_version = "1.0.0dev1001"
+    min_benchopt_version = "0.0.0dev1001"
     parameters = {
         'reg': [0.05, .1, .5]
     }

--- a/benchopt/tests/test_benchmarks/future_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/future_benchmark/objective.py
@@ -1,0 +1,14 @@
+from benchopt import BaseObjective
+
+
+class Objective(BaseObjective):
+    min_benchopt_version = "99.0.0"
+
+    def set_data(self):
+        pass
+
+    def get_objective(self):
+        pass
+
+    def compute(self, beta):
+        pass

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from joblib.memory import _FUNCTION_HASHES
 from click.shell_completion import ShellComplete
 
+from benchopt.benchmark import Benchmark
 from benchopt.plotting import PLOT_KINDS
 from benchopt.utils.stream_redirection import SuppressStd
 
@@ -20,7 +21,6 @@ from benchopt.tests import SELECT_ONE_OBJECTIVE
 from benchopt.tests import TEST_BENCHMARK_DIR
 from benchopt.tests import DUMMY_BENCHMARK
 from benchopt.tests import DUMMY_BENCHMARK_PATH
-from benchopt.tests import REQUIREMENT_BENCHMARK
 from benchopt.tests import REQUIREMENT_BENCHMARK_PATH
 
 
@@ -371,7 +371,9 @@ class TestInstallCmd:
         )
 
     def test_benchopt_install_in_env_with_requirements(self, test_env_name):
-        objective = REQUIREMENT_BENCHMARK.get_benchmark_objective()
+        objective = Benchmark(
+            REQUIREMENT_BENCHMARK_PATH
+        ).get_benchmark_objective()
         out = 'already installed but failed to import.'
         if not objective.is_installed(env_name=test_env_name):
             with CaptureRunOutput() as out:

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -17,6 +17,7 @@ from benchopt.tests import CaptureRunOutput
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
 from benchopt.tests import SELECT_ONE_OBJECTIVE
+from benchopt.tests import TEST_BENCHMARK_DIR
 from benchopt.tests import DUMMY_BENCHMARK
 from benchopt.tests import DUMMY_BENCHMARK_PATH
 from benchopt.tests import REQUIREMENT_BENCHMARK
@@ -32,15 +33,11 @@ from benchopt.cli.process_results import plot
 from benchopt.cli.process_results import generate_results
 
 
+ALL_BENCHMARKS = [str(p) for p in TEST_BENCHMARK_DIR.glob("*")]
+
 BENCHMARK_COMPLETION_CASES = [
-    (str(DUMMY_BENCHMARK_PATH.parent), [
-        str(DUMMY_BENCHMARK_PATH),
-        str(REQUIREMENT_BENCHMARK_PATH),
-    ]),
-    (str(DUMMY_BENCHMARK_PATH.parent)[:-2], [
-        str(DUMMY_BENCHMARK_PATH),
-        str(REQUIREMENT_BENCHMARK_PATH),
-    ]),
+    (str(DUMMY_BENCHMARK_PATH.parent), ALL_BENCHMARKS),
+    (str(DUMMY_BENCHMARK_PATH.parent)[:-2], ALL_BENCHMARKS),
     (str(DUMMY_BENCHMARK_PATH)[:-2], [str(DUMMY_BENCHMARK_PATH)])
 ]
 SOLVER_COMPLETION_CASES = [


### PR DESCRIPTION
Define `min_benchopt_version` attribute in a benchmark to raise an error if the version of benchopt that is used it too old.