### PR TITLE
FIX pin julia version to <=1.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: |
             # remove the cache index
             mamba clean -i -y
-            mamba install python=3.10 julia<=1.10.0  r-base rpy2 \
+            mamba install python=3.10 julia r-base rpy2 \
                           numpy cython -yq
             pip install --upgrade "setuptools<58.5"
             pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,9 @@ jobs:
           command: |
             # remove the cache index
             mamba clean -i -y
-            mamba install python=3.10 "julia<=1.10.0" r-base rpy2 \
+            mamba install python=3.10 r-base rpy2 \
                           numpy cython -yq
             pip install --upgrade "setuptools<58.5"
-            pip install --upgrade --progress-bar off julia
             pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
             pip install --upgrade --progress-bar off -e .[doc]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,10 @@ jobs:
           command: |
             # remove the cache index
             mamba clean -i -y
-            mamba install python=3.10 julia r-base rpy2 \
+            mamba install python=3.10 "julia<=1.10.0" r-base rpy2 \
                           numpy cython -yq
             pip install --upgrade "setuptools<58.5"
+            pip install --upgrade --progress-bar off julia
             pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
             pip install --upgrade --progress-bar off -e .[doc]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
             mamba install python=3.10 julia<=1.10.0  r-base rpy2 \
                           numpy cython -yq
             pip install --upgrade "setuptools<58.5"
-            pip install --upgrade --progress-bar off julia
             pip install --upgrade --progress-bar off git+https://github.com/scikit-learn-contrib/lightning.git
             pip install --upgrade --progress-bar off -e .[doc]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: |
             # remove the cache index
             mamba clean -i -y
-            mamba install python=3.10 julia r-base rpy2 \
+            mamba install python=3.10 julia<=1.10.0  r-base rpy2 \
                           numpy cython -yq
             pip install --upgrade "setuptools<58.5"
             pip install --upgrade --progress-bar off julia

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           conda info
           conda install -yq pip
+          conda install -yq julia<=1.10.0
           pip install -e .[test]
           # Install mamba in base environment to make it accessible test env
           test $BENCHOPT_CONDA_CMD == "mamba" && conda install -n base mamba || echo "using conda"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           conda info
           conda install -yq pip
-          conda install -yq julia<=1.10.0
+          conda install -yq "julia<=1.10.0"
           pip install -e .[test]
           # Install mamba in base environment to make it accessible test env
           test $BENCHOPT_CONDA_CMD == "mamba" && conda install -n base mamba || echo "using conda"


### PR DESCRIPTION
Temporary fix as 1.10.1 seems to have broken some downloads functionalities : https://github.com/JuliaLang/julia/issues/53339, causing the tests to fail on `main`: https://github.com/benchopt/benchopt/actions/runs/8018415344/job/21904251404#step:6:1302