### PR TITLE
FIX clean benchopt_run

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -24,6 +24,7 @@ from .config import RAISE_INSTALL_ERROR
 
 
 CACHE_DIR = '__cache__'
+SLURM_JOB_NAME = 'benchopt_run'
 
 
 class Benchmark:
@@ -230,6 +231,11 @@ class Benchmark:
         output_dir = self.benchmark_dir / "outputs"
         output_dir.mkdir(exist_ok=True)
         return output_dir
+
+    def get_slurm_folder(self):
+        """Get the folder to store the output of the slurm executor."""
+        slurm_dir = self.benchmark_dir / SLURM_JOB_NAME
+        return slurm_dir
 
     def get_result_file(self, filename=None):
         """Get a result file from the benchmark.

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -20,7 +20,6 @@ from benchopt.config import get_global_config_file
 from benchopt.config import GLOBAL_CONFIG_FILE_MODE
 from benchopt.utils.dynamic_modules import _load_class_from_module
 from benchopt.utils.shell_cmd import _run_shell_in_conda_env
-from benchopt.utils.slurm_executor import get_slurm_folder
 from benchopt.utils.terminal_output import colorify
 from benchopt.utils.terminal_output import RED, GREEN, TICK, CROSS
 
@@ -74,7 +73,7 @@ def clean(benchmark, token=None, filename='all'):
                 with open(json_path, "w") as cache_run:
                     json.dump(json_file, cache_run)
     # Delete slurm files
-    slurm_folder = get_slurm_folder(benchmark)
+    slurm_folder = benchmark.get_slurm_folder()
     if slurm_folder.exists():
         print(f"rm -rf {slurm_folder}")
         rm_folder(slurm_folder)

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -20,6 +20,7 @@ from benchopt.config import get_global_config_file
 from benchopt.config import GLOBAL_CONFIG_FILE_MODE
 from benchopt.utils.dynamic_modules import _load_class_from_module
 from benchopt.utils.shell_cmd import _run_shell_in_conda_env
+from benchopt.utils.slurm_executor import get_slurm_folder
 from benchopt.utils.terminal_output import colorify
 from benchopt.utils.terminal_output import RED, GREEN, TICK, CROSS
 
@@ -72,6 +73,11 @@ def clean(benchmark, token=None, filename='all'):
                 json_file.pop(f"{filename}.{ext}", None)
                 with open(json_path, "w") as cache_run:
                     json.dump(json_file, cache_run)
+    # Delete slurm files
+    slurm_folder = get_slurm_folder(benchmark)
+    if slurm_folder.exists():
+        print(f"rm -rf {slurm_folder}")
+        rm_folder(slurm_folder)
     # Delete cache files
     print("Clear joblib cache")
     benchmark.mem.clear(warn=False)

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -328,8 +328,10 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
 
     if slurm is not None:
         from .utils.slurm_executor import run_on_slurm
-        results = run_on_slurm(benchmark, slurm, run_one_solver,
-                               common_kwargs, all_runs)
+        results = run_on_slurm(
+            benchmark, slurm, run_one_solver, common_kwargs,
+            all_runs
+        )
     else:
         results = Parallel(n_jobs=n_jobs)(
             delayed(run_one_solver)(**common_kwargs, **kwargs)

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -328,7 +328,8 @@ def run_benchmark(benchmark, solver_names=None, forced_solvers=None,
 
     if slurm is not None:
         from .utils.slurm_executor import run_on_slurm
-        results = run_on_slurm(slurm, run_one_solver, common_kwargs, all_runs)
+        results = run_on_slurm(benchmark, slurm, run_one_solver,
+                               common_kwargs, all_runs)
     else:
         results = Parallel(n_jobs=n_jobs)(
             delayed(run_one_solver)(**common_kwargs, **kwargs)

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -7,6 +7,7 @@ try:
     from rich import progress
 
     _SLURM_INSTALLED = True
+    SLURM_JOB_NAME = "benchopt_run"
 except ImportError:
     _SLURM_INSTALLED = False
 
@@ -23,14 +24,14 @@ def get_slurm_launch():
     return _LAUNCHING_SLURM
 
 
-def get_slurm_folder(benchmark, job_name="benchopt_run"):
+def get_slurm_folder(benchmark):
     """Get the folder to store the output of the slurm executor."""
     benchmark_dir = benchmark.benchmark_dir
-    output_dir = benchmark_dir / job_name
+    output_dir = benchmark_dir / SLURM_JOB_NAME
     return output_dir
 
 
-def get_slurm_executor(slurm_config, timeout=100, job_name="benchopt_run"):
+def get_slurm_executor(slurm_config, timeout=100):
 
     with open(slurm_config, "r") as f:
         config = yaml.safe_load(f)
@@ -43,7 +44,7 @@ def get_slurm_executor(slurm_config, timeout=100, job_name="benchopt_run"):
         # Timeout is in second in benchopt
         config['slurm_time'] = f"00:{int(1.5*timeout)}"
 
-    executor = submitit.AutoExecutor(job_name)
+    executor = submitit.AutoExecutor(SLURM_JOB_NAME)
     executor.update_parameters(**config)
     return executor
 

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -1,4 +1,5 @@
 import yaml
+from pathlib import Path
 
 try:
     import submitit
@@ -20,6 +21,13 @@ def set_slurm_launch():
 
 def get_slurm_launch():
     return _LAUNCHING_SLURM
+
+
+def get_slurm_folder(benchmark, job_name="benchopt_run"):
+    """Get the folder to store the output of the slurm executor."""
+    benchmark_dir = benchmark.benchmark_dir
+    output_dir = benchmark_dir / job_name
+    return output_dir
 
 
 def get_slurm_executor(slurm_config, timeout=100, job_name="benchopt_run"):

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -1,5 +1,4 @@
 import yaml
-from pathlib import Path
 
 try:
     import submitit

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -57,9 +57,7 @@ def run_on_slurm(
         )
 
     executor = get_slurm_executor(
-        benchmark,
-        slurm_config,
-        common_kwargs["timeout"]
+        benchmark, slurm_config, common_kwargs["timeout"]
     )
     with executor.batch():
         tasks = [


### PR DESCRIPTION
Fixes #664 

The command ```benchopt clean``` now cleans the content of the ```benchopt_run``` directory if it exists (for SLURM submissions).

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
