### PR TITLE
PLT - Allow editing of title and axis label

### DIFF
--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -67,7 +67,7 @@ const makePlot = () => {
   const data = isBarChart() ? getBarData() : getScatterCurves();
   const layout = isBarChart() ? getBarChartLayout() : getScatterChartLayout();
 
-  Plotly.react(div, data, layout);
+  Plotly.react(div, data, layout, {editable: true});
 };
 
 /**


### PR DESCRIPTION
Just scrutinized the [Plotly JS documentation.](https://plotly.com/javascript/configuration-options/)
I find out that it is possible to enable editing of title and axis labels.

https://github.com/benchopt/benchopt/assets/65614794/7d0db536-b6b7-401d-9324-c52158eb0ddf

Here is a [live preview](https://badr-moufad.github.io/share-benchmarks/editable_plots/benchmark_lasso_benchopt_run_2023-07-05_15h56m19.html) of the feature.

@apmellot your feedback is valuable!
Also related to #600.