### PR TITLE
DOC - more clear syntax highlighting in code blocks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,8 +87,6 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-# for the theme "sphinx_book_theme", `pygments_style` has no effect
-# on the syntax highlight theme. Instead, modify it with `html_theme_options`
 # pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,7 +87,9 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+# for the theme "sphinx_book_theme", `pygments_style` has no effect
+# on the syntax highlight theme. Instead, modify it with `html_theme_options`
+# pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -121,6 +123,9 @@ html_theme_options = {
     "use_fullscreen_button": False,
     "repository_url": "https://github.com/benchopt/benchopt",
     "home_page_in_toc": True,
+    # for a complete list of themes refer to https://pygments.org/styles/
+    "pygment_light_style": "colorful",
+    "pygment_dark_style": "one-dark",
 }
 
 html_sidebars = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
     "home_page_in_toc": True,
     # for a complete list of themes refer to https://pygments.org/styles/
     "pygment_light_style": "colorful",
-    "pygment_dark_style": "one-dark",
+    "pygment_dark_style": "gruvbox-dark",
 }
 
 html_sidebars = {


### PR DESCRIPTION
The PR #635 showed that syntax highlighting in code blocks is a bit confusing,
namely, the color of comment is the same as ``self``

![](https://cdn.discordapp.com/attachments/920775550325383189/1136952721358999562/image.png)

This changes the theme to a more suitable one.

### Checks before merging PR
- [ ] ~added documentation for any new feature~
- [ ] ~added unit test~
- [ ] ~edited the [what's new](../../whatsnew.rst) (if applicable)~
