### PR TITLE
PLT - add responsiveness to benchmarks figures

### DIFF
--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -277,19 +277,6 @@ input:checked+.slider:before {
 /***** Plot *****/
 /*----------------------------------------*/
 
-@media (min-width: 768px) {
-  #unique_plot {
-    flex: 1 1 0%;
-  }
-}
-
-@media (max-width: 767px) {
-  #unique_plot {
-    flex: initial;
-    flex-shrink: 0;
-  }
-}
-
 .js-plotly-plot .plotly .modebar {
   transform: translateX(-30px);
 }

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -59,8 +59,11 @@ const makePlot = () => {
   const div = document.getElementById('unique_plot');
   const data = isBarChart() ? getBarData() : getScatterCurves();
   const layout = isBarChart() ? getBarChartLayout() : getScatterChartLayout();
+  const config = {
+    responsive: true
+  }
 
-  Plotly.react(div, data, layout);
+  Plotly.react(div, data, layout, config);
 };
 
 /**


### PR DESCRIPTION
In response to @jolars request in #488,

This adds responsiveness to the benchmarks figures.

closes #488 

---------------
[link to preview new features](https://badr-moufad.github.io/share-benchmarks/responsive-plot/generated_df_lasso_bench.html)