### PR TITLE
FIX abstract classes in BaseObjective

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -422,8 +422,9 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         # XXX remove in version 1.5 and make this method abstract
         if hasattr(self, "compute"):
             warnings.warn(
-                "`Objective.compute` was renamed `Objective.evaluate_result`. "
-                "This will raise an error starting v1.5", FutureWarning,
+                "`Objective.compute` was renamed `Objective.evaluate_result` " 
+                "in v 1.5, and now takes as input the unpacked dict returned "
+                "by `Solver.get_result`", FutureWarning,
             )
             if '_result' in solver_result:
                 solver_result = solver_result['_result']

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -422,7 +422,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         # XXX remove in version 1.5 and make this method abstract
         if hasattr(self, "compute"):
             warnings.warn(
-                "`Objective.compute` was renamed `Objective.evaluate_result` " 
+                "`Objective.compute` was renamed `Objective.evaluate_result` "
                 "in v 1.5, and now takes as input the unpacked dict returned "
                 "by `Solver.get_result`", FutureWarning,
             )

--- a/benchopt/callback.py
+++ b/benchopt/callback.py
@@ -88,7 +88,7 @@ class _Callback:
             warnings.warn(
                 "Starting 1.5, the callback does not take any arguments. "
                 "The results are passed to `Objective.evaluate_result` "
-                "directly from `Solver.get_result`."
+                "directly from `Solver.get_result`.", FutureWarning
             )
             result = args[0]
         else:

--- a/benchopt/callback.py
+++ b/benchopt/callback.py
@@ -1,4 +1,5 @@
 import time
+import warnings
 
 from .utils.sys_info import get_sys_info
 
