### PR TITLE
MNT update pypa action tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,14 @@ jobs:
 
     - name: Publish distribution 📦 to Test PyPI
       if: ${{ github.ref == 'refs/heads/main' && steps.wait-for-tests.outputs.conclusion == 'success' }}
-      uses: pypa/gh-action-pypi-publish@release
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
       if: ${{ startsWith(github.ref, 'refs/tags') && steps.wait-for-tests.outputs.conclusion == 'success' }}
-      uses: pypa/gh-action-pypi-publish@release
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,14 @@ jobs:
 
     - name: Publish distribution 📦 to Test PyPI
       if: ${{ github.ref == 'refs/heads/main' && steps.wait-for-tests.outputs.conclusion == 'success' }}
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish distribution 📦 to PyPI
       if: ${{ startsWith(github.ref, 'refs/tags') && steps.wait-for-tests.outputs.conclusion == 'success' }}
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+


### PR DESCRIPTION
See warning message here : https://github.com/benchopt/benchopt/actions/runs/9346497454/job/25721464718#step:9:49

```
You are using `pypa/gh-action-pypi-publish@master`. The `master` branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use `pypa/gh-action-pypi-publish@release/v1`. If you feel adventurous, you may opt to use use `pypa/gh-action-pypi-publish@unstable/v1` instead.
```