### PR TITLE
BUG - ``evaluate_result`` breaks down when it accepts a single dict argument

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -432,12 +432,17 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin):
             #   "Rename objective.compute to objective.evaluate_result")
             warnings.warn(
                 "objective.compute was renamed `objective.evaluate_result` in "
-                "v 1.5", FutureWarning,
+                "v 1.5, and now takes as input the unpacked dict returned by"
+                "solver.get_result", FutureWarning,
             )
             self.evaluate_result = self.compute
         # XXX remove in version 1.5
         if isinstance(solver_result, dict):
-            objective_dict = self.evaluate_result(**solver_result)
+            # handle case where solver already returned a dict
+            if hasattr(self, "compute"):
+                objective_dict = self.compute(solver_result)
+            else:
+                objective_dict = self.evaluate_result(**solver_result)
         else:
             warnings.warn(
                 "From benchopt 1.5, Solver.get_result() should return a dict.",

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -38,7 +38,9 @@ class Objective(BaseObjective):
     def get_one_solution(self):
         return np.zeros(self.X.shape[1])
 
-    def evaluate_result(self, beta):
+    def evaluate_result(self, solver_result):
+        beta = solver_result["beta"]
+
         diff = self.y - self.X.dot(beta)
         objective_value = .5 * diff.dot(diff) + self.lmbd * abs(beta).sum()
 


### PR DESCRIPTION
After #576,

It happens that the depreciation cycle doesn't work for benchmarks that anticipated passing in ``solver_result`` as a dictionary.
Indeed, this check destruct the input dict

https://github.com/benchopt/benchopt/blob/c689d242ac7910d9f1b4dbf9b0dff915925559e2/benchopt/base.py#L439-L446 

resulting in

```bash
TypeError: compute() got an unexpected keyword argument 'x'
```

as illustrated in the PR change.

------

Pinning @agonon for flagging that

