### PR TITLE
[WIP] Make `benchopt.cli`an executable module

### DIFF
--- a/benchopt/cli/__main__.py
+++ b/benchopt/cli/__main__.py
@@ -1,0 +1,4 @@
+from benchopt.cli import benchopt
+
+if __name__ == '__main__':
+    benchopt()


### PR DESCRIPTION
This PR aim at alowing calling benchopt from any python interpreter with something like 

```
python -m benchopt.cli
```
Basically we just need to add a file in the cli module

I find this interesting because it allow to run benchopt from different environments without the need to activate them. Similar feature are available for pytest and pip

### Checks before merging PR
- [ ] added documentation for any new feature
- [ ] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
