### PR TITLE
FIX - Broken link to documentation artifact

### DIFF
--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -23,4 +23,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/dev/index.html
           circleci-jobs: build_doc
-          api-token: ${{ secrets.CIRCLE_CI_STATUS_TOKEN }}s
+          api-token: ${{ secrets.CIRCLE_CI_STATUS_TOKEN }}

--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/dev/index.html
-          circleci-jobs: build_doc
+          circleci-jobs: build_docs
           api-token: ${{ secrets.CIRCLE_CI_STATUS_TOKEN }}


### PR DESCRIPTION
So far, CI doesn't expose the link to the documentation artifact.