### PR TITLE
PLT - Add objective description

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -93,6 +93,14 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             fname = fname_in_output
         fname = fname.absolute().relative_to(root_html.absolute())
 
+        # get obj description
+        # wrap in try-except block to preserve compatibility
+        # with older version
+        try:
+            obj_description = df["obj_description"].unique()[0]
+        except KeyError:
+            obj_description = ""
+
         # Generate figures
         result = dict(
             fname=fname,
@@ -101,7 +109,7 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             sysinfo=sysinfo,
             dataset_names=df['data_name'].unique(),
             objective_names=df['objective_name'].unique(),
-            obj_description=df["obj_description"].unique()[0],
+            obj_description=obj_description,
             obj_cols=[k for k in df.columns if k.startswith('objective_')
                       and k != 'objective_name'],
             kinds=list(kinds),

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -93,9 +93,9 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             fname = fname_in_output
         fname = fname.absolute().relative_to(root_html.absolute())
 
-        # get obj description
-        # wrap in try-except block to preserve compatibility
-        # with older version
+        # get objective description and use `obj_` instead of `objective_`
+        # to avoid conflicts with objective metrics
+        # try-except block to preserve compatibility with benchopt <= v1.3.1
         try:
             obj_description = df["obj_description"].unique()[0]
         except KeyError:

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -101,6 +101,7 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             sysinfo=sysinfo,
             dataset_names=df['data_name'].unique(),
             objective_names=df['objective_name'].unique(),
+            obj_description=df["obj_description"].unique()[0],
             obj_cols=[k for k in df.columns if k.startswith('objective_')
                       and k != 'objective_name'],
             kinds=list(kinds),

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -93,14 +93,6 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             fname = fname_in_output
         fname = fname.absolute().relative_to(root_html.absolute())
 
-        # get objective description and use `obj_` instead of `objective_`
-        # to avoid conflicts with objective metrics
-        # try-except block to preserve compatibility with benchopt <= v1.3.1
-        try:
-            obj_description = df["obj_description"].unique()[0]
-        except KeyError:
-            obj_description = ""
-
         # Generate figures
         result = dict(
             fname=fname,
@@ -109,7 +101,6 @@ def get_results(fnames, kinds, root_html, benchmark_name, copy=False):
             sysinfo=sysinfo,
             dataset_names=df['data_name'].unique(),
             objective_names=df['objective_name'].unique(),
-            obj_description=obj_description,
             obj_cols=[k for k in df.columns if k.startswith('objective_')
                       and k != 'objective_name'],
             kinds=list(kinds),
@@ -157,6 +148,15 @@ def get_metadata(df):
         metadata["solvers_description"] = solvers_description.to_dict()
     except KeyError:
         metadata["solvers_description"] = {}
+
+    # to avoid conflicts with objective metrics
+    # get objective description and use `obj_` instead of `objective_`
+    # try-except block to preserve compatibility with benchopt <= v1.3.1
+    try:
+        obj_description = df["obj_description"].unique()[0]
+        metadata["obj_description"] = obj_description
+    except KeyError:
+        metadata["obj_description"] = ""
 
     return metadata
 

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -317,3 +317,25 @@ input:checked+.slider:before {
 .space-r-2 > * {
   margin-right: 0.5rem;
 }
+
+
+.objective-description-content {
+  display: flex;
+  visibility: hidden;
+  background-color: rgb(55 65 81);
+  color: #fff;
+  border-radius: 6px;
+  padding: 0.5em;
+  padding-right: 1rem;
+  opacity: 90%;
+  max-width: 300px;
+  max-height: 500px;
+  white-space: pre-wrap;
+  position: absolute;
+  transform: translate(0%, -150%);
+  z-index: 99999;
+}
+
+.objective-description-icon:hover .objective-description-content {
+  visibility: visible;
+}

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -347,19 +347,11 @@ input:checked+.slider:before {
 
 .objective-description-icon {
   width: 1.25rem;
-  align-self:center;
+  align-self: center;
 
   border-radius: 50%;
-  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.25);
-  animation: pulse ease-out 2s infinite;
 }
 
 .objective-description-trigger:hover .objective-description-content {
   visibility: visible;
-}
-
-@keyframes pulse {
-	0% {box-shadow: 0 0 0 0 rgb(255, 255, 255, 0.25);}
-	70% {box-shadow: 0 0 0 0.25em rgb(255, 255, 255, 0.25);}
-	100% {box-shadow: 0 0 0 0 rgb(255, 255, 255, 0.25);}
 }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -321,9 +321,11 @@ input:checked+.slider:before {
 
 .objective-description-content {
   visibility: hidden;
+
   background-color: rgb(55 65 81);
   color: #fff;
   border-radius: 6px;
+  margin-top: 1.5em;
   padding-right: 0.5em;
   padding-left: 0.5em;
   padding-top: 1em;
@@ -331,12 +333,33 @@ input:checked+.slider:before {
   opacity: 90%;
   max-width: 250px;
   max-height: 200px;
+
   overflow-y: auto;
   white-space: pre-wrap;
   position: absolute;
   z-index: 99999;
 }
 
-.objective-description-icon:hover .objective-description-content {
+.objective-description-trigger {
+  display: flex;
+  flex-direction: row;
+}
+
+.objective-description-icon {
+  width: 1.25rem;
+  align-self:center;
+
+  border-radius: 50%;
+  box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.25);
+  animation: pulse ease-out 2s infinite;
+}
+
+.objective-description-trigger:hover .objective-description-content {
   visibility: visible;
+}
+
+@keyframes pulse {
+	0% {box-shadow: 0 0 0 0 rgb(255, 255, 255, 0.25);}
+	70% {box-shadow: 0 0 0 0.25em rgb(255, 255, 255, 0.25);}
+	100% {box-shadow: 0 0 0 0 rgb(255, 255, 255, 0.25);}
 }

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -320,19 +320,20 @@ input:checked+.slider:before {
 
 
 .objective-description-content {
-  display: flex;
   visibility: hidden;
   background-color: rgb(55 65 81);
   color: #fff;
   border-radius: 6px;
-  padding: 0.5em;
-  padding-right: 1rem;
+  padding-right: 0.5em;
+  padding-left: 0.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
   opacity: 90%;
-  max-width: 300px;
-  max-height: 500px;
+  max-width: 250px;
+  max-height: 200px;
+  overflow-y: auto;
   white-space: pre-wrap;
   position: absolute;
-  transform: translate(0%, -150%);
   z-index: 99999;
 }
 

--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -362,7 +362,7 @@ input:checked+.slider:before {
   padding-top: 1em;
   padding-bottom: 1em;
   opacity: 90%;
-  max-width: 250px;
+  max-width: 80ch;
   max-height: 200px;
 
   overflow-y: auto;

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -59,9 +59,11 @@
                                 <label for="objective_column" class="block">Objective column</label>
                                 <!--don't show description unless it is provided -->
                                 % if result['obj_description'] != "":
-                                    <span class="objective-description-icon" style="cursor: pointer;">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-4 h-4" viewBox="0 0 512 512">
-                                            <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>
+                                    <span class="objective-description-trigger" style="cursor: pointer;">
+                                        <span style="margin-right: 0.5em;">(hover over)</span>
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="objective-description-icon" viewBox="0 0 512 512">
+                                            <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
+                                        </svg>
                                         <div class="objective-description-content">${result['obj_description']}</div>
                                     </span>
                                 % endif

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -60,7 +60,7 @@
                                 <!--don't show description unless it is provided -->
                                 % if result['obj_description'] != "":
                                     <span class="objective-description-trigger" style="cursor: pointer;">
-                                        <span style="margin-right: 0.5em;">(hover over)</span>
+                                        <span style="margin-right: 0.5em;">(description)</span>
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="objective-description-icon" viewBox="0 0 512 512">
                                             <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
                                         </svg>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -58,13 +58,13 @@
                             <div class="flex flex-row items-center justify-between text-sm font-medium text-white">
                                 <label for="objective_column" class="block">Objective column</label>
                                 <!--don't show description unless it is provided -->
-                                % if result['obj_description'] != "":
+                                % if result['metadata']['obj_description'] != "":
                                     <span class="objective-description-trigger" style="cursor: pointer;">
                                         <span style="margin-right: 0.5em;">(description)</span>
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="objective-description-icon" viewBox="0 0 512 512">
                                             <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
                                         </svg>
-                                        <div class="objective-description-content">${result['obj_description']}</div>
+                                        <div class="objective-description-content">${result['metadata']['obj_description']}</div>
                                     </span>
                                 % endif
                             </div>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -60,7 +60,7 @@
                                 <!--don't show description unless it is provided -->
                                 % if result['metadata']['obj_description'] != "":
                                     <span class="objective-description-trigger" style="cursor: pointer;">
-                                        <span style="margin-right: 0.5em;">(description)</span>
+                                        <span style="margin-right: 0.5em;">description</span>
                                         <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="objective-description-icon" viewBox="0 0 512 512">
                                             <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/>
                                         </svg>

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -55,7 +55,14 @@
                             </div>
                         </div>
                         <div class="mt-8 px-8">
-                            <label for="objective_column" class="block text-sm font-medium text-white">Objective column</label>
+                            <div class="flex flex-row items-center justify-between text-sm font-medium text-white">
+                                <label for="objective_column" class="block">Objective column</label>
+                                <span class="objective-description-icon" style="cursor: pointer;">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-4 h-4" viewBox="0 0 512 512">
+                                        <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>
+                                    <div class="objective-description-content">Some description of the objective</div>
+                                </span>
+                            </div>
                             <div class="mt-1 rounded-md shadow-sm">
                                 <select id="objective_column" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({objective_column: this.value})">
                                     % for obj_col in result['obj_cols']:

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -57,11 +57,14 @@
                         <div class="mt-8 px-8">
                             <div class="flex flex-row items-center justify-between text-sm font-medium text-white">
                                 <label for="objective_column" class="block">Objective column</label>
-                                <span class="objective-description-icon" style="cursor: pointer;">
-                                    <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-4 h-4" viewBox="0 0 512 512">
-                                        <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>
-                                    <div class="objective-description-content">${result['obj_description']}</div>
-                                </span>
+                                <!--don't show description unless it is provided -->
+                                % if result['obj_description'] != "":
+                                    <span class="objective-description-icon" style="cursor: pointer;">
+                                        <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-4 h-4" viewBox="0 0 512 512">
+                                            <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>
+                                        <div class="objective-description-content">${result['obj_description']}</div>
+                                    </span>
+                                % endif
                             </div>
                             <div class="mt-1 rounded-md shadow-sm">
                                 <select id="objective_column" class="focus:ring-blue-500 focus:border-blue-500 block w-full h-8 px-4 sm:text-sm border-gray-300 rounded-md" onchange="setState({objective_column: this.value})">

--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -60,7 +60,7 @@
                                 <span class="objective-description-icon" style="cursor: pointer;">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-4 h-4" viewBox="0 0 512 512">
                                         <path d="M464 256A208 208 0 1 0 48 256a208 208 0 1 0 416 0zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm169.8-90.7c7.9-22.3 29.1-37.3 52.8-37.3h58.3c34.9 0 63.1 28.3 63.1 63.1c0 22.6-12.1 43.5-31.7 54.8L280 264.4c-.2 13-10.9 23.6-24 23.6c-13.3 0-24-10.7-24-24V250.5c0-8.6 4.6-16.5 12.1-20.8l44.3-25.4c4.7-2.7 7.6-7.7 7.6-13.1c0-8.4-6.8-15.1-15.1-15.1H222.6c-3.4 0-6.4 2.1-7.5 5.3l-.4 1.2c-4.4 12.5-18.2 19-30.6 14.6s-19-18.2-14.6-30.6l.4-1.2zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"/></svg>
-                                    <div class="objective-description-content">Some description of the objective</div>
+                                    <div class="objective-description-content">${result['obj_description']}</div>
                                 </span>
                             </div>
                             <div class="mt-1 rounded-md shadow-sm">

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -187,6 +187,13 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     if stopping_strategy == 'callback':
         stopping_strategy = 'iteration'
 
+    # get objective description
+    # use `obj_` instead of `objective_` to avoid conflicts with
+    # the name of metrics in Objective.compute
+    obj_description = objective.__doc__
+    if obj_description is None:
+        obj_description = ""
+
     for rep in range(n_repetitions):
 
         output.set(rep=rep)
@@ -196,7 +203,8 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             solver_name=str(solver),
             data_name=str(dataset),
             idx_rep=rep,
-            stopping_strategy=stopping_strategy.capitalize()
+            stopping_strategy=stopping_strategy.capitalize(),
+            obj_description=obj_description,
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -190,9 +190,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     # get objective description
     # use `obj_` instead of `objective_` to avoid conflicts with
     # the name of metrics in Objective.compute
-    obj_description = objective.__doc__
-    if obj_description is None:
-        obj_description = ""
+    obj_description = objective.__doc__ or ""
 
     for rep in range(n_repetitions):
 
@@ -205,9 +203,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             idx_rep=rep,
             stopping_strategy=stopping_strategy.capitalize(),
             obj_description=obj_description,
-            solver_description=(
-                solver.__doc__ if solver.__doc__ is not None else ""
-            ),
+            solver_description=solver.__doc__ or "",
         )
 
         stopping_criterion = solver.stopping_criterion.get_runner_instance(

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -6,6 +6,14 @@ with safe_import_context() as import_ctx:
 
 
 class Objective(BaseObjective):
+    """Here one can provide a description of the Objetive.
+
+    Lorem ipsum dolor sit amet. Eos voluptatem natus ab vero voluptatum est
+    excepturi saepe non minima alias sed laboriosam optio qui dolores autem
+    sit quae sequi. Cum dolorem maxime est perferendis dolores aut veritatis
+    officia ad voluptas quisquam in consequuntur aperiam qui optio sint.
+    """
+
     name = "Dummy Sparse Regression"
 
     # Make sure we can run with the current version

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -33,6 +33,9 @@ API
 PLOT
 ~~~~
 
+- Add a tooltip beside to show description of objective. Description is provided as docstring of
+  the :class:`~benchopt.BaseObjective` class. By `Badr Moufad`_ (:gh:`556`)
+
 - Show solver description when hovering over solvers. Description is provided as docstring of
   the :class:`~benchopt.BaseSolver` class. By `Badr Moufad`_ (:gh:`543`)
 


### PR DESCRIPTION
This adds the possibility to provide details about the objective metrics, for instance, value and support size.

It exposes an icon beside ``objective_column`` which when hovered shows a description of the objective metrics.
[Live preview of the feature](https://badr-moufad.github.io/share-benchmarks/prev_objective_desc/generated_df_lasso_bench.html).

------
revival of #523 