### PR TITLE
MNT Execute only the last push commit in CI

### DIFF
--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -1,4 +1,6 @@
 name: Expose result artifact
+# Cancel in-progress workflows when pushing
+# a new commit on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true

--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -2,7 +2,7 @@ name: Expose result artifact
 # Cancel in-progress workflows when pushing
 # a new commit on the same branch
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on: [status]
 jobs:

--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -1,10 +1,10 @@
 name: Expose result artifact
+on: [status]
 # Cancel in-progress workflows when pushing
 # a new commit on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-on: [status]
 jobs:
   circleci_result_artifact_redirector_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/expose_link.yml
+++ b/.github/workflows/expose_link.yml
@@ -1,4 +1,7 @@
 name: Expose result artifact
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 on: [status]
 jobs:
   circleci_result_artifact_redirector_job:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,8 +1,10 @@
 name: linting
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 on:
+  # Cancel in-progress workflows when pushing
+  # a new commit on the same branch
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
   push:
     branches:
       - main

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,7 @@
 name: linting
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: test
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 on:
+  # Cancel in-progress workflows when pushing
+  # a new commit on the same branch
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
   push:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:


### PR DESCRIPTION
In a PR, each push executes continuous integration tests; however, if you commit and push multiple times within a PR, you create a queue of jobs and testing.

If you have tests that take longer, this ends up generating a long queue to have one test done. This is meaningless, as we always want to test only the last commit.

In this PR, we ensure that CI stops the tests for the previous push and runs the test only for the last one.