@@ -44,8 +45,9 @@ class _Callback:
         The time when exiting the callback call.
     """
 
-    def __init__(self, objective, meta, stopping_criterion):
+    def __init__(self, objective, solver, meta, stopping_criterion):
         self.objective = objective
+        self.solver = solver
         self.meta = meta
         self.stopping_criterion = stopping_criterion
 
@@ -60,7 +62,7 @@ class _Callback:
     def start(self):
         self.time_callback = time.perf_counter()
 
-    def __call__(self, x):
+    def __call__(self, *args):
         # Stop time and update computation time since the beginning
         t0 = time.perf_counter()
 
@@ -68,7 +70,7 @@ class _Callback:
 
         # Evaluate the iteration if necessary.
         if self.it == self.next_stopval:
-            if self.log_value(x):
+            if self.log_value(*args):
                 return False
 
         # Update iteration number and restart time measurement.
@@ -76,12 +78,23 @@ class _Callback:
         self.time_callback = time.perf_counter()
         return True
 
-    def log_value(self, x):
+    def log_value(self, *args):
         """Store the objective value with running time and stop if needed.
 
         Return True if the solver should be stopped.
         """
-        objective_dict = self.objective(x)
+        # XXX: remove in 1.5
+        if len(args) > 0:
+            warnings.warn(
+                "Starting 1.5, the callback does not take any arguments. "
+                "The results are passed to `Objective.evaluate_result` "
+                "directly from `Solver.get_result`."
+            )
+            result = args[0]
+        else:
+            result = self.solver.get_result()
+
+        objective_dict = self.objective(result)
         self.curve.append(dict(
             **self.meta, stop_val=self.it,
             time=self.time_iter,

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -101,7 +101,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             # If sampling_strategy is 'callback', only call once to get the
             # results up to convergence.
             callback = _Callback(
-                objective, meta, stopping_criterion
+                objective, solver, meta, stopping_criterion
             )
             solver.pre_run_hook(callback)
             callback.start()

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -196,3 +196,33 @@ def test_deprecated_support_sparse():
             run([str(benchmark.benchmark_dir),
                  *'-s solver1 -d test-dataset -n 1 -r 1 --no-plot'.split()],
                 standalone_mode=False)
+
+
+def test_deprecated_compute():
+    # XXX remove in 1.5
+    assert benchopt.__version__ < '1.5'
+
+    objective = """from benchopt import BaseObjective
+
+    class Objective(BaseObjective):
+        name = 'dummy'
+
+        def set_data(self, X, y):
+            self.X, self.y = X, y
+
+        def compute(self, beta):
+            return 1
+
+        def get_one_result(self):
+            return dict(beta=0)
+
+        def get_objective(self):
+            return dict(X=self.X, y=self.y, lmbd=0)
+    """
+
+    match = "`Objective.compute` was renamed `Objective.evaluate_result` "
+    with temp_benchmark(objective=objective) as benchmark:
+        with pytest.warns(FutureWarning, match=match):
+            run([str(benchmark.benchmark_dir),
+                 *'-s python-pgd -d test-dataset -n 1 -r 1 --no-plot'.split()],
+                standalone_mode=False)

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -1,12 +1,9 @@
 import pytest
 import numpy as np
 
-import benchopt
-from benchopt.cli.main import run
 from benchopt.runner import _Callback
 from benchopt.stopping_criterion import SAMPLING_STRATEGIES
 from benchopt.utils import product_param
-from benchopt.utils.temp_benchmark import temp_benchmark
 
 
 def test_benchmark_objective(benchmark, dataset_simu):
@@ -222,68 +219,3 @@ def _test_solver_one_objective(solver, objective):
 
             diff = val_eps - val_star
             assert diff >= 0
-
-
-def test_deprecated_stopping_strategy():
-    # XXX remove in 1.5
-    assert benchopt.__version__ < '1.5'
-
-    solver1 = """from benchopt import BaseSolver
-    import numpy as np
-
-    class Solver(BaseSolver):
-        name = 'solver1'
-        stopping_strategy = 'iteration'
-
-        def run(self, n_iter): pass
-
-        def set_objective(self, X, y, lmbd):
-            self.n_features = X.shape[1]
-
-        def get_result(self, **data):
-            return {'beta': np.zeros(self.n_features)}
-    """
-
-    solver2 = solver1.replace("stopping_strategy", "sampling_strategy")
-    solver2 = solver2.replace("solver1", "solver2")
-
-    with temp_benchmark(solvers=[solver1, solver2]) as benchmark:
-        with pytest.warns(
-                FutureWarning,
-                match="'stopping_strategy' attribute is deprecated"):
-            run([str(benchmark.benchmark_dir),
-                 *'-s solver1 -d test-dataset -n 1 -r 1 --no-plot'.split()],
-                standalone_mode=False)
-
-        run([str(benchmark.benchmark_dir),
-             *'-s solver2 -d test-dataset -n 1 -r 1 --no-plot'.split()],
-            standalone_mode=False)
-
-
-def test_deprecated_support_sparse():
-    # XXX remove in 1.5
-    assert benchopt.__version__ < '1.5'
-
-    solver1 = """from benchopt import BaseSolver
-    import numpy as np
-
-    class Solver(BaseSolver):
-        name = 'solver1'
-        support_sparse = True
-
-        def run(self, n_iter): pass
-
-        def set_objective(self, X, y, lmbd):
-            self.n_features = X.shape[1]
-
-        def get_result(self, **data):
-            return np.zeros(self.n_features)
-    """
-
-    with temp_benchmark(solvers=solver1) as benchmark:
-        with pytest.warns(
-                FutureWarning,
-                match="`support_sparse = False` is deprecated"):
-            run([str(benchmark.benchmark_dir),
-                 *'-s solver1 -d test-dataset -n 1 -r 1 --no-plot'.split()],
-                standalone_mode=False)

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -191,7 +191,7 @@ def _test_solver_one_objective(solver, objective):
             # Set large tolerance for the stopping criterion to stop fast
             sc.eps = 5e-1
         cb = _Callback(
-            objective, meta={}, stopping_criterion=sc
+            objective, solver, meta={}, stopping_criterion=sc
         )
         cb.start()
         solver.run(cb)

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -20,7 +20,7 @@ def test_benchmark_objective(benchmark, dataset_simu):
     # check that the reported dimension is correct and that the result of
     # the objective function is a dictionary containing a scalar value for
     # `objective_value`.
-    beta_hat = objective.get_one_solution()
+    beta_hat = objective.get_one_result()
     objective_dict = objective(beta_hat)
 
     assert 'objective_value' in objective_dict, (

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/doc_objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/doc_objective.py
@@ -19,7 +19,7 @@ class Objective(BaseObjective):
         'reg': [0.05, .1, .5]
     }
 
-    def get_one_solution(self):
+    def get_one_result(self):
         "Return one solution for which the objective can be evaluated."
         return np.zeros(self.X.shape[1])
 

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -36,7 +36,7 @@ class Objective(BaseObjective):
         return False, None
 
     def get_one_result(self):
-        return np.zeros(self.X.shape[1])
+        return dict(beta=np.zeros(self.X.shape[1]))
 
     def evaluate_result(self, beta):
         diff = self.y - self.X.dot(beta)

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/objective.py
@@ -35,7 +35,7 @@ class Objective(BaseObjective):
             return True, 'X is all zeros'
         return False, None
 
-    def get_one_solution(self):
+    def get_one_result(self):
         return np.zeros(self.X.shape[1])
 
     def evaluate_result(self, beta):

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/python_pgd_callback.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/python_pgd_callback.py
@@ -57,7 +57,7 @@ class Solver(BaseSolver):
             z = np.zeros(n_features)
 
         t_new = 1
-        while callback(self.get_result()):
+        while callback():
             if self.use_acceleration:
                 t_old = t_new
                 t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2

--- a/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/python_pgd_callback.py
+++ b/benchopt/tests/test_benchmarks/dummy_benchmark/solvers/python_pgd_callback.py
@@ -52,12 +52,12 @@ class Solver(BaseSolver):
     def run(self, callback):  # instead of the number of iteration or tolerance
         L = self.compute_lipschitz_cst()
         n_features = self.X.shape[1]
-        w = np.zeros(n_features)
+        self.w = w = np.zeros(n_features)
         if self.use_acceleration:
             z = np.zeros(n_features)
 
         t_new = 1
-        while callback(w):
+        while callback(self.get_result()):
             if self.use_acceleration:
                 t_old = t_new
                 t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2

--- a/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
@@ -22,7 +22,7 @@ class Objective(BaseObjective):
         return 1
 
     def get_one_result(self):
-        dict(beta=None)
+        return dict(beta=None)
 
     def get_objective(self):
         return dict(X=self.X)

--- a/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
@@ -22,7 +22,7 @@ class Objective(BaseObjective):
         return 1
 
     def get_one_result(self):
-        pass
+        dict(beta=None)
 
     def get_objective(self):
         return dict(X=self.X)

--- a/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
+++ b/benchopt/tests/test_benchmarks/requirement_benchmark/objective.py
@@ -21,7 +21,7 @@ class Objective(BaseObjective):
         dummy_package.__version__  # make sure this was imported
         return 1
 
-    def get_one_solution(self):
+    def get_one_result(self):
         pass
 
     def get_objective(self):

--- a/benchopt/tests/test_benchmarks/requirement_benchmark/solvers/baseline.py
+++ b/benchopt/tests/test_benchmarks/requirement_benchmark/solvers/baseline.py
@@ -9,11 +9,9 @@ class Solver(BaseSolver):
         self.X = X
 
     def run(self, callback):
-
-        while callback(0):
-            pass
-
         self.w = 0
+        while callback(self.get_result()):
+            pass
 
     def get_result(self):
         return {'beta': self.w}

--- a/benchopt/tests/test_benchmarks/requirement_benchmark/solvers/baseline.py
+++ b/benchopt/tests/test_benchmarks/requirement_benchmark/solvers/baseline.py
@@ -10,7 +10,7 @@ class Solver(BaseSolver):
 
     def run(self, callback):
         self.w = 0
-        while callback(self.get_result()):
+        while callback():
             pass
 
     def get_result(self):

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -46,12 +46,12 @@ def test_skip_api():
     assert reason == 'X is all zeros'
 
 
-def test_get_one_solution():
+def test_get_one_result():
     dataset = TEST_DATASET.get_instance()
     objective = TEST_OBJECTIVE.get_instance()
     objective.set_dataset(dataset)
 
-    one_solution = objective.get_one_solution()
+    one_solution = objective.get_one_result()
     expected = np.zeros(objective.X.shape[1])
     assert all(one_solution == expected)
 

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -53,7 +53,7 @@ def test_get_one_result():
 
     one_solution = objective.get_one_result()
     expected = np.zeros(objective.X.shape[1])
-    assert all(one_solution == expected)
+    assert all(one_solution['beta'] == expected)
 
 
 def _assert_parameters_equal(instance, parameters):

--- a/doc/benchmark_workflow/write_benchmark.rst
+++ b/doc/benchmark_workflow/write_benchmark.rst
@@ -44,7 +44,7 @@ This class allows to monitor the quantities of interest along the iterations
 of the solvers. Typically it allows to evaluate the objective function to
 be minimized by the solvers. An objective class should define 3 methods:
 
-- ``get_one_solution()``: it returns one solution that can be returned by a solver.
+- ``get_one_result()``: it returns one solution that can be returned by a solver.
   This defines the shape of the solution and will be used to test that the
   benchmark works properly.
 - ``set_data(**data)``: it allows to specify the data. See the data as a dictionary

--- a/doc/user_guide/performance_curves.rst
+++ b/doc/user_guide/performance_curves.rst
@@ -59,11 +59,13 @@ It returns ``False`` when the solver should be stopped. A classical usage patter
 .. code:: python
 
     def run(self, callback):
-        x = ... # Initialize iterate
+        self.x = ... # Initialize iterate
 
-        while callback(x):
-            x = ...  # Update iterate
-        self.x = x
+        while callback():
+            self.x = ...  # Update iterate
+
+    def get_result(self):
+        return {'x': self.x}
 
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,10 @@ Version 1.5 (dev)
 API
 ~~~
 
+- Deprecate ``Objective.get_one_solution`` in favor of ``Obejctive.get_one_result``
+  for consistency with ``Objective.evaluate_result``.
+  By `Thomas Moreau`_ (:gh:`631`)
+
 - Deprecate ``Objective.compute`` in favor of ``Objective.evaluate_result``, for
   consistency with ``Solver.get_result``. Like ``Dataset.get_data``,
   ``Solver.get_result`` must now return a dictionary, which is unpacked as

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,7 +13,7 @@ Version 1.5 (dev)
 API
 ~~~
 
-- Deprecate ``Objective.get_one_solution`` in favor of ``Obejctive.get_one_result``
+- Deprecate ``Objective.get_one_solution`` in favor of ``Objective.get_one_result``
   for consistency with ``Objective.evaluate_result``.
   By `Thomas Moreau`_ (:gh:`631`)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,15 +13,19 @@ Version 1.5 (dev)
 API
 ~~~
 
+- The callback now does not take any argument anymore. The results from the
+  ``Solver`` are always collected using ``get_result``.
+  By `Thomas Moreau`_ (:gh:`631`).
+
 - Deprecate ``Objective.get_one_solution`` in favor of ``Objective.get_one_result``
   for consistency with ``Objective.evaluate_result``.
-  By `Thomas Moreau`_ (:gh:`631`)
+  By `Thomas Moreau`_ (:gh:`631`).
 
 - Deprecate ``Objective.compute`` in favor of ``Objective.evaluate_result``, for
   consistency with ``Solver.get_result``. Like ``Dataset.get_data``,
   ``Solver.get_result`` must now return a dictionary, which is unpacked as
   arguments to ``Objective.evaluate_result``.
-  By `Mathurin Massias`_ (:gh:`576`)
+  By `Mathurin Massias`_ (:gh:`576`).
 
 - ``Solver.support_sparse`` attribute is deprecated in favor of the use of
 ``Solver.skip``, by `Mathurin Massias`_ (:gh:`614`).


### PR DESCRIPTION
This fixes the fact that `BaseObjective` was not raising error if an abstractmethod is not implemented.
It also makes the backward compatibility between `compute/evaluate_result` work with results that are dictionaries.

Finally, it renames `Objective.get_one_solution` into `Objective.get_one_result`.
