### PR TITLE
ENH download data

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -1,6 +1,7 @@
 import re
 import click
 import warnings
+import itertools
 from pathlib import Path
 
 from .config import get_setting
@@ -17,6 +18,7 @@ from .utils.terminal_output import YELLOW
 
 from .utils.conda_env_cmd import install_in_conda_env
 from .utils.conda_env_cmd import shell_install_in_conda_env
+from .utils.shell_cmd import _run_shell_in_conda_env
 
 # Get config values
 from .config import RAISE_INSTALL_ERROR
@@ -135,10 +137,11 @@ class Benchmark:
         "List all available solver names for the benchmark."
         return [s.name for s in self.get_solvers()]
 
-    def check_solver_patterns(self, solver_patterns):
+    def check_solver_patterns(self, solver_patterns, class_only=False):
         "Check that the patterns are valid and return selected configurations."
         return _check_patterns(
-            self.get_solvers(), solver_patterns, name_type='solver'
+            self.get_solvers(), solver_patterns, name_type='solver',
+            class_only=class_only
         )
 
     def get_datasets(self):
@@ -149,10 +152,11 @@ class Benchmark:
         "List all available dataset names for the benchmark."
         return [d.name for d in self.get_datasets()]
 
-    def check_dataset_patterns(self, dataset_patterns):
+    def check_dataset_patterns(self, dataset_patterns, class_only=False):
         "Check that the patterns are valid and return selected configurations."
         return _check_patterns(
-            self.get_datasets(), dataset_patterns, name_type='dataset'
+            self.get_datasets(), dataset_patterns, name_type='dataset',
+            class_only=class_only
         )
 
     def _list_benchmark_classes(self, base_class):
@@ -393,14 +397,14 @@ class Benchmark:
 
     def install_all_requirements(self, include_solvers, include_datasets,
                                  minimal=False, env_name=None,
-                                 force=False, quiet=False):
+                                 force=False, quiet=False, download=False):
         """Install all classes that are required for the run.
 
         Parameters
         ----------
-        include_solvers : list of str
+        include_solvers : list of BaseSolver
             patterns to select solvers to install.
-        include_datasets : list of str
+        include_datasets : list of BaseDataset
             patterns to select datasets to install.
         minimal : bool (default: False)
             only install requirements for the objective function.
@@ -411,27 +415,11 @@ class Benchmark:
             If set to True, forces reinstallation when using conda.
         quiet : bool (default: False)
             If True, silences the output of install commands.
+        download : bool (default: False)
+            If True, make sure the data are downloaded on the computer.
         """
         # Collect all classes matching one of the patterns
         print("Collecting packages:")
-
-        install_solvers = not minimal
-        install_datasets = not minimal
-
-        # If -d is used but not -s, then does not install any solver
-        if len(include_solvers) == 0 and len(include_datasets) > 0:
-            install_solvers = False
-
-        # If -s is used but not -d, then does not install any dataset
-        if len(include_datasets) == 0 and len(include_solvers) > 0:
-            install_datasets = False
-
-        # If -d or -s are followed by 'all' then all
-        # solvers or datasets are included
-        if 'all' in include_solvers:
-            include_solvers = []
-        if 'all' in include_datasets:
-            include_datasets = []
 
         check_installs, missings = [], []
         objective = self.get_benchmark_objective()
@@ -446,31 +434,23 @@ class Benchmark:
 
         if len(shell_install_scripts) > 0 or len(conda_reqs) > 0:
             check_installs += [objective]
-        for list_classes, include_patterns, to_install in [
-                (self.get_solvers(), include_solvers, install_solvers),
-                (self.get_datasets(), include_datasets, install_datasets)
-        ]:
-            include_patterns = _check_name_lists(include_patterns)
-            for klass in list_classes:
-                for klass_parameters in product_param(klass.parameters):
-                    name = klass._get_parametrized_name(**klass_parameters)
-                    if is_matched(name, include_patterns) and to_install:
-                        reqs, scripts, hooks, missing = (
-                            klass.collect(env_name=env_name, force=force)
-                        )
-                        # If a class is not importable but has no requirements,
-                        # it might be because the requirements are specified
-                        # as global ones in the Objective. Otherwise, raise a
-                        # comprehensible error.
-                        if missing is not None:
-                            missings.append(missing)
+        to_install = itertools.chain(include_datasets, include_solvers)
+        for klass in to_install:
+            reqs, scripts, hooks, missing = (
+                klass.collect(env_name=env_name, force=force)
+            )
+            # If a class is not importable but has no requirements,
+            # it might be because the requirements are specified
+            # as global ones in the Objective. Otherwise, raise a
+            # comprehensible error.
+            if missing is not None:
+                missings.append(missing)
 
