### PR TITLE
MNT - remove ``NoCriterion`` class

### DIFF
--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -466,11 +466,3 @@ class SingleRunCriterion(StoppingCriterion):
 
     def check_convergence(self, cost_curve):
         return True, 1
-
-
-class NoCriterion(StoppingCriterion):
-    """Run the solvers for a number of time fixed by max_iter and timeout.
-    """
-
-    def check_convergence(self, cost_curve):
-        return False, 0


### PR DESCRIPTION
``NoCriterion`` is stale legacy code.

Removing it as it induces errors and confusion, cf. #615 