### PR TITLE
PLT - preserve plotting for benchmark run in previous version

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -184,20 +184,7 @@ def shape_solvers_for_html(df, objective_column):
         groupby_stop_val_median = df_filtered.groupby('stop_val').median()
         color, marker = get_solver_style(solver)
 
-        stopping_strategy = df_filtered['stopping_strategy'].unique()
-
-        if len(stopping_strategy) != 1:
-            found_stopping_strategies = ', '.join(
-                f"`{item}`" for item in stopping_strategy
-            )
-
-            raise Exception(
-                "Solver can be run using only one stopping strategy. "
-                f"Expected one stopping strategy "
-                f"but found {found_stopping_strategies}"
-            )
-
-        stopping_strategy = stopping_strategy[0]
+        stopping_strategy = _get_solver_stopping_strategy(df_filtered)
 
         solver_data[solver] = {
             'scatter': {
@@ -216,6 +203,29 @@ def shape_solvers_for_html(df, objective_column):
         }
 
     return solver_data
+
+
+def _get_solver_stopping_strategy(df_filtered):
+    # to preserve support of previous benchopt version
+    # where 'stopping_strategy' wasn't saved in solver meta
+    if 'stopping_strategy' not in df_filtered.columns:
+        return "Time"
+
+    stopping_strategy = df_filtered['stopping_strategy'].unique()
+
+    if len(stopping_strategy) != 1:
+        found_stopping_strategies = ', '.join(
+            f"`{item}`" for item in stopping_strategy
+            )
+
+        raise Exception(
+            "Solver can be run using only one stopping strategy. "
+            f"Expected one stopping strategy "
+            f"but found {found_stopping_strategies}"
+        )
+
+    stopping_strategy = stopping_strategy[0]
+    return stopping_strategy
 
 
 def get_sysinfo(df):

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -189,7 +189,25 @@ def shape_solvers_for_html(df, objective_column):
         q1, q9 = compute_quantiles(df_filtered)
 
         color, marker = get_solver_style(solver)
-        stopping_strategy = _get_solver_stopping_strategy(df_filtered)
+        # to preserve support of previous benchopt version
+        # where 'stopping_strategy' wasn't saved in solver meta
+        try:
+            stopping_strategy = df_filtered['stopping_strategy'].unique()
+        except KeyError:
+            stopping_strategy = ["Time"]
+
+        if len(stopping_strategy) != 1:
+            found_stopping_strategies = ', '.join(
+                f"`{item}`" for item in stopping_strategy
+                )
+
+            raise Exception(
+                "Solver can be run using only one stopping strategy. "
+                f"Expected one stopping strategy "
+                f"but found {found_stopping_strategies}"
+            )
+
+        stopping_strategy = stopping_strategy[0]
 
         solver_data[solver] = {
             'scatter': {
@@ -208,29 +226,6 @@ def shape_solvers_for_html(df, objective_column):
         }
 
     return solver_data
-
-
-def _get_solver_stopping_strategy(df_filtered):
-    # to preserve support of previous benchopt version
-    # where 'stopping_strategy' wasn't saved in solver meta
-    if 'stopping_strategy' not in df_filtered.columns:
-        return "Time"
-
-    stopping_strategy = df_filtered['stopping_strategy'].unique()
-
-    if len(stopping_strategy) != 1:
-        found_stopping_strategies = ', '.join(
-            f"`{item}`" for item in stopping_strategy
-            )
-
-        raise Exception(
-            "Solver can be run using only one stopping strategy. "
-            f"Expected one stopping strategy "
-            f"but found {found_stopping_strategies}"
-        )
-
-    stopping_strategy = stopping_strategy[0]
-    return stopping_strategy
 
 
 def get_sysinfo(df):

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -199,7 +199,7 @@ def shape_solvers_for_html(df, objective_column):
         if len(stopping_strategy) != 1:
             found_stopping_strategies = ', '.join(
                 f"`{item}`" for item in stopping_strategy
-                )
+            )
 
             raise Exception(
                 "Solver can be run using only one stopping strategy. "

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -180,10 +180,15 @@ def shape_solvers_for_html(df, objective_column):
         df_filtered = df_filtered.replace([np.inf, -np.inf], np.nan)
         df_filtered = df_filtered.dropna(subset=[objective_column])
 
-        q1, q9 = compute_quantiles(df_filtered)
-        groupby_stop_val_median = df_filtered.groupby('stop_val').median()
-        color, marker = get_solver_style(solver)
+        # compute median of 'time' and objective_column
+        fields = ["time", objective_column]
+        groupby_stop_val_median = df_filtered.groupby('stop_val')
+        groupby_stop_val_median = groupby_stop_val_median[fields]
+        groupby_stop_val_median = groupby_stop_val_median.median()
 
+        q1, q9 = compute_quantiles(df_filtered)
+
+        color, marker = get_solver_style(solver)
         stopping_strategy = _get_solver_stopping_strategy(df_filtered)
 
         solver_data[solver] = {

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -19,3 +19,5 @@
 .. _Amélie Vernay: https://github.com/AmelieVernay
 
 .. _Melvine Nargeot: https://github.com/Melvin-klein
+
+.. _Badr Moufad: https://github.com/Badr-MOUFAD

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -11,14 +11,14 @@ Version 1.4 - in development
 ----------------------------
 
 CLI
----
+~~~
 
 - Add support for minute and hour unit suffix in timeout limit through the syntax
   ``--timeout 10m`` or ``--timeout 1h``.
   By `Mathurin Massias`_ (:gh:`535`).
 
 API
----
+~~~
 
 - Add :class:`~benchopt.stopping_criterion.SingleRunCriterion` to run a solver
   only once. This can be used for benchmarking methods where we are interested
@@ -30,8 +30,14 @@ API
 - Add :func:`~benchopt.BaseSolver.pre_run_hook` hook to ignore cost that cannot
   be cached globally for a solver. By `Thomas Moreau`_ (:gh:`525`)
 
+PLOT
+~~~~
+
+- Enable visualizing the objective as function of ``stopping_criterion``: time,
+  iteration, or tolerance. By `Badr Moufad`_ (:gh:`546`)
+
 FIX
----
+~~~
 
 - Do not fail and raise a warning when ``safe_import_context`` is not named
   ``import_ctx``. By `Mathurin Massias`_ (:gh:`524`)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,7 +34,7 @@ PLOT
 ~~~~
 
 - Enable visualizing the objective as function of ``stopping_criterion``: time,
-  iteration, or tolerance. By `Badr Moufad`_ (:gh:`546`)
+  iteration, or tolerance. By `Badr Moufad`_ (:gh:`479`)
 
 FIX
 ~~~


### PR DESCRIPTION
After merging #479, we might have dropped the ability to replot previous benchmarks.

closes #545 