-                        conda_reqs += reqs
-                        shell_install_scripts += scripts
-                        post_install_hooks += hooks
-                        if len(scripts) > 0 or len(reqs) > 0:
-                            check_installs += [klass]
-                        break
+            conda_reqs += reqs
+            shell_install_scripts += scripts
+            post_install_hooks += hooks
+            if len(scripts) > 0 or len(reqs) > 0:
+                check_installs += [klass]
         print('... done')
 
         # Install the collected requirements
@@ -480,7 +460,10 @@ class Benchmark:
         if len(list_install) == 0:
             self.check_missing(missings)
             print("All required solvers are already installed.")
+            if download:
+                self.download_all_data(include_datasets, env_name, quiet)
             return
+
         print(f"Installing required packages for:\n{list_install}\n...",
               end='', flush=True)
         install_in_conda_env(
@@ -518,6 +501,18 @@ class Benchmark:
                 UserWarning
             )
         print(' done')
+
+        if download:
+            self.download_all_data(include_datasets, env_name, quiet)
+
+    def download_all_data(self, datasets, env_name, quiet):
+        if len(datasets) == 0:
+            return
+        cmd = f"benchopt check-data {self.benchmark_dir} -d "
+        cmd += "-d ".join(d.name for d in datasets)
+        _run_shell_in_conda_env(
+            cmd, env_name=env_name, raise_on_error=True, capture_stdout=False
+        )
 
     def check_missing(self, missings):
         # Check that classes not importable, with no requirements, only depends
@@ -737,7 +732,8 @@ def _extract_parameters(string):
         raise ValueError(f"Invalid name '{original}', evaluated as {string}.")
 
 
