### PR TITLE
DOC Pin sphinx version to 4.5.0 

### DIFF
--- a/doc/names.inc
+++ b/doc/names.inc
@@ -18,4 +18,4 @@
 
 .. _Amélie Vernay: https://github.com/AmelieVernay
 
-.. Melvine Nargeot: https://github.com/Melvin-klein
+.. _Melvine Nargeot: https://github.com/Melvin-klein

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -17,3 +17,5 @@
 .. _Benoît Malézieux: https://github.com/bmalezieux
 
 .. _Amélie Vernay: https://github.com/AmelieVernay
+
+.. Melvine Nargeot: https://github.com/Melvin-klein

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
 
 doc =
     numpydoc
+    sphinx==4.5.0
     sphinx-bootstrap-theme
     sphinx-click
     sphinx_gallery


### PR DESCRIPTION
With sphinx 5.0 I could not build the doc, as in https://github.com/alphacsc/alphacsc/pull/95


+ little fix to add @Melvin-klein 's name

