### PR TITLE
ENH replace channel specification from : to :: to accomodate url

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -37,8 +37,8 @@ MISSING_DEPS_MSG = (
     "dependencies should be specified in the `requirements` class attribute.\n"
     "Examples:\n"
     "   requirements = ['pkg'] # conda package `pkg`\n"
-    "   requirements = ['chan:pkg'] # package `pkg` in conda channel `chan`\n"
-    "   requirements = ['pip:pkg'] # PyPi package `pkg`"
+    "   requirements = ['chan::pkg'] # package `pkg` in conda channel `chan`\n"
+    "   requirements = ['pip::pkg'] # PyPi package `pkg`"
 )
 
 SUBSTITUTIONS = {"*": ".*"}

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -231,10 +231,10 @@ def print_info(cls_name_list, cls_list, env_name=None, verbose=False):
             if hasattr(cls, 'requirements') and cls.requirements:
                 print("> requirements:")
                 packages = cls.requirements
-                pip_packages = [pkg[4:] for pkg in packages
-                                if pkg.startswith('pip:')]
+                pip_packages = [pkg[5:] for pkg in packages
+                                if pkg.startswith('pip::')]
                 conda_packages = [pkg for pkg in packages
-                                  if not pkg.startswith('pip:')]
+                                  if not pkg.startswith('pip::')]
                 if len(conda_packages) > 0:
                     print("    conda install -c conda-forge "
                           f"{' '.join(conda_packages)}")

--- a/benchopt/cli/tests/test_cli.py
+++ b/benchopt/cli/tests/test_cli.py
@@ -570,7 +570,7 @@ class TestInstallCmd:
                 name = "requires_dummy"
                 install_cmd = 'conda'
                 requirements = [
-                    'pip:git+https://github.com/tommoral/dummy_package'
+                    'pip::git+https://github.com/tommoral/dummy_package'
                 ]
                 def set_data(self): pass
                 def evaluate_result(self, beta): pass
@@ -644,7 +644,7 @@ class TestInstallCmd:
                 name = "requires_dummy"
                 install_cmd = 'conda'
                 requirements = [
-                    'pip:git+https://github.com/tommoral/dummy_package'
+                    'pip::git+https://github.com/tommoral/dummy_package'
                 ]
                 def set_data(self): pass
                 def evaluate_result(self, beta): pass

--- a/benchopt/helpers/julia.py
+++ b/benchopt/helpers/julia.py
@@ -63,7 +63,9 @@ class JuliaSolver(BaseSolver):
 
     # Requirements
     install_cmd = 'conda'
-    requirements = ['julia', 'pip:julia']
+    requirements = [
+        'https://repo.prefix.dev/julia-forge::julia', 'pip::julia'
+    ]
 
     @classmethod
     def is_installed(cls, env_name=None, raise_on_not_installed=None):

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -177,6 +177,7 @@ def get_cmd_from_requirements(packages):
     This detects the packages that need to be installed with pip and also
     the additional channels for conda packages.
     """
+    # TODO: remove with benchopt 1.7
     # If ":" is present but not "::", warn that this is legacy syntax.
     has_legacy_colon = any(":" in pkg and "::" not in pkg for pkg in packages)
     if has_legacy_colon:
@@ -197,7 +198,7 @@ def get_cmd_from_requirements(packages):
             for pkg in conda_packages if '::' in pkg
         ))
         conda_packages = ' '.join(
-            pkg.rsplit('::', 1)[1] for pkg in conda_packages
+            pkg.rsplit('::', 1)[-1] for pkg in conda_packages
         )
         cmd.append(
             f"{CONDA_CMD} install --update-all -y {channels} {conda_packages}"

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -177,19 +177,37 @@ def get_cmd_from_requirements(packages):
     This detects the packages that need to be installed with pip and also
     the additional channels for conda packages.
     """
