### PR TITLE
FIX installing pip dependencies in conda environment

### DIFF
--- a/benchopt/tests/test_deprecation.py
+++ b/benchopt/tests/test_deprecation.py
@@ -1,32 +1,28 @@
 import pytest
 
-from benchopt.utils.conda_env_cmd import get_cmd_from_requirements
-from benchopt.utils.conda_env_cmd import CONDA_CMD, PIP_CMD
+from benchopt.utils.conda_env_cmd import get_env_file_from_requirements
 
 
 # TODO: remove this test in benchopt 1.7
 def test_deprecated_channel_spec():
-    with pytest.warns(DeprecationWarning):
-        cmd = get_cmd_from_requirements(["chan:pkg"])
-
-    assert len(cmd) == 1
-    assert cmd[0] == f"{CONDA_CMD} install --update-all -y -c chan pkg"
 
     with pytest.warns(DeprecationWarning):
-        cmd = get_cmd_from_requirements(["pip:pkg"])
-
-    assert len(cmd) == 1
-    assert cmd[0] == f"{PIP_CMD} install pkg"
+        env = get_env_file_from_requirements(["chan:pkg"])
+    assert env == "channels:\n  - chan\ndependencies:\n  - pkg"
 
     with pytest.warns(DeprecationWarning):
-        cmd = get_cmd_from_requirements(["pip:git+https://test.org"])
-
-    assert len(cmd) == 1
-    assert cmd[0] == f"{PIP_CMD} install git+https://test.org"
+        env = get_env_file_from_requirements(["pip:pkg"])
+    assert env == "dependencies:\n  - pip\n  - pip:\n    - pkg"
 
     with pytest.warns(DeprecationWarning):
-        cmd = get_cmd_from_requirements(["pkg1", "chan:pkg2", "pip:pkg3"])
+        env = get_env_file_from_requirements(["pip:git+https://test.org"])
+    assert env == (
+        "dependencies:\n  - pip\n  - pip:\n    - git+https://test.org"
+    )
 
-    assert len(cmd) == 2
-    assert cmd[0] == f"{CONDA_CMD} install --update-all -y -c chan pkg1 pkg2"
-    assert cmd[1] == f"{PIP_CMD} install pkg3"
+    with pytest.warns(DeprecationWarning):
+        env = get_env_file_from_requirements(["pkg1", "chan:pkg2", "pip:pkg3"])
+    assert env == (
+        "channels:\n  - chan\n"
+        "dependencies:\n  - pkg1\n  - pkg2\n  - pip\n  - pip:\n    - pkg3"
+    )

--- a/benchopt/utils/tests/test_conda_env_cmd.py
+++ b/benchopt/utils/tests/test_conda_env_cmd.py
@@ -1,6 +1,4 @@
-import pytest
-
-from benchopt.utils.conda_env_cmd import get_cmd_from_requirements
+from benchopt.utils.conda_env_cmd import get_env_file_from_requirements
 from benchopt.config import get_setting
 
 
@@ -9,54 +7,32 @@ CONDA_CMD = get_setting("conda_cmd")
 
 def test_requirements_conda():
 
-    packages = ["dep1", "dep2", "chan1::dep3"]
-    cmd = get_cmd_from_requirements(packages)
-
-    assert len(cmd) == 1
-    cmd = cmd[0]
-
-    assert CONDA_CMD in cmd, f"Should use {CONDA_CMD} to install deps."
-    assert " dep1" in cmd, f"missing dep1 in cmd: {cmd}"
-    assert " dep2" in cmd, f"missing dep2 in cmd: {cmd}"
-    assert " dep3" in cmd, f"missing dep3 in cmd: {cmd}"
-    assert " -c chan1 " in cmd, f"missing channel in cmd: {cmd}"
+    packages = ["dep1", "dep2"]
+    env = get_env_file_from_requirements(packages)
+    assert env == "dependencies:\n  - dep1\n  - dep2"
 
 
-def test_deprecated_channel():
-
-    packages = ["chan:dep"]
-    with pytest.warns(DeprecationWarning):
-        cmd = get_cmd_from_requirements(packages)
-
-    assert len(cmd) == 1
-    cmd = cmd[0]
-
-    assert CONDA_CMD in cmd, f"Should use {CONDA_CMD} to install deps."
-    assert " dep" in cmd, f"missing dep in cmd: {cmd}"
-    assert " -c chan " in cmd, f"missing channel in cmd: {cmd}"
+def test_requirements_conda_with_channels():
+    packages = ["dep1", "dep2", "chan1::dep3", "chan2::dep4", "chan1::dep2"]
+    env = get_env_file_from_requirements(packages)
+    assert env == (
+        "channels:\n  - chan1\n  - chan2\n"
+        "dependencies:\n  - dep1\n  - dep2\n  - dep3\n  - dep4"
+    )
 
 
 def test_requirements_pip():
 
     packages = ["pip::dep1", "pip::dep2"]
-    cmd = get_cmd_from_requirements(packages)
-
-    assert len(cmd) == 1
-    cmd = cmd[0]
-
-    assert 'pip' in cmd, "Should use pip to install deps."
-    assert " dep1" in cmd, f"missing dep1 in cmd: {cmd}"
-    assert " dep2" in cmd, f"missing dep2 in cmd: {cmd}"
+    env = get_env_file_from_requirements(packages)
+    assert env == "dependencies:\n  - pip\n  - pip:\n    - dep1\n    - dep2"
 
 
 def test_requirements_mixed():
 
-    packages = ["dep1", "pip::dep2"]
-    cmd = get_cmd_from_requirements(packages)
-
-    assert len(cmd) == 2
-
-    assert CONDA_CMD in cmd[0], f"Should use {CONDA_CMD} to install dep1."
-    assert " dep1" in cmd[0], f"missing dep1 in cmd: {cmd[0]}"
-    assert 'pip ' in cmd[1], "Should use pip to install dep2."
-    assert " dep2" in cmd[1], f"missing dep2 in cmd: {cmd[1]}"
+    packages = ["dep1", "chan1::dep2", "pip::dep2", "pip::dep2"]
+    env = get_env_file_from_requirements(packages)
+    assert env == (
+        "channels:\n  - chan1\ndependencies:\n  - dep1\n  - dep2\n"
+        "  - pip\n  - pip:\n    - dep2"
+    )


### PR DESCRIPTION
The current use of `PIP_CMD` which use `sys.executable` does not point toward `python` in the right environment. As using only `pip` can cause issues on windows, I propose to create an environment file with both `conda` and `pip` deps and install everything in one go with [`conda env update`](https://docs.conda.io/projects/conda/en/latest/commands/env/update.html)