### PR TITLE
Saving final results of a solver

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -360,9 +360,15 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
       evaluated. This should be a dictionary where the keys correspond to the
       keyword arguments of `evaluate_result`.
 
-    - `save_final_results(**result)`: Return the data to be save from the
-       results of the solver. It will be save as a `.pkl` file in the
+    Optionally, the `Solver` can implement the following methods to change its
+    behavior:
+
+    - `save_final_results(**result)`: Return the data to be saved from the
+       results of the solver. It will be saved as a `.pkl` file in the
        `output/results` folder, and link to the benchmark results.
+
+    - `get_next(stop_val)`: Return the next iteration where the result will be
+      evaluated.
 
     This class is also used to specify information about the benchmark.
     In particular, it should have the following class attributes:

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -360,9 +360,9 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
       evaluated. This should be a dictionary where the keys correspond to the
       keyword arguments of `evaluate_result`.
 
-    - `save_final_results(**result)`: Return the data to be save from the results
-       of the solver. It will be save as a `.pkl` file in the `output/results`
-       folder, and link to the benchmark results.
+    - `save_final_results(**result)`: Return the data to be save from the
+       results of the solver. It will be save as a `.pkl` file in the
+       `output/results` folder, and link to the benchmark results.
 
     This class is also used to specify information about the benchmark.
     In particular, it should have the following class attributes:

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -360,6 +360,10 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
       evaluated. This should be a dictionary where the keys correspond to the
       keyword arguments of `evaluate_result`.
 
+    - `save_final_results(**result)`: Return the data to be save from the results
+       of the solver. It will be save as a `.pkl` file in the `output/results`
+       folder, and link to the benchmark results.
+
     This class is also used to specify information about the benchmark.
     In particular, it should have the following class attributes:
 
@@ -417,6 +421,21 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
             scalar value which will be used to detect convergence. With a
             dictionary, multiple metric values can be stored at once instead
             of running each separately.
+        """
+        pass
+
+    @abstractmethod
+    def save_final_results(self, **solver_result):
+        """Save the final results of the solver.
+
+        Parameters
+        ----------
+        solver_result : dict
+            All values needed to compute the objective metrics. This dictionary
+            is retrieved by calling ``solver_result = Solver.get_result()``.
+        Returns
+        -------
+        dict of values to save
         """
         pass
 

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -424,7 +424,6 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         """
         pass
 
