### PR TITLE
MNT - rename objective column to objective metrics

### DIFF
--- a/benchopt/plotting/html/templates/result.mako.html
+++ b/benchopt/plotting/html/templates/result.mako.html
@@ -56,7 +56,7 @@
                         </div>
                         <div class="mt-8 px-8">
                             <div class="flex flex-row items-center justify-between text-sm font-medium text-white">
-                                <label for="objective_column" class="block">Objective column</label>
+                                <label for="objective_column" class="block">Objective metrics</label>
                                 <!--don't show description unless it is provided -->
                                 % if result['metadata']['obj_description'] != "":
                                     <span class="objective-description-trigger" style="cursor: pointer;">


### PR DESCRIPTION
In the dashboard of results, the meaning of the **objective column** isn't very clear.
This suggests renaming it to **Objective metrics**.

pining @mathurinm  

![Screenshot from 2023-07-27 15-25-07](https://github.com/benchopt/benchopt/assets/65614794/ba134290-053b-429a-ba41-8654734e5292)


### Checks before merging PR
- [ ] ~added documentation for any new feature~
- [ ] ~added unit test~
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
