### PR TITLE
#175 TST add a test that a solver can run with n_iter=0 

### DIFF
--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -124,7 +124,7 @@ def test_solver_install(test_env_name, benchmark, solver_class, check_test):
         env_name=test_env_name, raise_on_not_installed=True
     )
 
-
+#HELPER FUNCTION TO REFACTOR test_solver_tolerance and test_solver
 def _test_solver_with_parameters(benchmark, solver_class, objective_config, dataset_config):
     if not solver_class.is_installed():
         pytest.skip("Solver is not installed")


### PR DESCRIPTION
closes #175  TST add a test that a solver can run with n_iter=0 #175 

added test to `test_benchamarks.py` for some solvers which do not support `n_iter=0` or `INFINITY` for solver based on tolerance.

### Checks before merging PR
- [ ] added documentation for any new feature
- [x] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
