### PR TITLE
FIX - broken links in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ To install ``benchopt``, start by creating a new ``conda`` environment and then 
 
 .. code-block:: bash
 
-    conda create -n benchopt
+    conda create -n benchopt python
     conda activate benchopt
 
 Then run the following command to install the **latest release** of ``benchopt``

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,6 @@ Programs available via `conda <https://docs.conda.io/en/latest/>`_ should be com
 See for instance an `example of usage <https://benchopt.github.io/auto_examples/plot_run_benchmark_python_R.html>`_ with ``R``.
 
 
-
 Install
 -------
 
@@ -30,25 +29,22 @@ from ``benchopt`` Command Line Interface (CLI).
 
 To install ``benchopt``, start by creating a new ``conda`` environment and then activate it
 
-.. code-block::
+.. code-block:: bash
 
-    conda create -n benchopt python
+    conda create -n benchopt
     conda activate benchopt
-
 
 Then run the following command to install the **latest release** of ``benchopt``
 
-.. code-block::
+.. code-block:: bash
 
     pip install -U benchopt
 
-
 It is also possible to use the **latest development version**. To do so, run instead
 
-.. code-block::
+.. code-block:: bash
 
     pip install -U -i https://test.pypi.org/simple/benchopt
-
 
 
 Getting started 
@@ -91,21 +87,19 @@ Here is how to do so for the `L2-logistic Regression benchmark <https://github.c
    :align: center
    :scale: 40%
 
-
 These steps illustrate how to reproduce the `L2-logistic Regression benchmark <https://github.com/benchopt/benchmark_logreg_l2>`_.
 Find the complete list of the `Available benchmarks`_.
 Also, refer to the `documentation <https://benchopt.github.io/>`_ to learn more about ``benchopt`` CLI and its features.
 You can also easily extend this benchmark by adding a dataset, solver or metric.
-Learn that and more in the `Write a benchmark <https://benchopt.github.io/how.html>`_ tutorial.
+Learn that and more in the `Benchmark workflow <https://benchopt.github.io/benchmark_workflow/index.html>`_.
 
 
 Creating a benchmark
 ^^^^^^^^^^^^^^^^^^^^
 
-The section `Write a benchmark <https://benchopt.github.io/how.html>`_ of the documentation provides a tutorial
+The section `Write a benchmark <https://benchopt.github.io/benchmark_workflow/write_benchmark.html>`_ of the documentation provides a tutorial
 for creating a benchmark. The ``benchopt`` community also maintains 
 a `template benchmark <https://github.com/benchopt/template_benchmark>`_ to quickly and easily start a new benchmark.
-
 
 
 Finding helps
@@ -114,7 +108,6 @@ Finding helps
 Join ``benchopt`` `discord server <https://discord.gg/EA2HGQb7nv>`_ and get in touch with the community!
 Feel free to drop us a message to get help with running/constructing benchmarks 
 or (why not) discuss new features to be added and future development directions that ``benchopt`` should take.
-
 
 
 Citing Benchopt
@@ -138,7 +131,6 @@ Join us in this endeavor! If you use ``benchopt`` in a scientific publication, p
       booktitle = {NeurIPS},
       url       = {https://arxiv.org/abs/2206.13424}
    }
-
 
 
 Available benchmarks


### PR DESCRIPTION
This updates the links pointing to documentation, after #619.
Also, it fixes the format

### Checks before merging PR
- [ ] ~added documentation for any new feature~
- [ ] ~added unit test~
- [ ] ~edited the [what's new](../../whatsnew.rst) (if applicable)~