### PR TITLE
ENH mini bench

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -283,6 +283,16 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
             module_hash, str(self._import_ctx._benchmark_dir)
         )
 
+    @staticmethod
+    def get_pickle_hooks():
+        return (
+            lambda obj: (
+                getattr(obj, '_objective', None), getattr(obj, '_output', None)
+            ),
+            lambda obj, args: obj._set_objective(*args) if args[0] else None
+         )
+
+
 
 class CommandLineSolver(BaseSolver, ABC):
     """A base class for solvers that are called through command lines
@@ -573,4 +583,11 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         return self._reconstruct, (
             self._module_filename, module_hash, self._parameters, dataset,
             str(self._import_ctx._benchmark_dir)
+        )
+
+    @staticmethod
+    def get_pickle_hooks():
+        return (
+            lambda obj: getattr(obj, '_dataset', None),
+            lambda obj, dataset: obj.set_dataset(dataset)
         )

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -4,6 +4,7 @@ import warnings
 from pathlib import Path
 
 from benchopt.benchmark import Benchmark
+from benchopt.mini import get_mini_benchmark
 from benchopt.cli.completion import complete_solvers
 from benchopt.cli.completion import complete_datasets
 from benchopt.cli.completion import complete_benchmarks
@@ -44,6 +45,7 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
 
     return_names = [
         "benchmark",
+        "mini",
         "solver",
         "force_solver",
         "dataset",
@@ -71,6 +73,9 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
 )
 @click.argument('benchmark', default=Path.cwd(), type=click.Path(exists=True),
                 shell_complete=complete_benchmarks)
+@click.option('--mini',
+              metavar="<file>", type=click.Path(exists=True),
+              help="")
 @click.option('--objective', '-o',
               metavar='<objective_filter>', multiple=True, type=str,
               help="Select the objective based on its parameters, with the "
@@ -170,7 +175,7 @@ def run(config_file=None, **kwargs):
         config = {}
 
     (
-        benchmark, solver_names, forced_solvers, dataset_names,
+        benchmark, mini_file, solver_names, forced_solvers, dataset_names,
         objective_filters, max_runs, n_repetitions, timeout, n_jobs, slurm,
         plot, html, pdb, do_profile, env_name, output
     ) = _get_run_args(kwargs, config)
@@ -182,7 +187,10 @@ def run(config_file=None, **kwargs):
         timeout = pd.to_timedelta(timeout).total_seconds()
 
     # Create the Benchmark object
-    benchmark = Benchmark(benchmark)
+    if mini_file is not None:
+        benchmark = get_mini_benchmark(mini_file)
+    else:
+        benchmark = Benchmark(benchmark)
 
     if benchmark.min_version is not None:
         from packaging.version import parse

--- a/benchopt/mini.py
+++ b/benchopt/mini.py
@@ -1,0 +1,187 @@
+from pathlib import Path
+from functools import partial
+
+
+from .base import BaseSolver
+from .base import BaseDataset
+from .base import BaseObjective
+from .benchmark import Benchmark
+from .utils.dynamic_modules import get_file_hash
+from .utils.safe_import import safe_import_context
+from .utils.safe_import import set_benchmark_module
+
+from .stopping_criterion import SingleRunCriterion
+from .stopping_criterion import SufficientProgressCriterion
+
+_datasets = []
+_solvers = []
+_objective = None
+
+
+def iterable(x):
+    from collections.abc import Iterable
+    return isinstance(x, Iterable)
+
+
+class _InstallDepsMixing:
+
+    _import_ctx = safe_import_context()
+
+    @classmethod
+    def is_installed(cls, env_name=None, raise_on_not_installed=None,
+                     quiet=False):
+        return True
+
+    @staticmethod
+    def _reconstruct(mini_file, pickled_hash, parameters, hook_args,
+                     klass, name):
+        benchmark = get_mini_benchmark(mini_file)
+
+        if klass == "_Objective":
+            klass = benchmark.get_benchmark_objective()
+        elif klass == "_Dataset":
+            klass = [c for c in benchmark.get_datasets() if c.name == name][0]
+        elif klass == "_Solver":
+            klass = [c for c in benchmark.get_solvers() if c.name == name][0]
+
+        obj = klass.get_instance(**parameters)
+        if hook_args is not None:
+            _, reconstruc_hook = obj.get_pickle_hooks()
+            reconstruc_hook(obj, hook_args)
+        return obj
+
+    def __reduce__(self):
+        file_hash = get_file_hash(self.mini_file)
+        reduce_hook, _ = self.get_pickle_hooks()
+        hook_args = reduce_hook(self)
+
+        return self._reconstruct, (
+            self.mini_file, file_hash, self._parameters, hook_args,
+            self.__class__.__name__, self.name
+        )
+
+
+class _MiniBenchmark(Benchmark):
+    def __init__(self, mini_file):
+
+        from benchopt.utils.dynamic_modules import _get_module_from_file
+        _get_module_from_file(mini_file)
+
+        assert _objective is not None, "Need to set one objective."
+
+        self.mini_file = Path(mini_file)
+        self.benchmark_dir = Path()
+        set_benchmark_module(self.benchmark_dir)
+
+        self.pretty_name = _objective.name
+        self.url = "mini_bench"
+        self.min_version = _objective.min_benchopt_version
+        self.name = "mini-bench"
+
+        # Store the mini_file argument in each component
+        _objective.mini_file = mini_file
+        for d in _datasets:
+            d.mini_file = mini_file
+        for s in _solvers:
+            s.mini_file = mini_file
+
+    def get_benchmark_objective(self):
+        return _objective
+
+    def get_datasets(self):
+        return _datasets
+
+    def get_solvers(self):
+        return _solvers
+
+
+def dataset(func=None, name=None, **kwargs):
+    if func is None:
+        return partial(dataset, name=name, **kwargs)
+
+    name_ = name if name is not None else func.__name__
+
+    class _Dataset(_InstallDepsMixing, BaseDataset):
+        name = name_
+        _klass = "dataset"
+        _module_filename = func.__code__.co_filename
+
+        parameters = {k: v if iterable(v) else [v] for k, v in kwargs.items()}
+
+        def get_data(self):
+            params = {k: getattr(self, k) for k in kwargs}
+            return func(**params)
+
+    _datasets.append(_Dataset)
+
+
+def solver(func=None, name=None, run_once=False, **params):
+    if func is None:
+        return partial(solver, name=name, run_once=run_once, **params)
+
+    name_ = name if name is not None else func.__name__
+
+    class _Solver(_InstallDepsMixing, BaseSolver):
+        name = name_
+        _module_filename = func.__code__.co_filename
+
+        parameters = {k: v if iterable(v) else [v] for k, v in params.items()}
+
+        sampling_strategy = "iteration"
+        stopping_criterion = (
+            SingleRunCriterion() if run_once else SufficientProgressCriterion()
+        )
+
+        def set_objective(self, **kwargs):
+            self.kwargs = kwargs
+
+        def warm_up(self):
+            self.run(2)
+
+        def run(self, n_iter):
+            params_ = {k: getattr(self, k) for k in params}
+            if run_once:
+                self.res = func(**self.kwargs, **params_)
+            else:
+                self.res = func(n_iter, **self.kwargs, **params_)
+
+        def get_result(self):
+            return self.res
+
+    _solvers.append(_Solver)
+
+
+def objective(func=None, name=None, min_benchopt_version=None):
+    if func is None:
+        return partial(objective, name=name)
+
+    print("call")
+
+    global _objective
+    assert _objective is None, "Can only call objective decorator once."
+
+    name_ = name if name is not None else func.__name__
+    min_benchopt_version_ = min_benchopt_version
+
+    class _Objective(_InstallDepsMixing, BaseObjective):
+        name = name_
+        min_benchopt_version = min_benchopt_version_
+        _module_filename = func.__code__.co_filename
+
+        def set_data(self, **kwargs):
+            self.data_kwargs = kwargs
+
+        def get_objective(self):
+            return self.data_kwargs
+
+        def evaluate_result(self, **result):
+            return func(**result)
+
+        def get_one_result(self):
+            raise RuntimeError("Should never be called.")
+
+    _objective = _Objective
+
+
+def get_mini_benchmark(mini_file):
+    return _MiniBenchmark(mini_file)

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -81,6 +81,10 @@ class ParametrizedNameMixin():
             pickled_module_hash=pickled_module_hash
         )
 
+    @staticmethod
+    def get_pickle_hooks():
+        return lambda obj: None, None
+
 
 def expand(keys, values):
     """Expand the multiple parameters for itertools product"""


### PR DESCRIPTION
Fixes #605.

This implements decorator to create mini benchmarks runnable with `benchopt run --mini mini_file.py`.
This allows to run the following benchmark:


```python
from benchopt.mini import solver, dataset, objective
import jax

@dataset(
    size=100,
    random_state=0
)
def simulated(size, random_state):
    key = jax.random.PRNGKey(random_state)
    key, subkey = jax.random.split(key)
    X = jax.random.normal(key, (size,))
    return dict(X=X)


@solver(
    name="Solver 1",
    lr=[1e-2, 1e-3]
)
def solver1(n_iter, X, lr):
    beta = X
    for i in range(n_iter):
        beta -= lr * beta

    return dict(beta=beta)


@objective(name="Benchmark HVP")
def evaluate(beta):
    return dict(value=(0.5 * beta.dot(beta)).item())

```

Not completely sure this is useful but got it done by playing with another benchmark, it would be nice to have feedback on whether it seems usable or not.

(No doc or test yet)

### Checks before merging PR
- [ ] added documentation for any new feature
- [ ] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