-    @abstractmethod
     def save_final_results(self, **solver_result):
         """Save the final results of the solver.
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -134,7 +134,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
 
-                final_results = benchmark.get_output_folder() / 'final_results' / f"{hash(meta)}.pkl"                final_result.parent.mkdir(exist=True, parents=True)
+                final_results = benchmark.get_output_folder() / 'final_results' / f"{hash(meta)}.pkl"
+                final_result.parent.mkdir(exist=True, parents=True)
                 meta['final_results'] = path
                 # hash meta  -> str.pkl
                 # save to folder benchmark.get_output_folder() / 'final_results' / hash(meta).pkl

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -130,8 +130,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                 stop, ctx.status, stop_val = stopping_criterion.should_stop(
                     stop_val, curve
                 )
-        # Save the final results if possible
-        if hasattr(objective, "save_final_results"):
+        # Only run if save_final_results is defined in the objective.
+        if objective.save_final_results is not super(objective).save_final_results:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
                 final_results = benchmark.get_output_folder() / 'final_results'

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -139,7 +139,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             if to_save is not None:
                 final_results = benchmark.get_output_folder() / 'final_results'
                 final_results /= f"{hash(meta)}.pkl"
-                final_results.parent.mkdir(exist=True, parents=True)
+                final_results.parent.mkdir(exist_ok=True, parents=True)
                 with open(final_results, 'wb') as f:
                     pickle.dump(to_save, f)
                 meta['final_results'] = final_results

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -132,7 +132,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                 )
         # Only run if save_final_results is defined in the objective.
         klass = type(objective)
-        base_klass = super(klass)
+        base_klass = super(klass, objective)
         if klass.save_final_results is not base_klass.save_final_results:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,5 +1,6 @@
 import time
 import inspect
+import pickle
 
 from datetime import datetime
 
@@ -133,13 +134,12 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
         if hasattr(objective, "save_final_results"):
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
-
-                final_results = benchmark.get_output_folder() / 'final_results' / f"{hash(meta)}.pkl"
-                final_result.parent.mkdir(exist=True, parents=True)
+                final_results = benchmark.get_output_folder() / 'final_results'
+                final_results /= f"{hash(meta)}.pkl"
+                final_results.parent.mkdir(exist=True, parents=True)
+                with open(final_results, 'wb') as f:
+                    pickle.dump(to_save, f)
                 meta['final_results'] = path
-                # hash meta  -> str.pkl
-                # save to folder benchmark.get_output_folder() / 'final_results' / hash(meta).pkl
-                # add the path to meta data
 
     return curve, ctx.status
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -131,7 +131,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                     stop_val, curve
                 )
         # Only run if save_final_results is defined in the objective.
-        if objective.save_final_results is not super(objective).save_final_results:
+        base = super(objective)
+        if objective.save_final_results is not base.save_final_results:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
                 final_results = benchmark.get_output_folder() / 'final_results'

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -3,7 +3,7 @@ import inspect
 
 from datetime import datetime
 
-from joblib import Parallel, delayed
+from joblib import Parallel, delayed, hash
 
 from .callback import _Callback
 from .utils.sys_info import get_sys_info
@@ -129,6 +129,16 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                 stop, ctx.status, stop_val = stopping_criterion.should_stop(
                     stop_val, curve
                 )
+        # Save the final results if possible
+        if hasattr(objective, "save_final_results"):
+            to_save = objective.save_final_results(**solver.get_result())
+            if to_save is not None:
+
+                final_results = benchmark.get_output_folder() / 'final_results' / f"{hash(meta)}.pkl"                final_result.parent.mkdir(exist=True, parents=True)
+                meta['final_results'] = path
+                # hash meta  -> str.pkl
+                # save to folder benchmark.get_output_folder() / 'final_results' / hash(meta).pkl
+                # add the path to meta data
 
     return curve, ctx.status
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -139,7 +139,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                 final_results.parent.mkdir(exist=True, parents=True)
                 with open(final_results, 'wb') as f:
                     pickle.dump(to_save, f)
-                meta['final_results'] = path
+                meta['final_results'] = final_results
 
     return curve, ctx.status
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -131,8 +131,9 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                     stop_val, curve
                 )
         # Only run if save_final_results is defined in the objective.
-        base = super(objective)
-        if objective.save_final_results is not base.save_final_results:
+        klass = type(objective)
+        base_klass = super(klass)
+        if klass.save_final_results is not base_klass.save_final_results:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
                 final_results = benchmark.get_output_folder() / 'final_results'

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -131,9 +131,10 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                     stop_val, curve
                 )
         # Only run if save_final_results is defined in the objective.
-        klass = type(objective)
-        base_klass = super(klass, objective)
-        if klass.save_final_results is not base_klass.save_final_results:
+        base_method = getattr(
+            super(type(objective), objective),
+            'save_final_results', None)
+        if objective.save_final_results is not base_method:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
                 final_results = benchmark.get_output_folder() / 'final_results'

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -98,7 +98,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
     # Augment the metadata with final_results if necessary.
     base_method = getattr(
         super(type(objective), objective),
-        'save_final_results', None)
+        'save_final_results', None
+    )
 
     has_save_final_results = objective.save_final_results is not base_method
     if has_save_final_results:

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -1,12 +1,9 @@
 import pytest
 import tempfile
 
-from pathlib import Path
-
 from benchopt.cli.main import run
 from benchopt.utils.temp_benchmark import temp_benchmark
 from benchopt.utils.dynamic_modules import _load_class_from_module
-from benchopt.utils.parquet import get_metadata
 
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
@@ -143,13 +140,14 @@ def test_objective_save_final_results(no_debug_test):
     with temp_benchmark(objective=save_final) as benchmark:
         with CaptureRunOutput(delete_result_files=False) as out:
             run([
-                str(benchmark.benchmark_dir), *('-s python-pgd -d test-dataset -n 1 '
-                '-r 1 --no-plot').split()
+                str(benchmark.benchmark_dir),
+                *('-s python-pgd -d test-dataset -n 1 -r 1 --no-plot').split()
             ],  standalone_mode=False)
         data = pd.read_parquet(out.result_files[0])
-        with open(data.loc[0,"final_results"], "rb") as final_result_file:
+        with open(data.loc[0, "final_results"], "rb") as final_result_file:
             final_results = pickle.load(final_result_file)
     assert final_results == "test_value"
+
 
 def test_objective_cv_splitter(no_debug_test):
 

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -1,9 +1,11 @@
 import pytest
 import tempfile
+from pathlib import Path
 
 from benchopt.cli.main import run
 from benchopt.utils.temp_benchmark import temp_benchmark
 from benchopt.utils.dynamic_modules import _load_class_from_module
+from benchopt.utils.parquet import get_metadata
 
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
@@ -112,6 +114,39 @@ def test_objective_no_cv(no_debug_test):
                  *'-s python-pgd -d test-dataset -n 1 -r 1 --no-plot'.split()],
                 standalone_mode=False)
 
+
+def test_objective_save_final_results(no_debug_test):
+    save_final = """
+    from benchopt import BaseObjective
+
+    class Objective(BaseObjective):
+        name = "cross_val"
+
+        min_benchopt_version = "0.0.0"
+
+        def set_data(self, X, y): self.X, self.y = X, y
+        def get_one_result(self): return 0
+        def evaluate_result(self, beta): return dict(value=1)
+
+        def save_final_results(self, beta):
+            print("save final called")
+            return "test_value"
+
+        def get_objective(self):
+            return dict(X=self.X, y=self.y, lmbd=1)
+
+    """
+    with temp_benchmark(objective=save_final) as benchmark:
+        with CaptureRunOutput(delete_result_files=False) as out:
+            run([
+                str(benchmark.benchmark_dir), *('-s python-pgd -d test-dataset -n 1 '
+                '-r 1 --no-plot').split()
+            ],  standalone_mode=False)
+        print(out.result_files)
+
+        config = get_metadata(Path(out.result_files[0]))
+        print(config)
+    assert False
 
 def test_objective_cv_splitter(no_debug_test):
 

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -34,3 +34,7 @@ Frequently asked questions (FAQ)
 .. dropdown:: Can I run a benchmark in parallel?
 
     Benchopt allows to run different benchmarked methods in parallel, either with ``joblib`` using ``-j 4`` to run on multiple CPUs of a single machine or using SLURM, as described in :ref:`slurm_run`.
+
+.. dropdown:: How do I get the final result of a benchmark ?
+
+    Learn how to :ref:`save_final_results` for saving the last iteration of your solver.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -34,7 +34,3 @@ Frequently asked questions (FAQ)
 .. dropdown:: Can I run a benchmark in parallel?
 
     Benchopt allows to run different benchmarked methods in parallel, either with ``joblib`` using ``-j 4`` to run on multiple CPUs of a single machine or using SLURM, as described in :ref:`slurm_run`.
-
-.. dropdown:: How do I get the final result of a benchmark ?
-
-    Learn how to :ref:`save_final_results` for saving the last iteration of your solver.

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -25,3 +25,5 @@
 .. _Pierre Ablin: https://github.com/pierreablin
 
 .. _Christopher Marouani: https://github.com/chris-mrn
+
+.. _Pierre-Antoine Comby: https://github.com/paquiteau

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -216,3 +216,10 @@ It assume that the python script is located at the same level as the benchmark f
 
 .. |SlurmExecutor| replace:: ``submitit.SlurmExecutor``
 .. _SlurmExecutor: https://github.com/facebookincubator/submitit/blob/main/submitit/slurm/slurm.py#L214
+
+.. _save_final_results:
+
+Saving Final Results of a Solver
+--------------------------------
+
+Using the `save_final_results(**results)` method of the objective function to retrieve the results to save. They are saved in `outputs/final_results/` directory and reference is added in the benchmark `.parquet` file.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,6 +13,9 @@ Version 1.6 - In development
 API
 ~~~
 
+- Add a `save_final_results` method to Objective. If implemented it is run after the last solver iteration, to get desired outputs to be saved to file system.
+  By `Pierre-Antoine Comby`_ (:gh:`722`)
+
 - Add native way to do cross-validation in a benchmark with
   ``Objective.cv`` attribute that change split for each repetition.
   By `Christopher Marouani`_ and `Thomas Moreau`_ (:gh:`623`).


### PR DESCRIPTION
Hey there ! 

This PR add the possibility to save the final results of a benchmark to the filesystem. The data is saved as a `.pkl` file and a reference is added to the metadata of the benchmark. 

This is a much need capability for imaging problems, where getting visualisation of the results is complementary of quantitative metrics (PSNR, SSIM). 

It also opens the possibility to perform further processing on solver outputs (computing extra metrics, statistics, etc.)

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)