### PR TITLE
Created error message for requirements error

### DIFF
--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -466,6 +466,50 @@ class TestInstallCmd:
 
         out.check_output(r"done \(not enough run\)", repetition=1)
 
+    @pytest.mark.parametrize("cls_type", ['dataset', 'solver'])
+    def test_error_wih_missing_requirements(self, test_env_name, cls_type):
+        # if cls_type == "solver":
+        Cls = cls_type.capitalize()
+
+        # solver with missing dependency specified
+        src = (
+            f"from benchopt import Base{Cls}\n"
+            "from benchopt import safe_import_context\n"
+            "\n"
+            "with safe_import_context() as import_ctx:\n"
+            "    import sjdhfg\n"
+            f"class {Cls}(Base{Cls}):\n"
+            "    name = 'buggy-cls'\n"
+            "    def __init__(self):\n"
+            "        pass\n"
+            "    def set_objective(self):\n"
+            "        pass\n"
+            "    def get_data(self):\n"
+            "        {}\n"
+            "    def get_result(self):\n"
+            "        pass\n"
+            "    def run(self):\n"
+            "        pass\n"
+        )
+
+        TmpFileCtx = tempfile.NamedTemporaryFile
+        solver_dir = DUMMY_BENCHMARK_PATH / f"{cls_type}s"
+
+        with TmpFileCtx("w+", suffix='.py', dir=solver_dir) as tmp_solver:
+
+            tmp_solver.write(src)
+            tmp_solver.flush()
+
+            install_args = [
+                str(DUMMY_BENCHMARK_PATH),
+                '--env-name', test_env_name,
+                f'-{cls_type[0]}', "buggy-cls"
+            ]
+
+            error_match = f"Could not import the class {Cls} for buggy-cls"
+            with pytest.raises(AttributeError, match=error_match):
+                install(install_args, 'benchopt', standalone_mode=False)
+
     def test_shell_complete(self):
         # Completion for benchmark name
         _test_shell_completion(install, [], BENCHMARK_COMPLETION_CASES)

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -506,7 +506,7 @@ class TestInstallCmd:
                 f'-{cls_type[0]}', "buggy-cls"
             ]
 
-            error_match = f"Could not import the class {Cls} for buggy-cls"
+            error_match = f"Could not find dependencies for buggy-cls {Cls}"
             with pytest.raises(AttributeError, match=error_match):
                 install(install_args, 'benchopt', standalone_mode=False)
 

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -99,19 +99,18 @@ class DependenciesMixin:
             try:
                 cls._pre_install_hook(env_name=env_name)
                 if cls.install_cmd == 'conda':
-                    try:
+                    if hasattr(cls, "requirements"):
                         install_in_conda_env(*cls.requirements,
                                              env_name=env_name,
                                              force=force)
