### PR TITLE
RELEASE bugfix v1.5.1

### DIFF
--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -5,6 +5,20 @@ What's new
 
 .. currentmodule:: benchopt
 
+.. _changes_1_5_1:
+
+Version 1.5.1 - 22/09/2023
+--------------------------
+
+Bugfix release.
+
+FIX
+~~~
+
+- Fix benchopt dependency specification to install benchopt in child env
+  with extra ``[test]``. By `Thomas Moreau`_ (:gh:`662`).
+
+
 .. _changes_1_5:
 
 Version 1.5 - 18/09/2023


### PR DESCRIPTION
Bugfix release following up on #662 .
This release should fix the failures on all the benchmarks CI for workflow with the released version of benchopt.