### PR TITLE
ENH improve running benchopt in a script

### DIFF
--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -237,7 +237,7 @@ def run(config_file=None, **kwargs):
             print("Running on SLURM")
             set_slurm_launch()
 
-        from benchopt.runner import run_benchmark
+        from benchopt.runner import _run_benchmark
 
         if do_profile:
             from benchopt.utils.profiling import use_profile
@@ -250,6 +250,7 @@ def run(config_file=None, **kwargs):
         # Check that the dataset/solver patterns match actual dataset
         datasets = benchmark.check_dataset_patterns(dataset_names)
         objectives = benchmark.check_objective_filters(objective_filters)
+
         # pyyaml returns tuples: make sure everything is a list
         if isinstance(solver_names, dict):
             solver_names = [solver_names]
@@ -259,7 +260,7 @@ def run(config_file=None, **kwargs):
             solver_names + list(forced_solvers)
         )
 
-        run_benchmark(
+        _run_benchmark(
             benchmark, solvers, forced_solvers,
             datasets=datasets, objectives=objectives,
             max_runs=max_runs, n_repetitions=n_repetitions,

--- a/benchopt/cli/tests/test_cli.py
+++ b/benchopt/cli/tests/test_cli.py
@@ -444,7 +444,7 @@ class TestRunCmd:
             with pytest.raises(TypeError, match=error_match):
                 run(run_cmd, 'benchopt', standalone_mode=False)
 
-    def test_result_collection(self, no_debug_test):
+    def test_result_collection(self, no_debug_log):
         solver = """
             from benchopt import BaseSolver
             import numpy as np

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -488,7 +488,7 @@ def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
         solver_names + list(forced_solvers)
     )
     datasets = benchmark.check_dataset_patterns(dataset_names)
-    objective = benchmark.check_objective_patterns(objective_filters)
+    objective = benchmark.check_objective_filters(objective_filters)
 
     return _run_benchmark(
         benchmark, solvers, forced_solvers, datasets, objective,

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from joblib import Parallel, delayed, hash
 
 from .callback import _Callback
+from .benchmark import Benchmark
 from .utils.sys_info import get_sys_info
 from .utils.files import uniquify_results
 from .utils.pdb_helpers import exception_handler
@@ -296,11 +297,11 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
     return run_statistics
 
 
-def run_benchmark(benchmark, solvers=None, forced_solvers=None,
-                  datasets=None, objectives=None, max_runs=10,
-                  n_repetitions=1, timeout=None, n_jobs=1, slurm=None,
-                  plot_result=True, display=True, html=True,  collect=False,
-                  show_progress=True, pdb=False, output_name="None"):
+def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
+                   datasets=None, objectives=None, max_runs=10,
+                   n_repetitions=1, timeout=None, n_jobs=1, slurm=None,
+                   plot_result=True, display=True, html=True,  collect=False,
+                   show_progress=True, pdb=False, output_name="None"):
     """Run full benchmark.
 
     Parameters
@@ -417,3 +418,80 @@ def run_benchmark(benchmark, solvers=None, forced_solvers=None,
         from benchopt.plotting import plot_benchmark
         plot_benchmark(save_file, benchmark, html=html, display=display)
     return save_file
+
+
+def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
+                  dataset_names=None, objective_filters=None, max_runs=10,
+                  n_repetitions=1, timeout=None, n_jobs=1, slurm=None,
+                  plot_result=True, display=True, html=True,  collect=False,
+                  show_progress=True, pdb=False, output_name="None"):
+    """Run full benchmark.
+
+    Parameters
+    ----------
+    benchmark : benchopt.Benchmark object
+        Object to represent the benchmark.
+    solver_names : list | None
+        List of solver names to include in the benchmark. If None
+        all solvers available are run.
+    forced_solvers : list | None
+        List of solvers to include in the benchmark and for
+        which one forces recomputation.
+    dataset_names : list | None
+        List of dataset names to include. If None all available
+        datasets are used.
+    objective_filters : list | None
+        Filters to select specific objective parameters. If None,
+        all objective parameters are tested
+    max_runs : int
+        The maximum number of solver runs to perform to estimate
+        the convergence curve.
+    n_repetitions : int
+        The number of repetitions to run. Defaults to 1.
+    timeout : float
+        The maximum duration in seconds of the solver run.
+    n_jobs : int
+        Maximal number of workers to use to run the benchmark in parallel.
+    slurm : Path | None
+        If not None, launch the job on a slurm cluster using the file to get
+        the cluster config parameters.
+    plot_result : bool
+        If set to True (default), generate the result plot and save them in
+        the benchmark directory.
+    display : bool
+        If set to True (default), open the result plots at the end of the run,
+        otherwise, simply save them.
+    html : bool
+        If set to True (default), display the result plot in HTML, otherwise
+        in matplotlib figures, default is True.
+    collect : bool
+        If set to True, only collect the results that have been put in cache,
+        and ignore the results that are not computed yet, default is False.
+    show_progress : bool
+        If show_progress is set to True, display the progress of the benchmark.
+    pdb : bool
+        If pdb is set to True, open a debugger on error.
+    output_name : str
+        Filename for the parquet output. If given, the results will
+        be stored at <BENCHMARK>/outputs/<filename>.parquet.
+
+    Returns
+    -------
+    df : instance of pandas.DataFrame
+        The benchmark results. If multiple metrics were computed, each
+        one is stored in a separate column. If the number of metrics computed
+        by the objective is not the same for all parameters, the missing data
+        is set to `NaN`.
+    """
+    benchmark = Benchmark(benchmark_path)
+    solvers = benchmark.check_solver_patterns(
+        solver_names + list(forced_solvers)
+    )
+    datasets = benchmark.check_dataset_patterns(dataset_names)
+    objective = benchmark.check_objective_patterns(objective_filters)
+
+    return _run_benchmark(
+        benchmark, solvers, forced_solvers, datasets, objective,
+        max_runs, n_repetitions, timeout, n_jobs, slurm,
+        plot_result, display, html, collect, show_progress, pdb, output_name
+    )

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -13,6 +13,9 @@ from .utils.files import uniquify_results
 from .utils.pdb_helpers import exception_handler
 from .utils.terminal_output import TerminalOutput
 
+
+FAILURE_STATUS = ['diverged', 'error', 'interrupted']
+
 ##################################
 # Time one run of a solver
 ##################################
@@ -146,12 +149,12 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                     stop_val, curve
                 )
         # Only run if save_final_results is defined in the objective.
-        if has_save_final_results:
+        if has_save_final_results and ctx.status not in FAILURE_STATUS:
             to_save = objective.save_final_results(**solver.get_result())
             if to_save is not None:
                 with open(meta["final_results"], 'wb') as f:
                     pickle.dump(to_save, f)
-    if ctx.status in ['diverged', 'error', 'interrupted']:
+    if ctx.status in FAILURE_STATUS:
         raise RuntimeError(ctx.status)
     return curve, ctx.status
 

--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -95,7 +95,7 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture
-def no_debug_test(request):
+def no_debug_log(request):
     """Deactivate the debug logs for a test."""
     os.environ["BENCHOPT_DEBUG"] = "0"
     yield

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -88,7 +88,7 @@ def test_error_reporting(error, raise_install_error):
         os.environ['BENCHOPT_RAISE_INSTALL_ERROR'] = prev_value
 
 
-def test_objective_no_cv(no_debug_test):
+def test_objective_no_cv(no_debug_log):
 
     no_cv = """from benchopt import BaseObjective
 
@@ -113,7 +113,7 @@ def test_objective_no_cv(no_debug_test):
                 standalone_mode=False)
 
 
-def test_objective_save_final_results(no_debug_test):
+def test_objective_save_final_results(no_debug_log):
     save_final = """
     from benchopt import BaseObjective
 
@@ -149,7 +149,7 @@ def test_objective_save_final_results(no_debug_test):
     assert final_results == "test_value"
 
 
-def test_objective_cv_splitter(no_debug_test):
+def test_objective_cv_splitter(no_debug_log):
 
     objective = """from benchopt import BaseObjective, safe_import_context
         with safe_import_context() as import_ctx:

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -113,7 +113,7 @@ def test_solver_install_api(benchmark, solver_class):
 
 
 @pytest.mark.requires_install
-def test_solver_install(test_env_name, benchmark, solver_class, check_test):
+def test_solver_install(check_test, test_env_name, benchmark, solver_class):
 
     if check_test is not None:
         check_test(solver_class)
@@ -125,7 +125,7 @@ def test_solver_install(test_env_name, benchmark, solver_class, check_test):
     )
 
 
-def test_solver(benchmark, solver_class, check_test):
+def test_solver(check_test, benchmark, solver_class):
     # Check that a solver run with at least one configuration of a simulated
     # dataset.
 

--- a/benchopt/tests/test_objective_outputs.py
+++ b/benchopt/tests/test_objective_outputs.py
@@ -16,7 +16,7 @@ MINIMAL_SOLVER = """from benchopt import BaseSolver
     """
 
 
-def test_objective_bad_name(no_debug_test):
+def test_objective_bad_name(no_debug_log):
     # Check that if Obejctive.evaluate_result return a `name` field, a sensible
     # error is raised.
 
@@ -45,7 +45,7 @@ def test_objective_bad_name(no_debug_test):
     out.check_output("ValueError: objective output cannot be called 'name'")
 
 
-def test_objective_no_value(no_debug_test):
+def test_objective_no_value(no_debug_log):
     # Check that if Obejctive.evaluate_result does not return a `value` field,
     # a sensible error is raised.
 
@@ -76,7 +76,7 @@ def test_objective_no_value(no_debug_test):
     )
 
 
-def test_objective_nonnumeric_values(no_debug_test):
+def test_objective_nonnumeric_values(no_debug_log):
     # Check that non-numerical values in objective do not raise error
     # in saving and generating the plots.
 

--- a/benchopt/tests/test_run_config_files.py
+++ b/benchopt/tests/test_run_config_files.py
@@ -33,7 +33,7 @@ CONFIG = """
 """
 
 
-def test_config_solver_no_params(no_debug_test):
+def test_config_solver_no_params(no_debug_log):
     with temp_benchmark(solvers=[TEST_SOLVER]) as benchmark:
         config_file = benchmark.benchmark_dir / "run_config.yml"
         config_file.write_text(CONFIG)
@@ -45,7 +45,7 @@ def test_config_solver_no_params(no_debug_test):
         out.check_output(r"RUN\(0\)", repetition=1)
 
 
-def test_config_solver_no_params_error(no_debug_test):
+def test_config_solver_no_params_error(no_debug_log):
     with temp_benchmark(solvers=[TEST_SOLVER]) as benchmark:
         config_file = benchmark.benchmark_dir / "run_config.yml"
         config_file.write_text(CONFIG.replace(" #PARAMS", "[param1=0]"))
@@ -63,7 +63,7 @@ def test_config_solver_no_params_error(no_debug_test):
                 ], standalone_mode=False)
 
 
-def test_config_solver_with_params(no_debug_test):
+def test_config_solver_with_params(no_debug_log):
     params = dict(param1=[None], param2=[None])
     with temp_benchmark(solvers=[
         TEST_SOLVER.replace("# PARAMETERS", f"parameters = {params}")
@@ -79,7 +79,7 @@ def test_config_solver_with_params(no_debug_test):
         out.check_output(r"solver1\[param1=None,param2=None\]", repetition=2)
 
 
-def test_config_solver_with_params_error(no_debug_test):
+def test_config_solver_with_params_error(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[param0=0]")
 
     params = dict(param1=[None], param2=[None])
@@ -102,7 +102,7 @@ def test_config_solver_with_params_error(no_debug_test):
                 ], standalone_mode=False)
 
 
-def test_config_solver_with_params_list_error(no_debug_test):
+def test_config_solver_with_params_list_error(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[0, 1]")
 
     params = dict(param1=[None], param2=[None])
@@ -121,7 +121,7 @@ def test_config_solver_with_params_list_error(no_debug_test):
                 ], standalone_mode=False)
 
 
-def test_config_solver_with_params_str_list(no_debug_test):
+def test_config_solver_with_params_str_list(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[param1=[0, 1]]")
 
     params = dict(param1=[None], param2=[None])
@@ -141,7 +141,7 @@ def test_config_solver_with_params_str_list(no_debug_test):
         out.check_output("param1=1,param2=None", repetition=2)
 
 
-def test_config_solver_with_params_str_value(no_debug_test):
+def test_config_solver_with_params_str_value(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[param1=0, param2=1]")
 
     params = dict(param1=[None], param2=[None])
@@ -161,7 +161,7 @@ def test_config_solver_with_params_str_value(no_debug_test):
         out.check_output("param1=0,param2=1", repetition=2)
 
 
-def test_config_solver_with_params_yaml_list(no_debug_test):
+def test_config_solver_with_params_yaml_list(no_debug_log):
     config = CONFIG.replace(" #PARAMS", ":\n            param1: [0, 1]")
 
     params = dict(param1=[None], param2=[None])
@@ -181,7 +181,7 @@ def test_config_solver_with_params_yaml_list(no_debug_test):
         out.check_output("param1=1,param2=None", repetition=2)
 
 
-def test_config_solver_with_params_yaml_items(no_debug_test):
+def test_config_solver_with_params_yaml_items(no_debug_log):
     config = CONFIG.replace(" #PARAMS", """:
               param1:
                 - 0
@@ -204,7 +204,7 @@ def test_config_solver_with_params_yaml_items(no_debug_test):
         out.check_output("param1=1", repetition=2)
 
 
-def test_config_solver_with_params_yaml_value(no_debug_test):
+def test_config_solver_with_params_yaml_value(no_debug_log):
     config = CONFIG.replace(" #PARAMS", """:
               param1: 0
               param2: 1
@@ -226,7 +226,7 @@ def test_config_solver_with_params_yaml_value(no_debug_test):
         out.check_output("param1=0,param2=1", repetition=2)
 
 
-def test_config_solver_with_params_complex_param(no_debug_test):
+def test_config_solver_with_params_complex_param(no_debug_log):
     config = CONFIG.replace(" #PARAMS", """:
               param1:
                 - test: 0
@@ -251,7 +251,7 @@ def test_config_solver_with_params_complex_param(no_debug_test):
         )
 
 
-def test_config_solver_with_one_params_list(no_debug_test):
+def test_config_solver_with_one_params_list(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[0, 1]")
 
     params = dict(param1=[None])
@@ -272,7 +272,7 @@ def test_config_solver_with_one_params_list(no_debug_test):
         out.check_output("param1=1", repetition=2)
 
 
-def test_config_solver_with_one_params_yaml_list(no_debug_test):
+def test_config_solver_with_one_params_yaml_list(no_debug_log):
     config = CONFIG.replace(" #PARAMS", ":\n          - 0\n          - 1")
 
     params = dict(param1=[None])
@@ -293,7 +293,7 @@ def test_config_solver_with_one_params_yaml_list(no_debug_test):
         out.check_output("param1=1", repetition=2)
 
 
-def test_config_solver_double_param_yaml_list(no_debug_test):
+def test_config_solver_double_param_yaml_list(no_debug_log):
     config = CONFIG.replace(
         " #PARAMS", ":\n            param1, param2: [[0, 1]]"
     )
@@ -316,7 +316,7 @@ def test_config_solver_double_param_yaml_list(no_debug_test):
         out.check_output("param1=0,param2=1", repetition=2)
 
 
-def test_config_solver_double_param_solver_yaml(no_debug_test):
+def test_config_solver_double_param_solver_yaml(no_debug_log):
     config = CONFIG.replace(" #PARAMS", "[param1=0]")
 
     params = {'param1, param2': [(None, None)]}

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -10,7 +10,6 @@ from benchopt.tests import TEST_OBJECTIVE
 from benchopt.tests import SELECT_ONE_PGD
 from benchopt.tests import SELECT_ONE_SIMULATED
 from benchopt.tests import SELECT_ONE_OBJECTIVE
-from benchopt.tests import DUMMY_BENCHMARK_PATH
 
 from benchopt.benchmark import _check_patterns
 from benchopt.benchmark import _extract_options

--- a/benchopt/tests/test_stopping_criterion.py
+++ b/benchopt/tests/test_stopping_criterion.py
@@ -115,7 +115,7 @@ def test_key_to_monitor(criterion_class, strategy):
 @pytest.mark.parametrize('criterion_class', [
     SufficientDescentCriterion, SufficientProgressCriterion
 ])
-def test_key_to_monitor_objective(no_debug_test, criterion_class, strategy):
+def test_key_to_monitor_objective(no_debug_log, criterion_class, strategy):
     "Check that the criterion tracks the right objective key."
     key = 'test_key'
 
@@ -155,7 +155,7 @@ def test_key_to_monitor_objective(no_debug_test, criterion_class, strategy):
 
 
 @pytest.mark.parametrize('strategy', SAMPLING_STRATEGIES)
-def test_solver_strategy(no_debug_test, strategy):
+def test_solver_strategy(no_debug_log, strategy):
 
     solver = f"""from benchopt import BaseSolver
 
@@ -192,7 +192,7 @@ def test_solver_strategy(no_debug_test, strategy):
 @pytest.mark.parametrize('criterion_class', [
     SufficientDescentCriterion, SufficientProgressCriterion
 ])
-def test_stopping_criterion_strategy(no_debug_test, criterion_class, strategy):
+def test_stopping_criterion_strategy(no_debug_log, criterion_class, strategy):
 
     if strategy == "run_once":
         criterion_class = SingleRunCriterion
@@ -233,7 +233,7 @@ def test_stopping_criterion_strategy(no_debug_test, criterion_class, strategy):
 @pytest.mark.parametrize('criterion_class', [
     SufficientDescentCriterion, SufficientProgressCriterion
 ])
-def test_solver_override_strategy(no_debug_test, criterion_class, strategy):
+def test_solver_override_strategy(no_debug_log, criterion_class, strategy):
 
     if strategy == "run_once":
         criterion_class = SingleRunCriterion
@@ -271,7 +271,7 @@ def test_solver_override_strategy(no_debug_test, criterion_class, strategy):
                 standalone_mode=False)
 
 
-def test_dual_strategy(no_debug_test):
+def test_dual_strategy(no_debug_log):
 
     solver = """from benchopt import BaseSolver
     from benchopt.stopping_criterion import SufficientDescentCriterion
@@ -296,7 +296,7 @@ def test_dual_strategy(no_debug_test):
                     standalone_mode=False)
 
 
-def test_objective_equals_zero(no_debug_test):
+def test_objective_equals_zero(no_debug_log):
 
     objective = """from benchopt import BaseObjective
 

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -184,15 +184,11 @@ It assume that the python script is located at the same level as the benchmark f
 .. code-block:: python
 
     from benchopt import run_benchmark
-    from benchopt.benchmark import Benchmark
 
-    # load benchmark
-    BENCHMARK_PATH = "./"
-    benchmark = Benchmark(BENCHMARK_PATH)
 
     # run benchmark
     run_benchmark(
-        benchmark,
+        benchmark_path='.',
         solver_names=[
             "skglm",
             "celer",

--- a/examples/plot_run_benchmark.py
+++ b/examples/plot_run_benchmark.py
@@ -20,20 +20,11 @@ BENCHMARK_PATH = (
 
 try:
 
-    benchmark = Benchmark(BENCHMARK_PATH)
-
-    solvers = benchmark.check_solver_patterns(
-        ['sklearn[liblinear]', 'sklearn[newton-cg]', 'lightning']
-    )
-    datasets = benchmark.check_dataset_patterns(
-        ["Simulated[n_features=500,n_samples=200]"]
-    )
-    objectives = benchmark.check_objective_filters(
-        ['L2 Logistic Regression[lmbd=1.0]']
-    )
-
     save_file = run_benchmark(
-        benchmark, solvers=solvers, datasets=datasets, objectives=objectives,
+        BENCHMARK_PATH,
+        solver_names=['sklearn[liblinear]', 'sklearn[newton-cg]', 'lightning'],
+        dataset_names=["Simulated[n_features=500,n_samples=200]"],
+        objective_filters=['L2 Logistic Regression[lmbd=1.0]'],
         max_runs=100, timeout=20, n_repetitions=15,
         plot_result=False, show_progress=True
     )

--- a/examples/plot_run_benchmark_python_R.py
+++ b/examples/plot_run_benchmark_python_R.py
@@ -23,20 +23,11 @@ if not BENCHMARK_PATH.exists():
         f"{BENCHMARK_PATH.resolve()}"
     )
 
-benchmark = Benchmark(BENCHMARK_PATH)
-
-solvers = benchmark.check_solver_patterns(
-    ['Python-PGD[use_acceleration=False]', 'R-PGD']
-)
-datasets = benchmark.check_dataset_patterns(
-    ["Simulated[n_features=5000,n_samples=100,rho=0]"]
-)
-objectives = benchmark.check_objective_filters(
-    ['*[fit_intercept=False,reg=0.5]']
-)
-
 save_file = run_benchmark(
-    benchmark, solvers=solvers, datasets=datasets, objectives=objectives,
+    BENCHMARK_PATH,
+    solver_names=['Python-PGD[use_acceleration=False]', 'R-PGD'],
+    dataset_names=["Simulated[n_features=5000,n_samples=100,rho=0]"],
+    objective_filters=['*[fit_intercept=False,reg=0.5]'],
     max_runs=100, timeout=100, n_repetitions=5,
     plot_result=False, show_progress=False
 )


### PR DESCRIPTION
It is sometimes useful to be able to run benchopt from a script, in particular to debug part of the code.
This feature was broken by #706.