### PR TITLE
FIX call pre_run_hook in run_once

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -244,9 +244,11 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
                 meta={},
                 stopping_criterion=stopping_criterion
             )
+            self.pre_run_hook(run_once_cb)
             run_once_cb.start()
             self.run(run_once_cb)
         else:
+            self.pre_run_hook(stop_val)
             self.run(stop_val)
 
     def warm_up(self):

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -234,6 +234,47 @@ def test_warm_up():
         out.check_output("WARMUP", repetition=1)
 
 
+def test_pre_run_hook():
+
+    solver1 = """from benchopt import BaseSolver
+    import numpy as np
+
+    class Solver(BaseSolver):
+        name = 'solver1'
+        sampling_strategy = 'iteration'
+
+        def set_objective(self, X, y, lmbd):
+            self.n_features = X.shape[1]
+
+        def pre_run_hook(self, n_iter):
+            self._pre_run_hook_n_iter = n_iter
+
+        def run(self, n_iter):
+            assert self._pre_run_hook_n_iter == n_iter
+
+        def get_result(self, **data):
+            return {'beta': np.zeros(self.n_features)}
+    """
+
+    with temp_benchmark(solvers=[solver1]) as benchmark:
+        with CaptureRunOutput() as out:
+            run([
+                str(benchmark.benchmark_dir),
+                *'-s solver1 -d test-dataset -n 0 -r 5 --no-plot '
+                '-o dummy*[reg=0.5]'.split()
+            ], standalone_mode=False)
+
+        with CaptureRunOutput() as out:
+            with pytest.raises(SystemExit, match="False"):
+                _cmd_test([
+                    str(benchmark.benchmark_dir), '-k', 'solver1',
+                    '--skip-install', '-v'
+                ], standalone_mode=False)
+
+        # Make sure warmup is called exactly once
+        out.check_output("3 passed, 1 skipped, 7 deselected", repetition=1)
+
+
 ##############################################################################
 # Test for deprecated features in 1.5
 ##############################################################################

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -184,25 +184,11 @@ def _test_solver_one_objective(solver, objective):
 
     is_convex = getattr(objective, "is_convex", False)
 
-    # Either call run_with_cb or run
-    if solver._solver_strategy == 'callback':
-        sc = solver.stopping_criterion.get_runner_instance(
-            max_runs=25 if is_convex else 2, timeout=None, solver=solver
-        )
-        if not is_convex:
-            # Set large tolerance for the stopping criterion to stop fast
-            sc.eps = 5e-1
-        cb = _Callback(
-            objective, solver, meta={}, stopping_criterion=sc
-        )
-        cb.start()
-        solver.run(cb)
+    if solver._solver_strategy in ['iteration', 'callback']:
+        stop_val = 5000 if is_convex else 2
     else:
-        if solver._solver_strategy == 'iteration':
-            stop_val = 5000 if is_convex else 2
-        else:
-            stop_val = 1e-10 if is_convex else 1e-2
-        solver.run(stop_val)
+        stop_val = 1e-10 if is_convex else 1e-2
+    solver.run_once(stop_val)
 
     # Check that returned results are compatible with the objective
     result = solver.get_result()

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -1,9 +1,8 @@
 import pytest
 import numpy as np
 
-from benchopt.runner import _Callback
-from benchopt.stopping_criterion import SAMPLING_STRATEGIES
 from benchopt.utils import product_param
+from benchopt.stopping_criterion import SAMPLING_STRATEGIES
 
 
 def test_benchmark_objective(benchmark, dataset_simu):


### PR DESCRIPTION
In benchopt/benchmark_ot#4, failures appears because `pre_run_hook` is not called before `run` in the test.
This PR makes sure `pre_run_hook` is always called before `run` in benchopt.

It also changes the tests to use `Solver.run_once` in `test_solver` instead of a custom implementation.
I will add a test with a `pre_run_hook` before merging this PR.