-    pip_packages = [pkg[4:] for pkg in packages if pkg.startswith('pip:')]
-    conda_packages = [pkg for pkg in packages if not pkg.startswith('pip:')]
-
-    cmd = []
-    if conda_packages:
-        channels = ' '.join(set(
-            f"-c {pkg.split(':')[0]}" for pkg in conda_packages if ':' in pkg
-        ))
-        packages = ' '.join(pkg.split(':')[-1] for pkg in conda_packages)
-        cmd.append(
-            f"{CONDA_CMD} install --update-all -y {channels} {packages}"
+    # If ":" is present but not "::", warn that this is legacy syntax.
+    has_legacy_colon = any(":" in pkg and "::" not in pkg for pkg in packages)
+    if has_legacy_colon:
+        warnings.warn(
+            "The use of ':' to specify the channel of a dependency is "
+            "deprecated. Please use '::' instead.", DeprecationWarning
         )
 
+    cmd = []
+    conda_packages = [pkg for pkg in packages if not pkg.startswith('pip::')]
+    if conda_packages:
+
+        for i, pkg in enumerate(packages):
+            if ":" in pkg and "::" not in pkg:
+                packages[i] = pkg.replace(":", "::")
+        channels = ' '.join(set(
+            f"-c {pkg.rsplit('::', 1)[0]}"
+            for pkg in conda_packages if '::' in pkg
+        ))
+        conda_packages = ' '.join(
+            pkg.rsplit('::', 1)[1] for pkg in conda_packages
+        )
+        cmd.append(
+            f"{CONDA_CMD} install --update-all -y {channels} {conda_packages}"
+        )
+
+    # TODO: simplify in benchopt 1.7
+    pip_packages = [
+        pkg.replace("pip::", "").replace("pip:", "")
+        for pkg in packages if pkg.startswith('pip:')
+    ]
     if pip_packages:
         packages = ' '.join(pip_packages)
         cmd.append(f"pip install {packages}")

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -190,9 +190,10 @@ def get_cmd_from_requirements(packages):
     conda_packages = [pkg for pkg in packages if not pkg.startswith('pip::')]
     if conda_packages:
 
-        for i, pkg in enumerate(packages):
-            if ":" in pkg and "::" not in pkg:
-                packages[i] = pkg.replace(":", "::")
+        conda_packages = [
+            pkg.replace(":", "::") if ":" in pkg and "::" not in pkg else pkg
+            for pkg in conda_packages
+        ]
         channels = ' '.join(set(
             f"-c {pkg.rsplit('::', 1)[0]}"
             for pkg in conda_packages if '::' in pkg

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -16,7 +16,7 @@ class DependenciesMixin:
     #
     # - 'conda': The class should have an attribute `requirements`.
     #          Benchopt will conda install `$requirements`, except for entries
-    #          starting with `pip:` which will be installed with `pip` in the
+    #          starting with `pip::` which will be installed with `pip` in the
     #          conda env.
     #
     # - 'shell': The solver should have attribute `install_script`. Benchopt
@@ -131,9 +131,10 @@ class DependenciesMixin:
                             "attribute `requirements`.\n"
                             "Examples:\n"
                             "   requirements = ['pkg'] # conda package `pkg`\n"
-                            "   requirements = ['chan:pkg'] # package `pkg` in"
-                            "conda channel `chan`\n"
-                            "   requirements = ['pip:pkg'] # pip package `pkg`"
+                            "   requirements = ['chan::pkg'] # package `pkg` "
+                            "in conda channel `chan`\n"
+                            "   requirements = ['pip::pkg'] "
+                            "# pip package `pkg`"
                         )
                 elif install_cmd_ == "shell":
                     install_file = (

--- a/benchopt/utils/tests/test_conda_env_cmd.py
+++ b/benchopt/utils/tests/test_conda_env_cmd.py
@@ -1,3 +1,5 @@
+import pytest
+
 from benchopt.utils.conda_env_cmd import get_cmd_from_requirements
 from benchopt.config import get_setting
 
@@ -7,7 +9,7 @@ CONDA_CMD = get_setting("conda_cmd")
 
 def test_requirements_conda():
 
-    packages = ["dep1", "dep2", "chan1:dep3"]
+    packages = ["dep1", "dep2", "chan1::dep3"]
     cmd = get_cmd_from_requirements(packages)
 
     assert len(cmd) == 1
@@ -20,9 +22,23 @@ def test_requirements_conda():
     assert " -c chan1 " in cmd, f"missing channel in cmd: {cmd}"
 
 
+def test_deprecated_channel():
+
+    packages = ["chan:dep"]
+    with pytest.warns(DeprecationWarning):
+        cmd = get_cmd_from_requirements(packages)
+
+    assert len(cmd) == 1
+    cmd = cmd[0]
+
+    assert CONDA_CMD in cmd, f"Should use {CONDA_CMD} to install deps."
+    assert " dep" in cmd, f"missing dep in cmd: {cmd}"
+    assert " -c chan " in cmd, f"missing channel in cmd: {cmd}"
+
+
 def test_requirements_pip():
 
-    packages = ["pip:dep1", "pip:dep2"]
+    packages = ["pip::dep1", "pip::dep2"]
     cmd = get_cmd_from_requirements(packages)
 
     assert len(cmd) == 1
@@ -35,7 +51,7 @@ def test_requirements_pip():
 
 def test_requirements_mixed():
 
-    packages = ["dep1", "pip:dep2"]
+    packages = ["dep1", "pip::dep2"]
     cmd = get_cmd_from_requirements(packages)
 
     assert len(cmd) == 2

--- a/doc/benchmark_workflow/install_benchmark.rst
+++ b/doc/benchmark_workflow/install_benchmark.rst
@@ -42,7 +42,7 @@ Examples:
 .. code-block:: python
 
   requirements = ['pkg']  # conda package `pkg`
-  requirements = ['chan:pkg']  # package `pkg` in conda channel `chan`
+  requirements = ['chan::pkg']  # package `pkg` in conda channel `chan`
 
 
 One might also need to install pip packages. This can be done by using the
@@ -51,5 +51,5 @@ channel `pip` and the `conda` installer. The syntax is the following:
 .. code-block:: python
 
   install_cmd = 'conda'  # optional
-  requirements = ['pip:pkg']  # pip package `pkg`
+  requirements = ['pip::pkg']  # pip package `pkg`
 


### PR DESCRIPTION
when specifying a channel with a URL, the `:` split breaks;
This PR changes this to get `::` instead to desambiguate.

TODO:
- [ ] add tests