### PR TITLE
Fix exception in shape_solvers_for_html when objective column has all nan values

### DIFF
--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -208,6 +208,8 @@ def shape_solvers_for_html(df, objective_column):
         # remove infinite values
         df_filtered = df_filtered.replace([np.inf, -np.inf], np.nan)
         df_filtered = df_filtered.dropna(subset=[objective_column])
+        if len(df_filtered) == 0:
+            continue
 
         # compute median of 'time' and objective_column
         fields = ["time", objective_column]


### PR DESCRIPTION
As observed in one case with @tomMoral this afternoon.

Here is the full traceback:

```
benchopt plot .
```
```python-traceback
Processing outputs/benchopt_run_2023-06-21_17h02m11.parquet
/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py:216: FutureWarning: The default value of numeric_only in DataFrameGroupBy.median is deprecated. In a future version, numeric_only will default to False. Either specify numeric_only or select only columns which should be valid for the function.
  groupby_stop_val_median = groupby_stop_val_median.median()
Traceback (most recent call last):
  File "/Users/ogrisel/mambaforge/envs/dev/bin/benchopt", line 8, in <module>
    sys.exit(benchopt())
             ^^^^^^^^^^
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/mambaforge/envs/dev/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/cli/process_results.py", line 70, in plot
    plot_benchmark(result_filename, benchmark, kinds=kinds, display=display,
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/__init__.py", line 47, in plot_benchmark
    plot_benchmark_html(fname, benchmark, kinds, display)
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 485, in plot_benchmark_html
    results = get_results(fnames, kinds, root_html, benchmark.name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 111, in get_results
    result['json'] = json.dumps(shape_datasets_for_html(df))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 160, in shape_datasets_for_html
    datasets_data[dataset] = shape_objectives_for_html(df, dataset)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 170, in shape_objectives_for_html
    objectives_data[objective] = shape_objectives_columns_for_html(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 189, in shape_objectives_columns_for_html
    'solvers': shape_solvers_for_html(df_filtered, column),
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ogrisel/code/benchopt/benchopt/plotting/generate_html.py", line 233, in shape_solvers_for_html
    raise Exception(
Exception: Solver can be run using only one stopping strategy. Expected one stopping strategy but found
```