### PR TITLE
ENH: add a warm_up function in the solvers

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -200,7 +200,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
     def run_once(self, stop_val=1):
         """Run the solver once, to cache warmup times (e.g. pre-compilations).
 
-        This function is intended to be called in ``Solver.set_objective``
+        This function is intended to be called in ``Solver.warm_up``
         method to avoid taking into account a solver's warmup costs.
 
         Parameters
@@ -231,7 +231,10 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
             self.run(stop_val)
 
     def warm_up(self):
-        """User specified warm up step, called once before the runs"""
+        """User specified warm up step, called once before the runs.
+        The time it takes to run this function is not taken into account.
+        The function `Solver.run_once` can be used here for solvers that 
+        require jit compilation."""
         ...
     
     def _warm_up(self):

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -238,9 +238,9 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
         ...
 
     def _warm_up(self):
-        if not getattr(self, 'warmup_done', True):
+        if not getattr(self, '_warmup_done', True):
             self.warm_up()
-            self.warmup_done = True
+            self._warmup_done = True
 
     @staticmethod
     def _reconstruct(module_filename, parameters, objective, output,

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -232,9 +232,11 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
 
     def warm_up(self):
         """User specified warm up step, called once before the runs.
+
         The time it takes to run this function is not taken into account.
         The function `Solver.run_once` can be used here for solvers that
-        require jit compilation."""
+        require jit compilation.
+        """
         ...
 
     def _warm_up(self):

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -233,10 +233,10 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
     def warm_up(self):
         """User specified warm up step, called once before the runs.
         The time it takes to run this function is not taken into account.
-        The function `Solver.run_once` can be used here for solvers that 
+        The function `Solver.run_once` can be used here for solvers that
         require jit compilation."""
         ...
-    
+
     def _warm_up(self):
         if not getattr(self, 'warmup_done', True):
             self.warm_up()

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -230,6 +230,15 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
         else:
             self.run(stop_val)
 
+    def warm_up(self):
+        """User specified warm up step, called once before the runs"""
+        return
+    
+    def _warm_up(self):
+        if not getattr(self, 'warmup_done', True):
+            self.warm_up()
+            self.warmup_done = True
+
     @staticmethod
     def _reconstruct(module_filename, parameters, objective, output,
                      pickled_module_hash=None, benchmark_dir=None):

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -232,7 +232,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
 
     def warm_up(self):
         """User specified warm up step, called once before the runs"""
-        return
+        ...
     
     def _warm_up(self):
         if not getattr(self, 'warmup_done', True):

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -90,7 +90,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
         The status on which the solver was stopped.
     """
 
-    # The warm-up step is only done once
+    # The warm-up step called for each repetition bit only run once.
     solver._warm_up()
 
     curve = []
@@ -241,8 +241,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     print(end='', flush=True)
 
     # refresh the solver warm up flag so that warm-up is done again
-    # in the future
-
+    # when calling the solver with another problem/dataset pair.
     solver._warmup_done = False
 
     if status == 'interrupted':

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -90,6 +90,9 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
         The status on which the solver was stopped.
     """
 
+    # The warm-up step is only done once
+    solver._warm_up()
+
     curve = []
     with exception_handler(output, pdb=pdb) as ctx:
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -243,7 +243,7 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     # refresh the solver warm up flag so that warm-up is done again
     # in the future
 
-    solver.warmup_done = False
+    solver._warmup_done = False
 
     if status == 'interrupted':
         raise SystemExit(1)

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -240,6 +240,11 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     # Make sure to flush so the parallel output is properly display
     print(end='', flush=True)
 
+    # refresh the solver warm up flag so that warm-up is done again
+    # in the future
+
+    solver.warmup_done = False
+
     if status == 'interrupted':
         raise SystemExit(1)
     return run_statistics

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -170,13 +170,14 @@ For some solvers, such as solver relying on just-in-time compilation with
 ``numba`` or ``jax``, the first iteration might be longer due to "warmup"
 effects. To avoid having such effect in the benchmark results, it is usually
 advised to call the solver once before running the benchmark. This should be
