### PR TITLE
CLN various cleanups

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -512,6 +512,12 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         ``Objective.compute``.
         """
 
+    def _get_one_result(self):
+        # Make sure the splits with CV are created before calling
+        # get_one_result
+        self.get_objective()
+        self.get_one_result()
+
     # Reduce the pickling and hashing burden by only pickling class parameters.
     @staticmethod
     def _reconstruct(module_filename, pickled_module_hash, parameters,

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -511,12 +511,13 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         type for benchopt. The returned object will be passed to
         ``Objective.compute``.
         """
+        ...
 
     def _get_one_result(self):
         # Make sure the splits with CV are created before calling
         # get_one_result
         self.get_objective()
-        self.get_one_result()
+        return self.get_one_result()
 
     # Reduce the pickling and hashing burden by only pickling class parameters.
     @staticmethod

--- a/benchopt/plotting/html/templates/benchmark.mako.html
+++ b/benchopt/plotting/html/templates/benchmark.mako.html
@@ -107,8 +107,8 @@
           name_data_old = ""
         split = dataset.split('[')
         if len(split) > 1:
-          name_data_new, options = split
-          options = options[:-1]
+          name_data_new, *options = split
+          options = '['.join(options)[:-1]
         else:
           name_data_new, options = split[0], []
         not_disp_name = name_data_new == name_data_old

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -201,7 +201,8 @@ class StoppingCriterion():
             raise ValueError(
                 "Objective.evaluate_result() should contain a key named "
                 f"'{key}' to be used with this stopping_criterion. The name of"
-                " this key can be changed via the 'key_to_monitor' parameter."
+                " this key can be changed via the 'key_to_monitor' parameter. "
+                f"Available keys are {list(objective_list[0].keys())}"
             )
 
         # Modify the criterion state:

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -16,8 +16,8 @@ def test_benchmark_objective(benchmark, dataset_simu):
     # check that the reported dimension is correct and that the result of
     # the objective function is a dictionary containing a scalar value for
     # `objective_value`.
-    beta_hat = objective.get_one_result()
-    objective_dict = objective(beta_hat)
+    result = objective._get_one_result()
+    objective_dict = objective(result)
 
     assert 'objective_value' in objective_dict, (
         "When the output of objective is a dict, it should at least "


### PR DESCRIPTION
- Improve stopping_criterion error on bad keys
- Fix rendering failure when `]` in objective name
- FIX make sure to call `get_objective` before calling `get_one_result` (to make sure `get_split` is called)
