### PR TITLE
Add support for MATLAB solver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,10 +52,6 @@ jobs:
           # Use miniforge to only get conda-forge as default channel.
           miniforge-version: latest
 
-      - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
-      - run: conda info
-
       - name: Install benchopt and its dependencies
         run: |
           conda info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
           # Use miniforge to only get conda-forge as default channel.
           miniforge-version: latest
 
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v1
       - run: conda info
 
       - name: Install benchopt and its dependencies

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,6 +32,7 @@ recursive-include examples *.txt
 
 # Include dummy benchmark for test
 recursive-include benchopt/tests/test_benchmarks *.R
+recursive-include benchopt/tests/test_benchmarks *.m
 recursive-include benchopt/tests/test_benchmarks *.jl
 recursive-include benchopt/tests/test_benchmarks *.py
 recursive-include benchopt/tests/test_benchmarks *.md

--- a/benchopt/helpers/matlab.py
+++ b/benchopt/helpers/matlab.py
@@ -22,6 +22,8 @@ def matlab_engine(paths):
     """
     import matlab.engine
     eng = matlab.engine.start_matlab()
+    if not isinstance(paths, list):
+        paths = [paths]
     for path in paths:
         eng.addpath(path)
     yield eng

--- a/benchopt/helpers/matlab.py
+++ b/benchopt/helpers/matlab.py
@@ -1,33 +1,38 @@
-from contextlib import contextmanager
-
 from benchopt.base import BaseSolver
 
 
 def assert_matlab_installed():
     import matlab
 
-@contextmanager
-def matlab_engine(paths):
-    """Context manager to start a matlab engine and close it properly.
+
+MATLAB_ENGINE = None # Global variable to store the matlab engine
+def get_matlab_engine(paths, background=False):
+    """
+    Return a matlab engine. If it does not exist, start it.
 
     Parameters
     ----------
-    paths : list of str or str
-        List of paths to add to the matlab path.
+    paths : str or list of str
+        Path to add to the matlab path.
+    async : bool
+        If True, start the engine in a separate process.
 
-    Yields
-    ------
-    eng : matlab.engine
+    Returns
+    -------
+    engine : matlab.engine
         The matlab engine.
     """
     import matlab.engine
-    eng = matlab.engine.start_matlab()
-    if not isinstance(paths, list):
+
+    global MATLAB_ENGINE
+    if MATLAB_ENGINE is None:
+        MATLAB_ENGINE = matlab.engine.start_matlab(background=background)
+    if isinstance(paths, str):
         paths = [paths]
     for path in paths:
-        eng.addpath(path)
-    yield eng
-    eng.quit()
+        MATLAB_ENGINE.addpath(path)
+
+    return MATLAB_ENGINE
 
 
 

--- a/benchopt/helpers/matlab.py
+++ b/benchopt/helpers/matlab.py
@@ -3,10 +3,10 @@ from contextlib import contextmanager
 from benchopt.base import BaseSolver
 
 
-def assert_julia_installed():
+def assert_matlab_installed():
     import matlab
 
-@contextmanager()
+@contextmanager
 def matlab_engine(paths):
     """Context manager to start a matlab engine and close it properly.
 
@@ -33,4 +33,4 @@ def matlab_engine(paths):
 
 class MatlabSolver(BaseSolver):
 
-    requirements = ['pip:matlabengine']
+    requirements = ['pip:matlabengine', 'numpy']

--- a/benchopt/helpers/matlab.py
+++ b/benchopt/helpers/matlab.py
@@ -2,10 +2,13 @@ from benchopt.base import BaseSolver
 
 
 def assert_matlab_installed():
-    import matlab
+    import matlab  # noqa: F401
 
 
-MATLAB_ENGINE = None # Global variable to store the matlab engine
+# Global variable to store the matlab engine
+MATLAB_ENGINE = None
+
+
 def get_matlab_engine(paths, background=False):
     """
     Return a matlab engine. If it does not exist, start it.
@@ -33,7 +36,6 @@ def get_matlab_engine(paths, background=False):
         MATLAB_ENGINE.addpath(path)
 
     return MATLAB_ENGINE