-implemented in the ``Solver.warm_up`` method, which is empty by default.
-For solvers with ``stopping_strategy`` in ``{'tolerance',  'iteration'}``, 
-simply calling the ``Solver.run`` with a simple enough value is usually enough.
-For solvers with ``stopping_strategy`` set to ``'callback'``, it is possible
-to call ``Solver.run_once``, which will call the ``run`` method with a simple
-callback that does not compute the objective value and stops after
-``n_iter`` calls to callback (default to 1).
+implemented in the ``Solver.warm_up`` method, which is empty by default and
+called after the `set_objective` method. For solvers with
+``stopping_strategy`` in ``{'tolerance',  'iteration'}``, simply calling the
+``Solver.run`` with a simple enough value is usually enough. For solvers with
+``stopping_strategy`` set to ``'callback'``, it is possible to call
+``Solver.run_once``, which will call the ``run`` method with a simple callback
+that does not compute the objective value and stops after ``n_iter`` calls to
+callback (default to 1).
 
 
 .. code-block:: python
@@ -185,7 +186,6 @@ callback that does not compute the objective value and stops after
         ...
 
         def warm_up(self):
-            ...
             # Cache pre-compilation and other one-time setups that should
             # not be included in the benchmark timing.
             self.run(1)  # For stopping_strategy == 'iteration' | 'tolerance'

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -169,13 +169,14 @@ Caching pre-compilation and warmup effects
 For some solvers, such as solver relying on just-in-time compilation with
 ``numba`` or ``jax``, the first iteration might be longer due to "warmup"
 effects. To avoid having such effect in the benchmark results, it is usually
-advised to call the solver once before running the benchmark, in the
-``Solver.set_objective`` method. For solvers with ``stopping_strategy`` in
-``{'tolerance',  'iteration'}``, simply calling the ``Solver.run`` with a
-simple enough value is usually enough. For solvers with ``stopping_strategy``
-set to ``'callback'``, it is possible to call ``Solver.run_once``, which will
-call the ``run`` method with a simple callback that does not compute the
-objective value and stops after ``n_iter`` calls to callback (default to 1).
+advised to call the solver once before running the benchmark. This should be
+implemented in the ``Solver.warm_up`` method, which is empty by default.
+For solvers with ``stopping_strategy`` in ``{'tolerance',  'iteration'}``, 
+simply calling the ``Solver.run`` with a simple enough value is usually enough.
+For solvers with ``stopping_strategy`` set to ``'callback'``, it is possible
+to call ``Solver.run_once``, which will call the ``run`` method with a simple
+callback that does not compute the objective value and stops after
+``n_iter`` calls to callback (default to 1).
 
 
 .. code-block:: python
@@ -183,7 +184,7 @@ objective value and stops after ``n_iter`` calls to callback (default to 1).
     class Solver(BaseSolver):
         ...
 
-        def set_objective(self, **objective):
+        def warm_up(self):
             ...
             # Cache pre-compilation and other one-time setups that should
             # not be included in the benchmark timing.

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -21,3 +21,5 @@
 .. _Melvine Nargeot: https://github.com/Melvin-klein
 
 .. _Badr Moufad: https://github.com/Badr-MOUFAD
+
+.. _Pierre Ablin: https://github.com/pierreablin

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -16,6 +16,10 @@ API
 - ``stopping_strategy`` attribute is replaced by ``sampling_strategy`` to clarify
   the concept, by `Mathurin Massias`_ (:gh:`585`).
 
+- Add ``Solver.warm_up`` function for explicit warmup instructions, such as
+  empty run for jitting. This function is called only once per solver.
+  By `Pierre Ablin`_ (:gh:`602`).
+
 .. _changes_1_4:
 
 Version 1.4 - 03/07/2023


### PR DESCRIPTION
This changes how to warm up solvers that are, e.g., jitted.

Previously, the warm-up was done in `set_objective`, so the warm-up is done even if the algorithm has already been run and the results are cached; warm-up was the bottleneck when results were already cached.

Now, the solvers have a `warm_up` method specified by the user,  and the warm_up method is called on the first `run_one_to_cvg` call. Hence, the warm_up is also in the cached function, so not run when results are already cached.

Not sure about the best way to code this is:

So far I have a `_warm_up` method that calls warm up if the flag `Solver.warmup_done` is False/ does not exist, but it would maybe be more explicit to play with the flag in the `run_one_to_cvg` function, WDYT?