### PR TITLE
ENH add pre_run_hook for Solvers

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -124,6 +124,24 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
         """
         ...
 
+    def pre_run_hook(self, stop_val):
+        """Hook to run pre-run operations.
+
+        This is mostly necessary to cache stop_val dependent computations, for
+        instance in ``jax`` with different number of iterations in a for loop.
+
+        Parameters
+        ----------
+        stop_val : int | float | callable
+            Value for the stopping criterion of the solver for. It allows to
+            sample the time/accuracy curve in the benchmark.
+            If it is a callable, then it should act as a callback. This
+            callback should be called once for each iteration with argument
+            the current iterate `parameters`. The callback returns False when
+            the computations should stop.
+        """
+        ...
+
     @abstractmethod
     def run(self, stop_val):
         """Call the solver with the given stop_val.

--- a/benchopt/callback.py
+++ b/benchopt/callback.py
@@ -56,6 +56,8 @@ class _Callback:
         self.it = 0
         self.time_iter = 0.
         self.next_stopval = self.stopping_criterion.init_stop_val()
+
+    def start(self):
         self.time_callback = time.perf_counter()
 
     def __call__(self, x):

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -44,6 +44,7 @@ def run_one_resolution(objective, solver, meta, stop_val):
             f"Failure during import in {solver.__module__}."
         )
 
+    solver.pre_run_hook(stop_val)
     t_start = time.perf_counter()
     solver.run(stop_val)
     delta_t = time.perf_counter() - t_start
@@ -98,6 +99,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             callback = _Callback(
                 objective, meta, stopping_criterion
             )
+            solver.pre_run_hook(callback)
+            callback.start()
             solver.run(callback)
             curve, ctx.status = callback.get_results()
         else:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -33,6 +33,10 @@ Also available for ``Dataset`` and ``Objective``.
 :func:`~benchopt.BaseSolver.get_next`: hook to change the sampling points for
 a given solver.
 
+:func:`~benchopt.BaseSolver.pre_run_hook`: hook called before each call to
+``run``, with the same argument. Allows to skip certain computation that
+cannot be cached globally, such as precompilation with different number of
+iterations in for jitted ``jax`` functions.
 
 Benchopt utils
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
This hook was necessary for tommoral/benchmark_ot, as the compilation for jitted function needs to be called each time, as it is recompilled when `n_iter` changes.