### PR TITLE
FIX benchmark_utils pickling

### DIFF
--- a/benchopt/utils/safe_import.py
+++ b/benchopt/utils/safe_import.py
@@ -3,6 +3,8 @@ import warnings
 import importlib
 from pathlib import Path
 
+from joblib.externals import cloudpickle
+
 from ..config import RAISE_INSTALL_ERROR
 
 SKIP_IMPORT = False
@@ -38,6 +40,7 @@ def set_benchmark_module(benchmark_dir):
         module = importlib.util.module_from_spec(spec)
         sys.modules[PACKAGE_NAME] = module
         spec.loader.exec_module(module)
+        cloudpickle.register_pickle_by_value(module)
     elif module_file.parent.exists():
         warnings.warn(
             "Folder `benchmark_utils` exists but is missing `__init__.py`. "

--- a/benchopt/utils/temp_benchmark.py
+++ b/benchopt/utils/temp_benchmark.py
@@ -26,7 +26,8 @@ dummy_datasets = [
 
 @contextlib.contextmanager
 def temp_benchmark(
-        objective=None, datasets=None, solvers=None, config=None
+        objective=None, datasets=None, solvers=None, config=None,
+        benchmark_utils=None
 ):
     """Create Benchmark in a temporary folder, for test purposes.
 
@@ -44,6 +45,7 @@ def temp_benchmark(
     config: str | None (default=None)
         Content of configuration file for running the Benchmark. If None,
         no config file is created.
+    benchmark_utils: dict(fname->str) | None (default=None)
     """
     if objective is None:
         objective = dummy_objective
@@ -74,5 +76,14 @@ def temp_benchmark(
         if config is not None:
             with open(temp_path / "config.yml", "w") as f:
                 f.write(config)
+
+        if benchmark_utils is not None:
+            benchmark_utils_dir = (temp_path / "benchmark_utils")
+            benchmark_utils_dir.mkdir()
+            (benchmark_utils_dir / "__init__.py").touch()
+            for fname, content in benchmark_utils.items():
+                fname = (benchmark_utils_dir / fname).with_suffix(".py")
+                with open(fname, "w") as f:
+                    f.write(inspect.cleandoc(content))
 
         yield Benchmark(temp_path)

--- a/benchopt/utils/tests/test_dynamic_module.py
+++ b/benchopt/utils/tests/test_dynamic_module.py
@@ -1,0 +1,37 @@
+from joblib import Parallel, delayed
+
+from benchopt.tests.utils import CaptureRunOutput
+from benchopt.utils.temp_benchmark import temp_benchmark
+
+
+def test_pickling_benchmark_utils():
+
+    solver = """
+    from benchopt import BaseSolver
+    from benchmark_utils.test1 import func1
+
+    class Solver(BaseSolver):
+        name = "test-solver"
+        def set_objective(self, X, y, reg): self.X, self.y = X, y
+        def run(self, _): func1()
+        def get_result(self): return dict(beta=1)
+    """
+
+    with temp_benchmark(
+            solvers=[solver],
+            benchmark_utils={'test1': 'def func1(): print("FUNC1")'}
+    ) as benchmark:
+        # Get the solver from the list of tuples
+        Solver, _ = benchmark.check_solver_patterns(["test-solver"])[0]
+        assert Solver.is_installed()
+
+        with CaptureRunOutput() as out:
+            Solver.run(None, None)
+        out.check_output("FUNC1", repetition=1)
+
+        # This will fail if the benchmark_utils module is not pickled by value
+        # by cloudpickle.
+        with CaptureRunOutput():
+            Parallel(n_jobs=2)(
+                delayed(Solver.run)(None, None) for _ in range(2)
+            )

--- a/benchopt/utils/tests/test_dynamic_module.py
+++ b/benchopt/utils/tests/test_dynamic_module.py
@@ -4,7 +4,12 @@ from benchopt.tests.utils import CaptureRunOutput
 from benchopt.utils.temp_benchmark import temp_benchmark
 
 
-def test_pickling_benchmark_utils():
+def test_pickling_dynamic_module():
+    # Make sure the dynamic modules can be pickled by joblib. In particular,
+    # this is necessary for nested parallelism in distributed context.
+    #
+    # This test check that the module containing a solver can be pickled, and
+    # that the dynamic benchmark_utils module can be retrieved in the process.
 
     solver = """
     from benchopt import BaseSolver

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,11 @@ CLI
 - Add ``--collect`` option to allow gathering results which are already
   in cache in a single parquet file. By `Thomas Moreau`_ (:gh:`710`)
 
+FIX
+~~~
+
+- Fix pickling of dynamic modules to allow for nested parallelism in
+  distributed runs. By `Thomas Moreau`_ (:gh:`713`)
 
 .. _changes_1_5_1:
 


### PR DESCRIPTION
Follow up of #712 which was merged a bit quickly.
This should fix the issue in scikit-adaptation/skada-bench#60 with missing `benchmark_utils` module.