### PR TITLE
FIX ignore hidden files when loading datasets, solvers, etc

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -144,7 +144,7 @@ class Benchmark:
         # List all available module in benchmark.subpkg
         class_name = base_class.__name__.replace('Base', '')
         package = self.benchmark_dir / f'{class_name.lower()}s'
-        submodule_files = package.glob('*.py')
+        submodule_files = package.glob('[!.]*.py')
         for module_filename in submodule_files:
             if module_filename.name.startswith("template_"):
                 # skip template solvers and datasets

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -103,22 +103,29 @@ def test_error_reporting(error, raise_install_error):
 
 
 def test_ignore_hidden_files():
+    # Non-regression test to make sure hidden files in datasets and solvers
+    # are ignored. If this is not the case, the call to run will fail if it
+    # is not ignored as there is no Dataset/Solver defined in the file.
     with tempfile.NamedTemporaryFile(
         dir=str(DUMMY_BENCHMARK_PATH / 'datasets'),
         prefix='.hidden_dataset_',
         suffix='.py',
         delete=True
-    ), tempfile.NamedTemporaryFile(
+    ), CaptureRunOutput():
+        run([
+            str(DUMMY_BENCHMARK_PATH), '-l', '-d',
+            SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD, '-n', '1',
+            '-r', '1', '-o', SELECT_ONE_OBJECTIVE, '--no-plot'
+        ], 'benchopt', standalone_mode=False)
+
+    with tempfile.NamedTemporaryFile(
         dir=str(DUMMY_BENCHMARK_PATH / 'solvers'),
         prefix='.hidden_solver_',
         suffix='.py',
         delete=True
-    ):
-        with CaptureRunOutput() as out:
-            run([
-                str(DUMMY_BENCHMARK_PATH), '-l', '-d',
-                SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD, '-n', '1',
-                '-r', '1', '-o', SELECT_ONE_OBJECTIVE, '--no-plot'
-            ], 'benchopt', standalone_mode=False)
-
-        out.check_output('Simulated', repetition=1)
+    ), CaptureRunOutput():
+        run([
+            str(DUMMY_BENCHMARK_PATH), '-l', '-d',
+            SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD, '-n', '1',
+            '-r', '1', '-o', SELECT_ONE_OBJECTIVE, '--no-plot'
+        ], 'benchopt', standalone_mode=False)

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -1,4 +1,5 @@
 import pytest
+import tempfile
 
 from benchopt.cli.main import run
 from benchopt.utils.dynamic_modules import _load_class_from_module
@@ -99,3 +100,25 @@ def test_error_reporting(error, raise_install_error):
             )
     finally:
         os.environ['BENCHOPT_RAISE_INSTALL_ERROR'] = prev_value
+
+
+def test_ignore_hidden_files():
+    with tempfile.NamedTemporaryFile(
+        dir=str(DUMMY_BENCHMARK_PATH / 'datasets'),
+        prefix='.hidden_dataset_',
+        suffix='.py',
+        delete=True
+    ), tempfile.NamedTemporaryFile(
+        dir=str(DUMMY_BENCHMARK_PATH / 'solvers'),
+        prefix='.hidden_solver_',
+        suffix='.py',
+        delete=True
+    ):
+        with CaptureRunOutput() as out:
+            run([
+                str(DUMMY_BENCHMARK_PATH), '-l', '-d',
+                SELECT_ONE_SIMULATED, '-f', SELECT_ONE_PGD, '-n', '1',
+                '-r', '1', '-o', SELECT_ONE_OBJECTIVE, '--no-plot'
+            ], 'benchopt', standalone_mode=False)
+
+        out.check_output('Simulated', repetition=1)


### PR DESCRIPTION
When working on remote machines (e.g. with sshfs), macos automatically creates hidden files.
For example, if there is a file `datasets/mnist.py`, then it automatically creates a metadata file `datasets/._mnist.py`.
Thus, benchopt loads `datasets/mnist.py` but also `datasets/._mnist.py` which creates errors since  `datasets/._mnist.py` only contains metadata. To prevent this, this PR changes the regex that loads submodules to ignore hidden files.