### PR TITLE
PLT - Show solver description when hovering over it

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -1,6 +1,5 @@
 import json
 import shutil
-import warnings
 import webbrowser
 from pathlib import Path
 from datetime import datetime

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -125,7 +125,10 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
 
 
 def get_metadata(df):
-    """Get the benchmark metadata such Objective and solver description.
+    """Get the benchmark metadata.
+
+    Metadata are already available among the columns of `df`.
+    It might be Objective and/or Solvers description.
 
     Returns
     -------

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -109,6 +109,18 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         # JSON
         result['json'] = json.dumps(shape_datasets_for_html(df))
 
+        # get solver description
+        solvers_description = df.groupby("solver_name")["solver_description"]
+        solvers_description = solvers_description.unique()
+
+        # convert description to str
+        solvers_description = solvers_description.apply(lambda desc: desc[0])
+
+        # save in result
+        result["solvers_description"] = json.dumps(
+            solvers_description.to_dict()
+        )
+
         results.append(result)
 
     for result in results:

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -109,17 +109,26 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         # JSON
         result['json'] = json.dumps(shape_datasets_for_html(df))
 
-        # get solver description
-        solvers_description = df.groupby("solver_name")["solver_description"]
-        solvers_description = solvers_description.unique()
+        # get solver descriptions
+        # wrap in try-except block to preserve compatibility
+        # with older versions
+        try:
+            solvers_description = df.groupby(
+                by=["solver_name"]
+            )["solver_description"]
+            solvers_description = solvers_description.unique()
 
-        # convert description to str
-        solvers_description = solvers_description.apply(lambda desc: desc[0])
+            # convert description to str
+            solvers_description = solvers_description.apply(
+                lambda desc: desc[0]
+            )
 
-        # save in result
-        result["solvers_description"] = json.dumps(
-            solvers_description.to_dict()
-        )
+            # save in result
+            result["solvers_description"] = json.dumps(
+                solvers_description.to_dict()
+            )
+        except KeyError:
+            result["solvers_description"] = json.dumps({})
 
         results.append(result)
 

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -1,5 +1,6 @@
 import json
 import shutil
+import warnings
 import webbrowser
 from pathlib import Path
 from datetime import datetime
@@ -104,25 +105,11 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             obj_cols=[k for k in df.columns if k.startswith('objective_')
                       and k != 'objective_name'],
             kinds=list(kinds),
+            metadata=get_metadata(df),
         )
 
         # JSON
         result['json'] = json.dumps(shape_datasets_for_html(df))
-
-        # get solver descriptions
-        # wrap in try-except block to preserve compatibility
-        # with older versions
-        try:
-            solvers_description = df.groupby(
-                by=["solver_name"]
-            )["solver_description"].first()
-
-            # save in result
-            result["solvers_description"] = json.dumps(
-                solvers_description.to_dict()
-            )
-        except KeyError:
-            result["solvers_description"] = json.dumps({})
 
         results.append(result)
 
@@ -136,6 +123,31 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         )
 
     return results