-def _check_patterns(all_classes, patterns, name_type='dataset'):
+def _check_patterns(all_classes, patterns, name_type='dataset',
+                    class_only=False):
     """Check the patterns and return a list of selected classes and params.
 
     Raise an error if a pattern does not match any dataset name,
@@ -756,6 +752,8 @@ def _check_patterns(all_classes, patterns, name_type='dataset'):
     name_type: str
         Used to raise sensible error depending on the type of classes which
         are selected.
+    class_only: bool
+        Only return the classes that are matched, without a list of parameters.
 
     Returns
     -------
@@ -837,7 +835,10 @@ def _check_patterns(all_classes, patterns, name_type='dataset'):
         params.update(kwargs)
         all_valid_patterns.append((cls, params))
 
-    return all_valid_patterns
+    if not class_only:
+        return all_valid_patterns
+
+    return set(cls for cls, _ in all_valid_patterns)
 
 
 def _list_parametrized_classes(*classes, check_installed=True):

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -764,7 +764,10 @@ def _check_patterns(all_classes, patterns, name_type='dataset',
     # If no patterns is provided or all is provided, return all the classes.
     if (patterns is None or len(patterns) == 0
             or any(p == 'all' for p, *_ in patterns)):
-        return [(cls, cls.parameters) for cls in all_classes]
+        all_valid_patterns = [(cls, cls.parameters) for cls in all_classes]
+        if not class_only:
+            return all_valid_patterns
+        return set(cls for cls, _ in all_valid_patterns)
 
     # Patterns can be either str or dict. Convert everything to 3-tuple with
     # (cls_name, args, kwargs). cls_name and kwargs correspond to class and

--- a/benchopt/cli/tests/test_cli.py
+++ b/benchopt/cli/tests/test_cli.py
@@ -457,14 +457,14 @@ class TestInstallCmd:
     def test_invalid_dataset(self):
         with pytest.raises(click.BadParameter, match=r"invalid_dataset"):
             install([str(DUMMY_BENCHMARK_PATH), '-d', 'invalid_dataset',
-                     '-s', 'pgd'], 'benchopt', standalone_mode=False)
+                     '-y'], 'benchopt', standalone_mode=False)
 
     def test_invalid_solver(self):
         with pytest.raises(click.BadParameter, match=r"invalid_solver"):
-            install([str(DUMMY_BENCHMARK_PATH), '-s', 'invalid_solver'],
-                    'benchopt', standalone_mode=False)
+            install([str(DUMMY_BENCHMARK_PATH), '-s', 'invalid_solver',
+                     '-y'], 'benchopt', standalone_mode=False)
 
-    def test_benchopt_install(self):
+    def test_valid_call(self):
         with CaptureRunOutput() as out:
             install(
                 [str(DUMMY_BENCHMARK_PATH), '-d', SELECT_ONE_SIMULATED, '-s',

--- a/benchopt/cli/tests/test_helpers.py
+++ b/benchopt/cli/tests/test_helpers.py
@@ -1,0 +1,87 @@
+import pytest
+
+
+from benchopt.tests import DUMMY_BENCHMARK_PATH
+from benchopt.tests.utils import CaptureRunOutput
+from benchopt.utils.temp_benchmark import temp_benchmark
+from benchopt.utils.terminal_output import TICK, CROSS
+
+
+from benchopt.cli.helpers import check_data
+from benchopt.cli.helpers import check_install
+
+
+class TestCheckInstallCmd:
+    def test_solver_installed(self):
+        pgd_solver = DUMMY_BENCHMARK_PATH / 'solvers' / 'python_pgd.py'
+        with pytest.raises(SystemExit, match=r'0'):
+            check_install([
+                str(DUMMY_BENCHMARK_PATH), str(pgd_solver.resolve()), 'Solver'
+            ], 'benchopt')
+
+    def test_solver_does_not_exists(self):
+        pgd_solver = DUMMY_BENCHMARK_PATH / 'solvers' / 'invalid.py'
+        with pytest.raises(FileNotFoundError, match=r'invalid.py'):
+            check_install([
+                str(DUMMY_BENCHMARK_PATH), str(pgd_solver.resolve()), 'Solver'
+            ], 'benchopt')
+
+    def test_dataset_installed(self):
+        pgd_solver = DUMMY_BENCHMARK_PATH / 'datasets' / 'simulated.py'
+        with pytest.raises(SystemExit, match=r'0'):
+            check_install([
+                str(DUMMY_BENCHMARK_PATH), str(pgd_solver.resolve()), 'Dataset'
+            ], 'benchopt')
+
+    def test_dataset_does_not_exists(self):
+        pgd_solver = DUMMY_BENCHMARK_PATH / 'datasets' / 'invalid.py'
+        with pytest.raises(FileNotFoundError, match=r'invalid.py'):
+            check_install([
+                str(DUMMY_BENCHMARK_PATH), str(pgd_solver.resolve()), 'Dataset'
+            ], 'benchopt')
+
+
+class TestCheckDataCmd:
+    def test_download_data(self):
+
+        # Make sure that when the Objective is not installed, due to a missing
+        # dependency, an error is raised.
+        dataset = """from benchopt import BaseDataset
+
+        class Dataset(BaseDataset):
+            name = 'test_data'
+            def get_data(self):
+                print("LOADING DATA")
+                return {'X': 1, 'y': 2}
+        """
+        with temp_benchmark(datasets=dataset) as benchmark:
+            with CaptureRunOutput() as out:
+                check_data(
+                    [str(benchmark.benchmark_dir), '-d', 'test_data'],
+                    'benchopt', standalone_mode=False
+                )
+
+            out.check_output("LOADING DATA", repetition=1)
+            out.check_output(TICK, repetition=1)
+
+    def test_fail_download_data(self):
+
+        # Make sure that when the Objective is not installed, due to a missing
+        # dependency, an error is raised.
+        dataset = """from benchopt import BaseDataset
+
+        class Dataset(BaseDataset):
+            name = 'test_data'
+            def get_data(self):
+                raise ValueError("Failed to load data")
+                return {'X': 1, 'y': 2}
+        """
+        with temp_benchmark(datasets=dataset) as benchmark:
+            with CaptureRunOutput() as out:
+                check_data(
+                    [str(benchmark.benchmark_dir), '-d', 'test_data'],
+                    'benchopt', standalone_mode=False
+                )
+
+            out.check_output(CROSS, repetition=1)
+            out.check_output("ValueError: Failed to load data", repetition=1)

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -182,7 +182,7 @@ class DependenciesMixin:
             post_install_hooks = [cls._post_install_hook]
         else:
             env_suffix = f" in '{env_name}'" if env_name else ''
-            colored_cls_name = colorify(f'{cls.name}', YELLOW)
+            colored_cls_name = colorify(cls.name, YELLOW)
             print(
                 f"- {colored_cls_name} already available{env_suffix}\n"
                 f"  No ImportError raised from {cls._module_filename}."

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -27,6 +27,9 @@ CLI
 - Add ``--collect`` option to allow gathering results which are already
   in cache in a single parquet file. By `Thomas Moreau`_ (:gh:`710`)
 
+- Add ``--download`` option in ``benchopt install`` to allow downloading
+  the data when installing the benchmark. By `Thomas Moreau`_ (:gh:`718`)
+
 FIX
 ~~~
 


### PR DESCRIPTION
In some cases, we want to make sure the data is properly loaded when installing the benchmark, by calling `get_data` on certain datasets.
This PR adds a `--download` flag to `benchopt install` to allow calling `get_data` on any installed datasets.

This is useful in particular on big cluster where internet is not available on the computing nodes, or to avoid multiple process all trying to download the data at the same time.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
