### PR TITLE
MNT update ubuntu 18.04 to ubuntu-latest (20.04) in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-n-publish:
     name: Release to PyPI and TestPyPI 📦
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Fixes failure of "release on PyPI" action  in https://github.com/benchopt/benchopt/actions/runs/4935551334?pr=231 for example

![image](https://github.com/benchopt/benchopt/assets/8993218/38d6b81d-3566-4069-923f-567ea5ef68c7)
