### PR TITLE
MTN config flake8+skip conda env test

### DIFF
--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -29,6 +29,8 @@ def pytest_report_header(config):
 def pytest_addoption(parser):
     parser.addoption("--skip-install", action="store_true",
                      help="skip install of solvers that can slow down CI.")
+    parser.addoption("--skip-env", action="store_true",
+                     help="skip tests which requires creating a conda env.")
     parser.addoption("--test-env", type=str, default=None,
                      help="Use a given env to test the solvers' install.")
     parser.addoption("--recreate", action="store_true",
@@ -122,6 +124,8 @@ def test_env_name(request):
     global _TEST_ENV_NAME
 
     if _TEST_ENV_NAME is None:
+        if request.config.getoption("--skip-env"):
+            pytest.skip("Skip creating a test env")
         env_name = request.config.getoption("--test-env")
         recreate = request.config.getoption("--recreate")
         if env_name is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,3 +74,6 @@ doc =
 slurm =
     submitit
     rich
+
+[flake8]
+exclude = benchmarks,__cache__


### PR DESCRIPTION
Config flake8 to ignore `benchmarks` folder and add option to skip tests which require creating a conda env and are slow.