### PR TITLE
FIX pinnig pytest for now

### DIFF
--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -473,12 +473,14 @@ def test_deprecated_get_one_solution():
 
     match = "`Objective.get_one_solution` is renamed `Objective.get_one_result"
     with temp_benchmark(objective=objective) as benchmark:
-        with CaptureRunOutput() as out:
+        # with CaptureRunOutput() as out:
             with pytest.raises(SystemExit, match='False'):
+                print(f'{benchmark.benchmark_dir} -- -k test_benchmark_objective')
+                import ipdb; ipdb.set_trace()
                 _cmd_test([str(benchmark.benchmark_dir),
                            *'-- -k test_benchmark_objective'.split()],
                           standalone_mode=False)
-        out.check_output(match, repetition=1)
+            out.check_output(match, repetition=1)
 
     objective = objective.replace("get_one_solution", "get_one_result")
     with temp_benchmark(objective=objective) as benchmark:

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -473,14 +473,12 @@ def test_deprecated_get_one_solution():
 
     match = "`Objective.get_one_solution` is renamed `Objective.get_one_result"
     with temp_benchmark(objective=objective) as benchmark:
-        # with CaptureRunOutput() as out:
+        with CaptureRunOutput() as out:
             with pytest.raises(SystemExit, match='False'):
-                print(f'{benchmark.benchmark_dir} -- -k test_benchmark_objective')
-                import ipdb; ipdb.set_trace()
                 _cmd_test([str(benchmark.benchmark_dir),
                            *'-- -k test_benchmark_objective'.split()],
                           standalone_mode=False)
-            out.check_output(match, repetition=1)
+        out.check_output(match, repetition=1)
 
     objective = objective.replace("get_one_solution", "get_one_result")
     with temp_benchmark(objective=objective) as benchmark:

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ benchopt.plotting =
 
 [options.extras_require]
 test =
-    pytest
+    pytest<=7.4.1
     pytest-cov
     pytest-timeout
     coverage


### PR DESCRIPTION
The test are failing following the latest release of pytest.
As a mitigation, I just pinned `pytest<7.4.1`

The issue seems to be with an internal in `pytest` from a call to the function `_early_rewrite_bailout` that  gives this error from l.203:

```
$ benchopt test /tmp/tmpdqk7v3vc -- -k test_benchmark_objective
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.9, pytest-7.4.2, pluggy-1.0.0
project deps: mylib-1.1
rootdir: /home/tom/Work/prog/benchopt/benchopt/tests
plugins: anyio-3.6.2, timeout-2.1.0, typeguard-2.13.3, cov-4.0.0
collected 35 items / 34 deselected / 1 selected                                                                                                                                                                                              

../benchopt/benchopt/tests/test_benchmarks.py E                                                                                                                                                                                        [100%]

=================================================================================================================== ERRORS ===================================================================================================================
_____________________________________________________________________________________ ERROR at setup of test_benchmark_objective[tmpdqk7v3vc-simulated] ______________________________________________________________________________________

self = PurePosixPath('.'), suffix = '.py'

    def with_suffix(self, suffix):
        """Return a new path with the file suffix changed.  If the path
        has no suffix, add given suffix.  If the given suffix is an empty
        string, remove the suffix from the path.
        """
        f = self._flavour
        if f.sep in suffix or f.altsep and f.altsep in suffix:
            raise ValueError("Invalid suffix %r" % (suffix,))
        if suffix and not suffix.startswith('.') or suffix == '.':
            raise ValueError("Invalid suffix %r" % (suffix))
        name = self.name
        if not name:
>           raise ValueError("%r has an empty name" % (self,))
E           ValueError: PurePosixPath('.') has an empty name

../../../.local/miniconda/lib/python3.10/pathlib.py:782: ValueError
========================================================================================================== short test summary info ===========================================================================================================
ERROR ../benchopt/benchopt/tests/test_benchmarks.py::test_benchmark_objective[tmpdqk7v3vc-simulated] - ValueError: PurePosixPath('.') has an empty name
====================================================================================================== 34 deselected, 1 error in 0.08s =======================================================================================================

```


