### PR TITLE
FIX call to warmup and add tests

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -259,7 +259,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
         ...
 
     def _warm_up(self):
-        if not getattr(self, '_warmup_done', True):
+        if not getattr(self, '_warmup_done', False):
             self.warm_up()
             self._warmup_done = True
 

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -200,6 +200,40 @@ def test_run_once_callback(n_iter):
         out.check_output(rf"RUNONCE\({n_iter}\)", repetition=1)
 
 
+def test_warm_up():
+
+    solver1 = """from benchopt import BaseSolver
+    import numpy as np
+
+    class Solver(BaseSolver):
+        name = 'solver1'
+        sampling_strategy = 'iteration'
+
+        def set_objective(self, X, y, lmbd):
+            self.n_features = X.shape[1]
+
+        def warm_up(self):
+            print("WARMUP")
+            self.run_once(1)
+
+        def run(self, n_iter): pass
+
+        def get_result(self, **data):
+            return {'beta': np.zeros(self.n_features)}
+    """
+
+    with temp_benchmark(solvers=[solver1]) as benchmark:
+        with CaptureRunOutput() as out:
+            run([
+                str(benchmark.benchmark_dir),
+                *'-s solver1 -d test-dataset -n 0 -r 5 --no-plot'.split(),
+                *'-o dummy*[reg=0.5]'.split()
+            ], standalone_mode=False)
+
+        # Make sure warmup is called exactly once
+        out.check_output("WARMUP", repetition=1)
+
+
 ##############################################################################
 # Test for deprecated features in 1.5
 ##############################################################################


### PR DESCRIPTION
Fix the call to warmup, which was always skipped.
Add non-regression tests.


### Checks before merging PR
- [x] ~added documentation for any new feature~
- [x] added unit test
- [x] ~edited the [what's new](../../whatsnew.rst) (if applicable)~


Fixes #642