### PR TITLE
ENH - make ``get_next`` a regular solver method

### DIFF
--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -131,10 +131,8 @@ class StoppingCriterion():
 
         # Override get_next_stop_val if ``get_next`` is implemented for solver.
         if hasattr(solver, 'get_next'):
-            assert (
-                callable(solver.get_next)
-                # and type(solver.get_next) == staticmethod
-            ), "if defined, get_next should be a static method of the solver."
+            assert (callable(solver.get_next))
+
             try:
                 solver.get_next(1)
             except TypeError:

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -133,7 +133,8 @@ class StoppingCriterion():
         if hasattr(solver, 'get_next'):
             if callable(solver.get_next):
                 raise TypeError(
-                    f"`get_next` in {solver.__module__} must be callable."
+                    f"`get_next` of Solver in {solver.__module__} "
+                    "must be callable."
                 )
 
             try:
@@ -141,8 +142,7 @@ class StoppingCriterion():
             except TypeError:
                 raise ValueError(
                     "get_next(1) throw a TypeError. Verify that `get_next` "
-                    "signature is get_next(stop_val) and that it is "
-                    "a staticmethod."
+                    "signature is get_next(self, stop_val)"
                 )
 
             stopping_criterion.get_next_stop_val = solver.get_next

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -131,7 +131,7 @@ class StoppingCriterion():
 
         # Override get_next_stop_val if ``get_next`` is implemented for solver.
         if hasattr(solver, 'get_next'):
-            if callable(solver.get_next):
+            if not callable(solver.get_next):
                 raise TypeError(
                     f"`get_next` of Solver in {solver.__module__} "
                     "must be callable."

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -131,7 +131,10 @@ class StoppingCriterion():
 
         # Override get_next_stop_val if ``get_next`` is implemented for solver.
         if hasattr(solver, 'get_next'):
-            assert (callable(solver.get_next))
+            if callable(solver.get_next):
+                raise TypeError(
+                    f"`get_next` in {solver.__module__} must be callable."
+                )
 
             try:
                 solver.get_next(1)

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -115,7 +115,7 @@ def test_solver_class(benchmark, solver_class):
     if hasattr(solver_class, 'get_next'):
         assert callable(solver_class.get_next), (
             "`get_next` for class Solver in "
-            f"'{solver_class.__module__}' should be a callable static method."
+            f"'{solver_class.__module__}' should be a callable."
         )
         # Make sure the signature is def get_next(int):
         solver_class.get_next(0)

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -1,6 +1,5 @@
 import pytest
 import numbers
-import inspect
 
 import numpy as np
 
@@ -114,11 +113,7 @@ def test_solver_class(benchmark, solver_class):
 
     # Check that the solver_class uses a valid callable to override get_next.
     if hasattr(solver_class, 'get_next'):
-        is_static = isinstance(
-            inspect.getattr_static(solver_class, "get_next"),
-            staticmethod
-        )
-        assert (callable(solver_class.get_next) and is_static), (
+        assert callable(solver_class.get_next), (
             "`get_next` for class Solver in "
             f"'{solver_class.__module__}' should be a callable static method."
         )

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -117,8 +117,9 @@ def test_solver_class(benchmark, solver_class):
             "`get_next` for class Solver in "
             f"'{solver_class.__module__}' should be a callable."
         )
-        # Make sure the signature is def get_next(int):
-        solver_class.get_next(0)
+        # Make sure the signature is def get_next(self, int). Create instance
+        # of `solver_class` then call `get_next` since it is a class method
+        solver_class().get_next(0)
 
 
 def test_solver_install_api(benchmark, solver_class):

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
@@ -52,6 +52,8 @@ class Solver(BaseSolver):
     def get_result(self):
         return self.w
 
-    @staticmethod
-    def get_next(stop_val):
+    def get_next(self, stop_val):
+        # check that we access instance parameters
+        self.X.shape[0] == self.y.shape[0]
+
         return stop_val + 1

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
@@ -54,6 +54,6 @@ class Solver(BaseSolver):
 
     def get_next(self, stop_val):
         # check that we access instance parameters
-        self.X.shape[0] == self.y.shape[0]
+        self.raise_error
 
         return stop_val + 1

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/solver_test.py
@@ -53,7 +53,4 @@ class Solver(BaseSolver):
         return self.w
 
     def get_next(self, stop_val):
-        # check that we access instance parameters
-        self.raise_error
-
         return stop_val + 1

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -109,7 +109,7 @@ objective. However, in some cases, this exponential growth might hide some
 effects, or might not be adapted to a given solver.
 
 The way this value is changed can be specified for each solver by
-implementing a static ``get_next`` method in the ``Solver`` class.
+implementing a ``get_next`` method in the ``Solver`` class.
 This method takes as input the previous value where the objective
 function has been logged, and outputs the next one. For instance,
 if a solver needs to be evaluated every 10 iterations, we would have
@@ -118,8 +118,7 @@ if a solver needs to be evaluated every 10 iterations, we would have
 
     class Solver(BaseSolver):
         ...
-        @staticmethod
-        def get_next(stop_val):
+        def get_next(self, stop_val):
             return stop_val + 10
 
 

--- a/doc/performance_curves.rst
+++ b/doc/performance_curves.rst
@@ -40,7 +40,7 @@ This stopping strategy creates curves by calling ``Solver.run(stop_val)`` severa
 In both cases, if the objective curve is flat (i.e., the variation of the objective between two points is numerically 0), the geometric rate :math:`\rho` is multiplied by 1.2.
 
 Note that the solver is restarted from scratch at each call to ``solver.run``.
-For more advanced configurations, the evolution of ``stop_val`` can be controlled on a per solver basis, by implementing a static  ``Solver.get_next`` method, which receives the current value for tolerance/number of iterations, and returns the next one.
+For more advanced configurations, the evolution of ``stop_val`` can be controlled on a per solver basis, by implementing a ``Solver.get_next`` method, which receives the current value for tolerance/number of iterations, and returns the next one.
 
 2. Using a callback
 -------------------

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,6 +20,9 @@ CLI
 API
 ~~~
 
+- Enable accessing :class:`~benchopt.BaseSolver` attributes in ``get_next``.
+  By `Badr Moufad`_ (:gh:`566`)
+
 - Add :class:`~benchopt.stopping_criterion.SingleRunCriterion` to run a solver
   only once. This can be used for benchmarking methods where we are interested
   in objective value at convergence. By `Thomas Moreau`_ (:gh:`511`)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,7 +20,7 @@ CLI
 API
 ~~~
 
-- Enable accessing :class:`~benchopt.BaseSolver` attributes in ``get_next``.
+- The ``get_next`` method of :class:`~benchopt.BaseSolver` is no longer static.
   By `Badr Moufad`_ (:gh:`566`)
 
 - Add :class:`~benchopt.stopping_criterion.SingleRunCriterion` to run a solver


### PR DESCRIPTION
This enables accessing solvers parameters and attributes by making `get_next` a regular method instead of `staticmethod`

closes #564 
