### PR TITLE
MTN adapt to joblib 1.4

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -339,11 +339,11 @@ class Benchmark:
         func_cached = self.mem.cache(func, ignore=ignore)
         if force:
             def _func_cached(**kwargs):
-                return func_cached.call(**kwargs)[0]
+                return func_cached.call(**kwargs)
         else:
             def _func_cached(**kwargs):
                 if kwargs.get('force', False):
-                    return func_cached.call(**kwargs)[0]
+                    return func_cached.call(**kwargs)
                 return func_cached(**kwargs)
 
         return _func_cached

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pandas
     matplotlib
     click>=8.0
-    joblib
+    joblib>=1.4
     pygithub
     mako
     psutil


### PR DESCRIPTION
`joblib1.4` introduced a beaking change that `MemorizedFunction.call` doesn't return the metadata anymore.
This adapt to this change and bump the necessary version of joblib.