-
 
 
 class MatlabSolver(BaseSolver):

--- a/benchopt/helpers/matlab.py
+++ b/benchopt/helpers/matlab.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+
+from benchopt.base import BaseSolver
+
+
+def assert_julia_installed():
+    import matlab
+
+@contextmanager()
+def matlab_engine(paths):
+    """Context manager to start a matlab engine and close it properly.
+
+    Parameters
+    ----------
+    paths : list of str or str
+        List of paths to add to the matlab path.
+
+    Yields
+    ------
+    eng : matlab.engine
+        The matlab engine.
+    """
+    import matlab.engine
+    eng = matlab.engine.start_matlab()
+    for path in paths:
+        eng.addpath(path)
+    yield eng
+    eng.quit()
+
+
+
+class MatlabSolver(BaseSolver):
+
+    requirements = ['pip:matlabengine']

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
@@ -1,11 +1,10 @@
 function w = matlab_pgd(X, y, lambda, n_iter)
     L = norm(X, 'fro')^2;
-
     n_features = size(X, 2);
     w = zeros(n_features, 1);
     t_new = 1;
     for i = 1:n_iter
-        grad = X' * (X * w - y);
+        grad = X' * (X * w - y');
         w = w - grad / L;
         w = st(w, lambda / L);
     end

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
@@ -1,0 +1,18 @@
+function w = matlab_pgd(X, y, lambda, n_iter)
+    L = norm(X, 'fro')^2;
+
+    n_features = size(X, 2);
+    w = zeros(n_features, 1);
+    t_new = 1;
+    for i = 1:n_iter
+        grad = X' * (X * w - y);
+        w = w - grad / L;
+        w = st(w, lambda / L);
+    end
+
+    return w;
+end
+
+function w = st(w, t)
+    w = sign(w) .* max(abs(w) - t, 0);
+end

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.m
@@ -9,8 +9,6 @@ function w = matlab_pgd(X, y, lambda, n_iter)
         w = w - grad / L;
         w = st(w, lambda / L);
     end
-
-    return w;
 end
 
 function w = st(w, t)

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from benchopt import safe_import_context
+
+from benchopt.helpers.matlab import MatlabSolver
+from benchopt.helpers.matlab import matlab_engine, assert_matlab_installed
+
+with safe_import_context() as import_ctx:
+    import numpy as np
+    assert_matlab_installed()
+
+
+# File containing the function to be called from julia
+MATLAB_SOLVER_FILE = str(Path(__file__).with_suffix('.m'))
+
+
+class Solver(MatlabSolver):
+
+    # Config of the solver
+    name = 'Matlab-PGD'
+    sampling_strategy = 'iteration'
+
+    def set_objective(self, X, y, lmbd):
+        self.X, self.y, self.lmbd = X, y, lmbd
+
+
+    def run(self, n_iter):
+        with matlab_engine([str(Path(__file__).parent)]) as eng:
+            self.beta = eng.matlab_pgd(self.X, self.y, self.lmbd, n_iter, nargout=1)
+
+
+    def get_result(self):
+        return np.array(self.beta).ravel()

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
@@ -2,16 +2,15 @@ from pathlib import Path
 from benchopt import safe_import_context
 
 from benchopt.helpers.matlab import MatlabSolver
-from benchopt.helpers.matlab import matlab_engine, assert_matlab_installed
+from benchopt.helpers.matlab import get_matlab_engine, assert_matlab_installed
 
 with safe_import_context() as import_ctx:
     import numpy as np
     assert_matlab_installed()
 
-
 # File containing the function to be called from julia
-MATLAB_SOLVER_FILE = str(Path(__file__).with_suffix('.m'))
 
+MATLAB_SOLVER_FILE = str(Path(__file__).parent)
 
 class Solver(MatlabSolver):
 
@@ -22,10 +21,10 @@ class Solver(MatlabSolver):
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 
+        self.eng = get_matlab_engine(MATLAB_SOLVER_FILE)
 
     def run(self, n_iter):
