### PR TITLE
Fix skip objective

### DIFF
--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -24,11 +24,8 @@ except Exception:
     DUMMY_BENCHMARK = None
 try:
     TEST_OBJECTIVE = DUMMY_BENCHMARK.get_benchmark_objective()
-    TEST_SOLVER = [s for s in DUMMY_BENCHMARK.get_solvers()
-                   if s.name == "Solver-Test"][0]
     TEST_DATASET = [d for d in DUMMY_BENCHMARK.get_datasets()
                     if d.name == "Test-Dataset"][0]
 except Exception:
     TEST_OBJECTIVE = None
-    TEST_SOLVER = None
     TEST_DATASET = None

--- a/benchopt/tests/dummy_benchmark/solvers/solver_test.py
+++ b/benchopt/tests/dummy_benchmark/solvers/solver_test.py
@@ -18,11 +18,6 @@ class Solver(BaseSolver):
     def __init__(self, raise_error=False):
         self.raise_error = raise_error
 
-    def skip(self, X, y, lmbd):
-        if lmbd == 0:
-            return True, "lmbd=0"
-        return False, None
-
     def set_objective(self, X, y, lmbd):
         self.X, self.y, self.lmbd = X, y, lmbd
 

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -63,6 +63,11 @@ def test_skip_api(n_jobs):
                 f'-j {n_jobs} --no-plot'
             ).split()], standalone_mode=False)
 
+            # Make sure joblib's executor is shutdown, as otherwise the output
+            # might be incomplete.
+            from joblib.externals.loky import get_reusable_executor
+            get_reusable_executor().shutdown(wait=True)
+
     out.check_output(r"Objective-skip\[should_skip=True\] skip", repetition=1)
     out.check_output(r"Reason: Objective\$skip", repetition=1)
 

--- a/benchopt/tests/utils/capture_run_output.py
+++ b/benchopt/tests/utils/capture_run_output.py
@@ -54,7 +54,14 @@ class CaptureRunOutput(object):
 
     def check_output(self, pattern, repetition=None):
         output = self.output
+
+        # Remove color for matches
+        for c in range(30, 38):
+            output = output.replace(f"\033[1;{c}m", "")
+        output = output.replace("\033[0m", "")
+
         matches = re.findall(pattern, output)
+
         if repetition is None:
             assert len(matches) > 0, (
                 f"Could not find '{pattern}' in output:\n{output}"

--- a/benchopt/utils/terminal_output.py
+++ b/benchopt/utils/terminal_output.py
@@ -84,7 +84,7 @@ class TerminalOutput:
         new_output = TerminalOutput(self.n_repetitions, self.show_progress)
         new_output.set(
             solver=self.solver, dataset=self.dataset, objective=self.objective,
-            verbose=self.verbose, rep=self.rep
+            verbose=self.verbose, rep=self.rep, i_solver=self.i_solver
         )
         return new_output
 
@@ -147,7 +147,7 @@ class TerminalOutput:
 
     def show_status(self, status, dataset=False, objective=False):
         if dataset or objective:
-            assert status == 'not installed'
+            assert status in ['not installed', 'skip']
         tag = (
             self.dataset_tag if dataset else
             self.objective_tag if objective else self.solver_tag

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -29,6 +29,9 @@ FIX
 - Default value for ``data_home`` was incorrect.
   By `Thomas Moreau`_ (:gh:`758`)
 
+- Fix the ``skip`` API for objectives that was leading to a display error.
+  By `Thomas Moreau`_ (:gh:`763`)
+
 
 .. _changes_1_6:
 


### PR DESCRIPTION
The current implementation of the `skip` API fails when skipping some objective, because of bad interactions with the terminal_output.
This PR fixes the issue and adds better tests for the full pipeline, including reporting.

cc @ceelestin 

- [x] Add tests
- [x] Add what's new entry