### PR TITLE
CLN default install_cmd to 'conda'

### DIFF
--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -132,8 +132,6 @@ def test_solver_install_api(benchmark, solver_class):
     assert solver_class.install_cmd in [None, 'conda', 'shell']
 
     # Check that the solver_class exposes a known install cmd
-    if solver_class.install_cmd == 'conda':
-        assert hasattr(solver_class, 'requirements')
     if solver_class.install_cmd == 'shell':
         assert hasattr(solver_class, 'install_script')
 

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -10,7 +10,7 @@ from .conda_env_cmd import shell_install_in_conda_env
 
 class DependenciesMixin:
     # Information on how to install the class. The value of install_cmd should
-    # be in {None, 'conda', 'shell'}. The API reads:
+    # be in {'conda', 'shell'}. The API reads:
     #
     # - 'conda': The class should have an attribute `requirements`.
     #          Benchopt will conda install `$requirements`, except for entries
@@ -22,7 +22,7 @@ class DependenciesMixin:
     #           env directory as an argument. The command should then be
     #           installed in the `bin` folder of the env and can be imported
     #           with import_shell_cmd in the safe_import_context.
-    install_cmd = None
+    install_cmd = 'conda'
 
     _error_displayed = False
 

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -150,7 +150,7 @@ class DependenciesMixin:
         if force or not is_installed:
             cls._pre_install_hook(env_name=env_name)
             if cls.install_cmd == 'conda':
-                conda_reqs = cls.requirements
+                conda_reqs = getattr(cls, "requirements", [])
             elif cls.install_cmd == 'shell':
                 shell_install_scripts = [
                     cls._module_filename.parents[1] / 'install_scripts' /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "benchopt/version.py"
 local_scheme = "no-local-version"
-fallback_version = "dev"
+fallback_version = "99.0.dev0"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/roadmap.md
+++ b/roadmap.md
@@ -25,3 +25,9 @@
 - [ ] Argument in client to pass solvers to run in benchmark
 - [ ] Make CI run the benchmark and check install
 
+
+## Discussion Owkin
+
+- Checkpointing is important.
+- Merging files from multiple run?
+


### PR DESCRIPTION
Just got stuck because I added some requirements but it did not get installed... I think it make more sense to default to `install_cmd='conda'` 