-        with matlab_engine([str(Path(__file__).parent)]) as eng:
-            self.beta = eng.matlab_pgd(self.X, self.y, self.lmbd, n_iter, nargout=1)
+        self.beta = self.eng.matlab_pgd(self.X, self.y, self.lmbd, n_iter, nargout=1)
 
 
     def get_result(self):

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
@@ -8,7 +8,7 @@ with safe_import_context() as import_ctx:
     import numpy as np
     assert_matlab_installed()
 
-# File containing the function to be called from julia
+# File containing the function to be called from matlab
 
 MATLAB_SOLVER_FILE = str(Path(__file__).parent)
 

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/matlab_pgd.py
@@ -12,6 +12,7 @@ with safe_import_context() as import_ctx:
 
 MATLAB_SOLVER_FILE = str(Path(__file__).parent)
 
+
 class Solver(MatlabSolver):
 
     # Config of the solver
@@ -24,8 +25,9 @@ class Solver(MatlabSolver):
         self.eng = get_matlab_engine(MATLAB_SOLVER_FILE)
 
     def run(self, n_iter):
-        self.beta = self.eng.matlab_pgd(self.X, self.y, self.lmbd, n_iter, nargout=1)
-
+        self.beta = self.eng.matlab_pgd(
+            self.X, self.y, self.lmbd, n_iter, nargout=1
+        )
 
     def get_result(self):
         return np.array(self.beta).ravel()

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
@@ -1,5 +1,5 @@
 import sys
-from shutils import which
+from shutil import which
 import pytest
 
 

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/test_config.py
@@ -1,5 +1,5 @@
 import sys
-
+from shutils import which
 import pytest
 
 
@@ -16,3 +16,6 @@ def check_test_solver_install(solver_class):
 
     if solver_class.name.lower() in ["solver-test"]:
         pytest.skip('Test solver that cannot be installed, skipping.')
+
+    if 'matlab' in solver_class.name.lower() and which('matlab') is None:
+        pytest.skip('Matlab not testable in CI, skipping.')

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -46,7 +46,7 @@ BENCHMARK_COMPLETION_CASES = [
 SOLVER_COMPLETION_CASES = [
     ('', [n.lower() for n in DUMMY_BENCHMARK.get_solver_names()]),
     ('sk', ['sklearn']),
-    ('pgd', ['julia-pgd', 'python-pgd', 'python-pgd-with-cb', 'r-pgd'])
+    ('pgd', ['julia-pgd', 'matlab-pgd', 'python-pgd', 'python-pgd-with-cb', 'r-pgd'])
 ]
 DATASET_COMPLETION_CASES = [
     ('', [n.lower() for n in DUMMY_BENCHMARK.get_dataset_names()]),

--- a/benchopt/tests/test_cli.py
+++ b/benchopt/tests/test_cli.py
@@ -46,7 +46,9 @@ BENCHMARK_COMPLETION_CASES = [
 SOLVER_COMPLETION_CASES = [
     ('', [n.lower() for n in DUMMY_BENCHMARK.get_solver_names()]),
     ('sk', ['sklearn']),
-    ('pgd', ['julia-pgd', 'matlab-pgd', 'python-pgd', 'python-pgd-with-cb', 'r-pgd'])
+    ('pgd', [
+        'julia-pgd', 'matlab-pgd', 'python-pgd', 'python-pgd-with-cb', 'r-pgd'
+    ])
 ]
 DATASET_COMPLETION_CASES = [
     ('', [n.lower() for n in DUMMY_BENCHMARK.get_dataset_names()]),


### PR DESCRIPTION
This add support for MATLAB-based solver, and is based on the [matlab-engine](https://www.mathworks.com/help/matlab/matlab_external/install-the-matlab-engine-for-python.html) package.

I also provide a dummy example of PGD solver using MATLAB. 

As mentioned in #606 , the CI is the main issue here. Running matlab from the engine in CI is not supported by Mathworks 
[^1] and would required to have a self hosted runner with a MATLAB license.


[^1]: https://github.com/matlab-actions/setup-matlab/issues/22


This make the CI fail for now. 