-                    except AttributeError:
-                        print(
-                            "Missing 'requirements' variable in Solver",
-                            "class.\nRequirements must be a list containing",
-                            "the name of the package that you are",
-                            "using for the solver (except scikit-learn).\n",
-                            "\rExamples :\n",
-                            "\rrequirements = ['package'] (conda package)\n",
-                            "\rrequirements = ['pip:package'] (Pypi package)"
+                    else:
+                        raise AttributeError(
+                            """Missing 'requirements' variable in Solver class.
+                            \rRequirements must be a list containing the name of the package that
+                            \ryou are using for the solver (except scikit-learn).\n
+                            \rExamples :
+                            \rrequirements = ['package'] (conda package)
+                            \rrequirements = ['pip:package'] (Pypi package)"""
                         )
                 elif cls.install_cmd == 'shell':
                     install_file = (

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -105,7 +105,13 @@ class DependenciesMixin:
                                              force=force)
                     except AttributeError:
                         print(
-                            "Missing 'requirements' variable in Solver class"
+                            "Missing 'requirements' variable in Solver",
+                            "class.\nRequirements must be a list containing",
+                            "the name of the package that you are",
+                            "using for the solver (except scikit-learn).\n",
+                            "\rExamples :\n",
+                            "\rrequirements = ['package'] (conda package)\n",
+                            "\rrequirements = ['pip:package'] (Pypi package)"
                         )
                 elif cls.install_cmd == 'shell':
                     install_file = (

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -105,16 +105,19 @@ class DependenciesMixin:
                                              force=force)
                     else:
                         # get details of class
-                        cls_file_name = cls._module_filename
                         cls_type = cls.__base__.__name__.replace("Base", "")
 
                         raise AttributeError(
-                            f"Missing `requirements` attribute for {cls_type}"
-                            f"in {cls_file_name}. Attribute `requirements` "
-                            "must be a list of the solver dependencies.\n"
+                            f"Could not find dependencies for {cls.name} "
+                            f"{cls_type} while it is not importable. This is "
+                            "probably due to missing dependency specification."
+                            " The dependencies should be specified in class "
+                            "attribute `requirements`.\n"
                             "Examples:\n"
-                            "   requirements = ['package'] (conda package)\n"
-                            "   requirements = ['pip:package'] (PyPi package)"
+                            "   requirements = ['pkg'] # conda package `pkg`\n"
+                            "   requirements = ['chan:pkg'] # package `pkg` in"
+                            "conda channel `chan`\n"
+                            "   requirements = ['pip:pkg'] # pip package `pkg`"
                         )
                 elif cls.install_cmd == 'shell':
                     install_file = (
@@ -166,6 +169,21 @@ class DependenciesMixin:
             cls._pre_install_hook(env_name=env_name)
             if cls.install_cmd == 'conda':
                 conda_reqs = getattr(cls, "requirements", [])
+                if not is_installed:
+                    # get details of class
+                    cls_type = cls.__base__.__name__.replace("Base", "")
+                    raise AttributeError(
+                        f"Could not find dependencies for {cls.name} "
+                        f"{cls_type} while it is not importable. This is "
+                        "probably due to missing dependency specification. "
+                        "The dependencies should be specified in class "
+                        "attribute `requirements`.\n"
+                        "Examples:\n"
+                        "   requirements = ['pkg'] # conda package `pkg`\n"
+                        "   requirements = ['chan:pkg'] # package `pkg` in"
+                        "conda channel `chan`\n"
+                        "   requirements = ['pip:pkg'] # PyPi package `pkg`"
+                    )
             elif cls.install_cmd == 'shell':
                 shell_install_scripts = [
                     cls._module_filename.parents[1] / 'install_scripts' /

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -104,13 +104,17 @@ class DependenciesMixin:
                                              env_name=env_name,
                                              force=force)
                     else:
+                        # get details of class
+                        cls_file_name = cls._module_filename
+                        cls_type = cls.__base__.__name__.replace("Base", "")
+
                         raise AttributeError(
-                            """Missing 'requirements' variable in Solver class.
-                            \rRequirements must be a list containing the name of the package that
-                            \ryou are using for the solver (except scikit-learn).\n
-                            \rExamples :
-                            \rrequirements = ['package'] (conda package)
-                            \rrequirements = ['pip:package'] (Pypi package)"""
+                            f"Missing `requirements` attribute for {cls_type}"
+                            f"in {cls_file_name}. Attribute `requirements` "
+                            "must be a list of the solver dependencies.\n"
+                            "Examples:\n"
+                            "   requirements = ['package'] (conda package)\n"
+                            "   requirements = ['pip:package'] (PyPi package)"
                         )
                 elif cls.install_cmd == 'shell':
                     install_file = (

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -99,8 +99,14 @@ class DependenciesMixin:
             try:
                 cls._pre_install_hook(env_name=env_name)
                 if cls.install_cmd == 'conda':
-                    install_in_conda_env(*cls.requirements, env_name=env_name,
-                                         force=force)
+                    try:
+                        install_in_conda_env(*cls.requirements,
+                                             env_name=env_name,
+                                             force=force)
+                    except AttributeError:
+                        print(
+                            "Missing 'requirements' variable in Solver class"
+                        )
                 elif cls.install_cmd == 'shell':
                     install_file = (
                         cls._module_filename.parents[1] / 'install_scripts' /

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -169,7 +169,7 @@ class DependenciesMixin:
             cls._pre_install_hook(env_name=env_name)
             if cls.install_cmd == 'conda':
                 conda_reqs = getattr(cls, "requirements", [])
-                if not is_installed:
+                if not is_installed and len(conda_reqs) == 0:
                     # get details of class
                     cls_type = cls.__base__.__name__.replace("Base", "")
                     raise AttributeError(


### PR DESCRIPTION
Added an error message in `install` method of `DependenciesMixin` class to make error `AttributeError: type object 'Solver' has no attribute 'requirements'` understandable.