+
+
+def get_metadata(df):
+    """Get the benchmark metadata such Objective and solver description.
+
+    Returns
+    -------
+    metadata: dict
+        Dictionary containing the benchmark metadata.
+    """
+    metadata = {}
+
+    # get solver descriptions
+    # wrap in try-except block to preserve compatibility
+    # with older versions
+    try:
+        solvers_description = df.groupby(
+            by=["solver_name"]
+        )["solver_description"].first()
+
+        metadata["solvers_description"] = solvers_description.to_dict()
+    except KeyError:
+        metadata["solvers_description"] = {}
+
+    return metadata
 
 
 def shape_datasets_for_html(df):

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -115,13 +115,7 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
         try:
             solvers_description = df.groupby(
                 by=["solver_name"]
-            )["solver_description"]
-            solvers_description = solvers_description.unique()
-
-            # convert description to str
-            solvers_description = solvers_description.apply(
-                lambda desc: desc[0]
-            )
+            )["solver_description"].first()
 
             # save in result
             result["solvers_description"] = json.dumps(

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -317,3 +317,43 @@ input:checked+.slider:before {
 .space-r-2 > * {
   margin-right: 0.5rem;
 }
+
+/* Description solver when hovered */
+.solver-description-container {
+  position: relative;
+  display: inline-flex;
+}
+
+.solver-description-content {
+  visibility: hidden;
+  background-color: rgb(55 65 81);
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 0.5em;
+  opacity: 90%;
+	
+  width: 200px;
+  
+  /* position description with respect to container and put it top-center */
+  position: absolute;
+  transform: translate(-50px, -100%) translate(100px, 0px);
+  z-index: 99999;
+}
+
+/* Show description when hovered */
+.solver-description-container:hover .solver-description-content {
+  visibility: visible;
+}
+
+/*Arrow at the bottom of the description*/
+.solver-description-container .solver-description-content::after {
+  content: " ";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: rgb(55 65 81) transparent transparent transparent;
+}

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -333,11 +333,11 @@ input:checked+.slider:before {
   padding: 0.5em;
   opacity: 90%;
 	
-  width: 200px;
+  width: 400px;
   
   /* position description with respect to container and put it top-center */
   position: absolute;
-  transform: translate(-50px, -100%) translate(100px, 0px);
+  transform: translate(0, -100%);
   z-index: 99999;
 }
 
@@ -351,9 +351,9 @@ input:checked+.slider:before {
   content: " ";
   position: absolute;
   top: 100%;
-  left: 50%;
+  left: 20px;
   margin-left: -5px;
-  border-width: 5px;
+  border-width: 7px;
   border-style: solid;
   border-color: rgb(55 65 81) transparent transparent transparent;
 }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -328,12 +328,13 @@ input:checked+.slider:before {
   visibility: hidden;
   background-color: rgb(55 65 81);
   color: #fff;
-  text-align: center;
   border-radius: 6px;
   padding: 0.5em;
   opacity: 90%;
 	
   width: 400px;
+  max-height: 700px;
+  white-space: pre-wrap;
   
   /* position description with respect to container and put it top-center */
   position: absolute;

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -325,15 +325,18 @@ input:checked+.slider:before {
 }
 
 .solver-description-content {
+  display: flex;
+  flex-direction: column;
   visibility: hidden;
   background-color: rgb(55 65 81);
   color: #fff;
   border-radius: 6px;
   padding: 0.5em;
+  padding-right: 1rem;
   opacity: 90%;
 	
   width: 400px;
-  max-height: 700px;
+  max-height: 500px;
   white-space: pre-wrap;
   
   /* position description with respect to container and put it top-center */
@@ -357,4 +360,15 @@ input:checked+.slider:before {
   border-width: 7px;
   border-style: solid;
   border-color: rgb(55 65 81) transparent transparent transparent;
+}
+
+.solver-description-title {
+  margin-bottom: 1em;
+  font-weight: bolder;
+}
+
+.solver-description-body {
+  max-height: 450px;
+  overflow-y: auto;
+
 }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -4,27 +4,36 @@
 
 /* Place rectangles in a grid */
 .grid {
-  position: relative; /* each rectangle is dependant of others */
+  position: relative;
+  /* each rectangle is dependant of others */
   margin: 0 auto;
-  padding: 1em 0 4em; /* padding top horizontal bottom */
-  display: grid; /* type of boxes generated */
+  padding: 1em 0 4em;
+  /* padding top horizontal bottom */
+  display: grid;
+  /* type of boxes generated */
   max-width: 1000px;
-  list-style: none; /* no item */
+  list-style: none;
+  /* no item */
   text-align: center;
-  column-gap: 2em; /* space between columns */
+  column-gap: 2em;
+  /* space between columns */
 }
 
 /* Figure inside grid */
 .grid figure {
   position: relative;
   float: left;
-  overflow: hidden; /* overflow not taken into account */
+  overflow: hidden;
+  /* overflow not taken into account */
   margin: 10px 1%;
-  width: 100%; /* 100% of the column */
+  width: 100%;
+  /* 100% of the column */
   background: #3085a3;
   text-align: center;
-  cursor: pointer; /* change shape cursor */
-  border-radius: 30px; /* rounded corners */
+  cursor: pointer;
+  /* change shape cursor */
+  border-radius: 30px;
+  /* rounded corners */
 }
 
 /* Each figure contains an img */
@@ -33,14 +42,18 @@
   display: block;
   max-height: 100%;
   max-width: 100%;
-  opacity: 1; /* over a dummy image */
+  opacity: 1;
+  /* over a dummy image */
 }
 
 /* Style caption (title of benchmarks) */
 .grid figure figcaption {
-  padding: 0.1em; /* add space */
-  color: #fff; /* writing color */
-  text-transform: uppercase; /* title in uppercase */
+  padding: 0.1em;
+  /* add space */
+  color: #fff;
+  /* writing color */
+  text-transform: uppercase;
+  /* title in uppercase */
   font-size: 1.25em;
 }
 
@@ -48,32 +61,39 @@
 @media (min-width: 600px) {
   .grid {
     grid-template-columns: repeat(2, 1fr);
-  } /* split in 2 columns */
+  }
+
+  /* split in 2 columns */
 }
 
 /* Larger sized screens */
 @media (min-width: 900px) {
   .grid {
     grid-template-columns: repeat(3, 1fr);
-  } /* split in 3 columns */
+  }
+
+  /* split in 3 columns */
 }
 
 /* Position and style of <a> elements (the View more) */
 .grid figure figcaption,
-.grid figure figcaption > a {
+.grid figure figcaption>a {
   position: absolute;
-  top: 0em; /* no space offset top */
+  top: 0em;
+  /* no space offset top */
   left: 0;
   width: 100%;
   height: 100%;
 }
 
 /* only to figcaption <a> tag */
-.grid figure figcaption > a {
-  z-index: 1000; /* top level */
+.grid figure figcaption>a {
+  z-index: 1000;
+  /* top level */
   text-indent: 0%;
   white-space: nowrap;
-  font-size: 0; /* do not display the View more */
+  font-size: 0;
+  /* do not display the View more */
   opacity: 1;
 }
 
@@ -111,43 +131,53 @@ figure.effect-ruby:hover {
 /* Define transformation */
 figure.effect-ruby img {
   opacity: 0;
-  transition: opacity 0.35s, transform 0.35s; /* transition time */
-  transform: scale(1.15); /* size transformation -> bigger */
+  transition: opacity 0.35s, transform 0.35s;
+  /* transition time */
+  transform: scale(1.15);
+  /* size transformation -> bigger */
 }
 
 /* transformation with hovering */
 figure.effect-ruby:hover img {
   opacity: 0;
-  transform: scale(1); /* size -> smaller */
+  transform: scale(1);
+  /* size -> smaller */
 }
 
 /* Apply effect to problem name */
 figure.effect-ruby h2 {
   margin-top: 0;
-  transition: transform 0.35s; /* transition time */
+  transition: transform 0.35s;
+  /* transition time */
   transform: translate3d(0, calc((150px - 100%)/2), 0);
-  font-size: 1.25em; /* default font */
+  font-size: 1.25em;
+  /* default font */
 }
 
 figure.effect-ruby p {
   margin: 2em -1em 2em -1em;
   padding: 1em 0em 1em 0em;
-  border: 1px solid #fff; /* create sort of white frame */
+  border: 1px solid #fff;
+  /* create sort of white frame */
   opacity: 0;
   transition: opacity 0.35s, transform 0.35s;
-  transform: translate3d(0, 20px, 0) scale(1.1); /* size transform */
+  transform: translate3d(0, 20px, 0) scale(1.1);
+  /* size transform */
 }
 
 /* Transform title on hover */
 figure.effect-ruby:hover h2 {
   -webkit-transform: translate3d(0, 0, 0);
-  transform: translate3d(0px, 10px, 0) scale(0.8); /* smaller */
-  margin-top: 0em; /* move up */
+  transform: translate3d(0px, 10px, 0) scale(0.8);
+  /* smaller */
+  margin-top: 0em;
+  /* move up */
 }
 
 figure.effect-ruby:hover p {
   opacity: 1;
-  transform: translate3d(0, 0, 0) scale(1.2); /* placement in box */
+  transform: translate3d(0, 0, 0) scale(1.2);
+  /* placement in box */
 }
 
 /* Button for inside the table with system informations */
@@ -165,7 +195,8 @@ figure.effect-ruby:hover p {
   background-color: transparent;
   outline: none;
   text-align: center;
-  margin-left: 1px; /* add margin */
+  margin-left: 1px;
+  /* add margin */
 }
 
 
@@ -262,8 +293,8 @@ input:checked+.slider:before {
   transform-origin: 0 50%;
 }
 
-.ml11 .line1 { 
-  top: 0; 
+.ml11 .line1 {
+  top: 0;
   left: 0;
 }
 
@@ -314,7 +345,7 @@ input:checked+.slider:before {
   color: #475569;
 }
 
-.space-r-2 > * {
+.space-r-2>* {
   margin-right: 0.5rem;
 }
 
@@ -334,11 +365,11 @@ input:checked+.slider:before {
   padding: 0.5em;
   padding-right: 1rem;
   opacity: 90%;
-	
+
   width: 400px;
   max-height: 500px;
   white-space: pre-wrap;
-  
+
   /* position description with respect to container and put it top-center */
   position: absolute;
   transform: translate(0, -100%);

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -370,5 +370,4 @@ input:checked+.slider:before {
 .solver-description-body {
   max-height: 450px;
   overflow-y: auto;
-
 }

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -669,7 +669,7 @@ const createLegendItem = (solver, color, symbolNumber) => {
 function createSolverDescription(legendItem, {title, description}) {
   // skip if no description was provided
   if (description === null || description === undefined || description === "")
-    return legendItem;
+    description = "No description provided";
 
   let descriptionContainer = document.createElement("div");
   descriptionContainer.setAttribute("class", "solver-description-container")

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -668,7 +668,6 @@ const createLegendItem = (solver, color, symbolNumber) => {
 
 
 function createSolverDescription(legendItem, {title, description}) {
-  // skip if no description was provided
   if (description === null || description === undefined || description === "")
     description = "No description provided";
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -568,7 +568,16 @@ const makeLegend = () => {
     const color = data().solvers[solver].color;
     const symbolNumber = data().solvers[solver].marker;
 
-    legend.appendChild(createLegendItem(solver, color, symbolNumber));
+    let legendItem = createLegendItem(solver, color, symbolNumber);
+
+    let description = `
+    I was hovered so I can provide additional information about
+    <b>${solver}</b>. Bla bla bla works using Ta ta ...
+    `;
+
+    legend.appendChild(
+      createSolverDescription(legendItem, description)
+    );
   });
 }
 
@@ -648,6 +657,20 @@ const createLegendItem = (solver, color, symbolNumber) => {
   item.appendChild(textContainer);
 
   return item;
+}
+
+
+function createSolverDescription(legendItem, descriptionText) {
+  let description = document.createElement("div");
+  description.setAttribute("class", "solver-description-container")
+
+  description.innerHTML = `
+    <span class="solver-description-content">${descriptionText}</span>
+  `;
+
+  description.prepend(legendItem);
+
+  return description;
 }
 
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -572,7 +572,6 @@ const makeLegend = () => {
 
     let description = window.solvers_description[solver];
 
-    window.solvers_description[solver]
     legend.appendChild(
       createSolverDescription(legendItem, description)
     );
@@ -663,7 +662,9 @@ function createSolverDescription(legendItem, descriptionText) {
   description.setAttribute("class", "solver-description-container")
 
   description.innerHTML = `
-    <span class="solver-description-content">${descriptionText}</span>
+  <div class="solver-description-content">
+    <div>${descriptionText}</div>
+  </div>
   `;
 
   description.prepend(legendItem);

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -570,10 +570,13 @@ const makeLegend = () => {
 
     let legendItem = createLegendItem(solver, color, symbolNumber);
 
-    let description = window.solvers_description[solver];
+    let payload = {
+      title: solver,
+      description: window.solvers_description[solver],
+    }
 
     legend.appendChild(
-      createSolverDescription(legendItem, description)
+      createSolverDescription(legendItem, payload)
     );
   });
 }
@@ -657,19 +660,20 @@ const createLegendItem = (solver, color, symbolNumber) => {
 }
 
 
-function createSolverDescription(legendItem, descriptionText) {
-  let description = document.createElement("div");
-  description.setAttribute("class", "solver-description-container")
+function createSolverDescription(legendItem, {title, description}) {
+  let descriptionContainer = document.createElement("div");
+  descriptionContainer.setAttribute("class", "solver-description-container")
 
-  description.innerHTML = `
+  descriptionContainer.innerHTML = `
   <div class="solver-description-content">
-    <div>${descriptionText}</div>
+    <span class="solver-description-title">${title}</span>
+    <span class="solver-description-body">${description}</span>
   </div>
   `;
 
-  description.prepend(legendItem);
+  descriptionContainer.prepend(legendItem);
 
-  return description;
+  return descriptionContainer;
 }
 
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -570,6 +570,12 @@ const makeLegend = () => {
 
     let legendItem = createLegendItem(solver, color, symbolNumber);
 
+    // preserve compatibility with prev version
+    if(window.solvers_description === null || window.solvers_description === undefined) {
+      legend.appendChild(legendItem);
+      return;
+    }
+
     let payload = {
       title: solver,
       description: window.solvers_description[solver],
@@ -661,6 +667,10 @@ const createLegendItem = (solver, color, symbolNumber) => {
 
 
 function createSolverDescription(legendItem, {title, description}) {
+  // skip if no description was provided
+  if (description === null || description === undefined || description === "")
+    return legendItem;
+
   let descriptionContainer = document.createElement("div");
   descriptionContainer.setAttribute("class", "solver-description-container")
 

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -563,6 +563,7 @@ const makeLegend = () => {
   const legend = document.getElementById('plot_legend');
 
   legend.innerHTML = '';
+  const solversDescription = window.metadata["solvers_description"];
 
   Object.keys(data().solvers).forEach(solver => {
     const color = data().solvers[solver].color;
@@ -571,14 +572,14 @@ const makeLegend = () => {
     let legendItem = createLegendItem(solver, color, symbolNumber);
 
     // preserve compatibility with prev version
-    if(window.solvers_description === null || window.solvers_description === undefined) {
+    if(solversDescription === null || solversDescription === undefined) {
       legend.appendChild(legendItem);
       return;
     }
 
     let payload = {
       title: solver,
-      description: window.solvers_description[solver],
+      description: solversDescription[solver],
     }
 
     legend.appendChild(

--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -570,11 +570,9 @@ const makeLegend = () => {
 
     let legendItem = createLegendItem(solver, color, symbolNumber);
 
-    let description = `
-    I was hovered so I can provide additional information about
-    <b>${solver}</b>. Bla bla bla works using Ta ta ...
-    `;
+    let description = window.solvers_description[solver];
 
+    window.solvers_description[solver]
     legend.appendChild(
       createSolverDescription(legendItem, description)
     );

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -385,7 +385,7 @@
         <!-- Manage plot -->
         <script>
             window.data = ${result['json']};
-            window.solvers_description = ${result['solvers_description']};
+            window.metadata = ${result['metadata']};
 
             window.addEventListener("load", () => {
                 // Initialize plot state

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -385,6 +385,7 @@
         <!-- Manage plot -->
         <script>
             window.data = ${result['json']};
+            window.solvers_description = ${result['solvers_description']};
 
             window.addEventListener("load", () => {
                 // Initialize plot state

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -85,6 +85,14 @@
                                 </select>
                             </div>
                         </div>
+                        <div id="xaxis-type-form-group" class="mt-8 px-8">
+                            <label for="change_scaling" class="block text-sm font-medium text-white">X-axis</label>
+                            <div class="mt-1 rounded-md shadow-sm">
+                                <select id="change_xaxis_type" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
+                                   <!-- options will be added dynamically -->
+                                </select>
+                            </div>
+                        </div>
                         <div class="flex items-center justify-between mt-8 px-8">
                             <div class="block text-sm font-medium text-white">Quantiles</div>
                             <label class="block switch">
@@ -214,6 +222,14 @@
                                         <option value="semilog-x">semilog-x</option>
                                         <option value="loglog">loglog</option>
                                         <option value="linear">linear</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div id="xaxis-type-form-group" class="mt-8 px-8">
+                                <label for="change_scaling" class="block text-sm font-medium text-white">X-axis</label>
+                                <div class="mt-1 rounded-md shadow-sm">
+                                    <select id="change_xaxis_type_mobile" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({xaxis_type: this.value})">
+                                       <!-- options will be added dynamically -->
                                     </select>
                                 </div>
                             </div>
@@ -379,6 +395,7 @@
                     'plot_kind': document.getElementById('plot_kind').value,
                     'scale': document.getElementById('change_scaling').value,
                     'with_quantiles': document.getElementById('change_shades').checked,
+                    'xaxis_type':  document.getElementById('change_xaxis_type').value || "Time",
                     'hidden_solvers': []
                 });
             });

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -197,7 +197,8 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             data_name=str(dataset),
             idx_rep=rep,
             stopping_strategy=stopping_strategy.capitalize(),
-            solver_description=str(solver.__doc__) or ""
+            solver_description=(solver.__doc__
+                                if solver.__doc__ is not None else ""),
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -180,6 +180,13 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
 
     states = []
     run_statistics = []
+
+    # get stopping strategy
+    # for plotting purpose consider 'callback' as 'iteration'
+    stopping_strategy = solver._solver_strategy
+    if stopping_strategy == 'callback':
+        stopping_strategy = 'iteration'
+
     for rep in range(n_repetitions):
 
         output.set(rep=rep)
@@ -189,6 +196,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
+            stopping_strategy=stopping_strategy.capitalize()
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -196,7 +196,8 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
-            stopping_strategy=stopping_strategy.capitalize()
+            stopping_strategy=stopping_strategy.capitalize(),
+            solver_description=str(solver.__doc__) or ""
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,9 @@ API
 PLOT
 ~~~~
 
+- Show solver description when hovering over solvers. Description is provided as docstring of
+  the :class:`~benchopt.BaseSolver` class. By `Badr Moufad`_ (:gh:`543`)
+
 - Enable visualizing the objective as function of ``stopping_criterion``: time,
   iteration, or tolerance. By `Badr Moufad`_ (:gh:`479`)
 


### PR DESCRIPTION
This adds a way of showing additional information about solvers when placing the cursor over them in the legend.

Here is a [preview of the features](https://badr-moufad.github.io/share-benchmarks/solver_description/validate-plotting-stop-val_benchopt_run_2023-03-08_17h46m44.html) that shows how the solvers' metadata would be displayed.

I see one limitation of this approach is the amount of content we can display.

-------------------
Also related to https://github.com/benchopt/benchopt/pull/523. 