### PR TITLE
WIP Document compute returns

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 from mako.template import Template
+from numpydoc import NumpyDocString
 
 from benchopt.benchmark import Benchmark
 from ..constants import PLOT_KINDS
@@ -281,6 +282,15 @@ def render_index(benchmarks, len_fnames):
         pretty_names=pretty_names,
         len_fnames=len_fnames
     )
+
+
+def get_objective_descr(bench_path):
+    if (bench_path / "objective.py").exists():
+        benchmark = Benchmark(bench_path)
+    else:
+        raise FileNotFoundError(f"No objective.py in {bench_path.resolve()}")
+    doc = NumpyDocString(benchmark.get_objective().compute.__doc__)
+    returns = doc["Returns"]
 
 
 def get_pretty_name(bench_path):


### PR DESCRIPTION
thanks to numpydoc it can be done quite easily.
We need to have valid variable names as keys i nthe dict which is currently not the case (eg in Ridge, "Test loss" cannot be parsed properly)

Once we have retrieved this where do we store it and in which fashion do we display it in the HTML ?

closes #522 