### PR TITLE
DOC - Explain benchopt internals when running a benchmark

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ extensions = [
     'gh_substitutions',  # custom ext, see ./sphinxext/gh_substitutions.py
     "sphinx_design",
     "sphinx_copybutton",
+    "sphinxcontrib.mermaid",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/user_guide/benchopt_internals.rst
+++ b/doc/user_guide/benchopt_internals.rst
@@ -1,0 +1,35 @@
+.. _benchopt_internals:
+
+Benchopt internals
+==================
+
+
+.. mermaid::
+    :zoom:
+
+    flowchart LR
+        subgraph "`**Dataset**`"
+            D1("get_data")
+        end
+
+        D1 -.-> O1
+
+        subgraph objective ["`**Objective**`"]
+
+            O1("pre hooks") --> O2("set_data")
+            O2 --> O3("get_objective")
+            O4("evaluate_result")
+
+        end
+
+        O3 -.-> S1
+
+        subgraph solver ["`**Solver**`"]
+    
+            S1("pre hooks") --> S2("set_objective")
+            S2("set_objective") --> S3("run")
+            S3 --> S4("get_result")
+
+        end
+
+        S4 <-.-> O4

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ doc =
     sphinx_gallery
     sphinx-prompt
     sphinx-copybutton
+    sphinxcontrib-mermaid
     pillow
     scikit-learn
 


### PR DESCRIPTION
It is possible to write diagrams directly into the documentation without using dedicated software + export as SVG.
This can be achieved with [mermaid](https://mermaid.js.org/) combined with its [sphinx extension](https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/).

I crafted a diagram to explain the flow of instructions when running a benchmark.
If you are +1 with the render I shall complete the page with explanations of each part. 

### Checks before merging PR
- [ ] ~added documentation for any new feature~
- [ ] ~added unit test~
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
