### PR TITLE
PLT - Fix solvers legend item vertically displayed

### DIFF
--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -391,7 +391,6 @@ input:checked+.slider:before {
 .solver-description-container {
   position: relative;
   display: inline-flex;
-  width: 100%;
 }
 
 .solver-description-content {
@@ -407,6 +406,7 @@ input:checked+.slider:before {
   padding-right: 0.5rem;
   opacity: 90%;
 
+  width: max-content;
   max-width: 80ch;
   max-height: 500px;
   white-space: pre-wrap;


### PR DESCRIPTION
After https://github.com/benchopt/benchopt/pull/575, a bug slipped through that made the solver legend item span the entire available space.

![Screenshot from 2023-07-10 11-05-20](https://github.com/benchopt/benchopt/assets/65614794/4532e5ec-771b-4005-b17a-89650514451d)

This fixes this malfunction.