### PR TITLE
FIX: use correct function in "benchopt info"

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -305,8 +305,8 @@ def info(benchmark, solver_names, dataset_names, env_name='False',
     print(f"Info regarding the benchmark '{benchmark.name}'")
 
     # validate solvers and datasets
-    benchmark.validate_dataset_patterns(dataset_names)
-    benchmark.validate_solver_patterns(solver_names)
+    benchmark.check_dataset_patterns(dataset_names)
+    benchmark.check_solver_patterns(solver_names)
 
     # get solvers and datasets in the benchmark
     all_solvers = benchmark.get_solvers()

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -38,6 +38,7 @@ FIX
 - Fix the ``skip`` API for objectives that was leading to a display error.
   By `Thomas Moreau`_ (:gh:`763`)
 
+- Fix the ``info`` command By `Pierre-Antoine Comby`_ (:gh:`&67`)
 
 .. _changes_1_6:
 


### PR DESCRIPTION
running `benchopt info` resulted in error because `validate_*` functions have been renamed to `check_*`

-------

### Checks before merging PR
- ~~[ ] added documentation for any new feature~~
- ~~[ ] added unit test~~
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)