### PR TITLE
ENH allow objective to produce multiple entries at once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install Julia
         run:
-          ${{ env.BENCHOPT_CONDA_CMD }} install -yq -c https://repo.prefix.dev/julia-forge julia[version">=1.10.0"]
+          ${{ env.BENCHOPT_CONDA_CMD }} install -yq -c https://repo.prefix.dev/julia-forge julia[version=">=1.10.0"]
 
       - name: Install benchopt and its dependencies
         run: |

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -348,12 +348,12 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
     - `evaluate_result(**result)`: evaluate the metrics on the results of a
       solver. Its arguments should correspond to the key of the dictionary
-      returned by `Solver.get_result` and it can return a scalar value or
-      a dictionary.
+      returned by `Solver.get_result` and it can return a scalar value,
+      a dictionary or a list of dictionaries.
       If it returns a dictionary, it should at least contain a key
       `value` associated to a scalar value which will be used to
       detect convergence. With a dictionary, multiple metric values can be
-      stored at once instead of running each separately.
+      stored at once instead of running each separately. With a list of dictionaries, these metrics can be computed on different objects.
 
     - `get_one_result()`: return one result for which the objective can be
       evaluated. This should be a dictionary where the keys correspond to the

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -444,24 +444,31 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         pass
 
     def format_objective_dict(self, objective_dict):
-        """Format that the output of the objective.
+        """Format the output of the objective.
+        
+        This will prefix all keys in the dictionary with `objective_`
+        to make the objective part of the results clear.
 
         Parameters
         ----------
         objective_dict: dict
             The output of the objective function, which should be a dictionary
-            not containing the key 'name'. The keys of the dictionary should
-            will be prefixed with 'objective_'.
+            not containing the key 'name'.
 
         Returns
         -------
         objective_dict : dict
-            The objective formatted for the result.
+            The formatted objective to include in the DataFrame.
         """
 
-        if 'name' in objective_dict:
+        if not isinstance(objective_dict, dict):
             raise ValueError(
-                "objective output cannot be called 'name'."
+                "The output of the objective should be a list of dictionary "
+                "with no 'name' key in it"
+            )
+        elif 'name' in objective_dict:
+            raise ValueError(
+                "objective output cannot contain a key 'name'"
             )
         return {
             f'objective_{k}': v for k, v in objective_dict.items()

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -464,9 +464,9 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
         if not isinstance(objective_dict, dict):
             raise ValueError(
-                "The output of Objective.evaluate_result should be either a single "
-                "dictionary or a list of dictionaries. Note that these dictionaries "
-                "cannot contain a key 'name'"
+                "The output of Objective.evaluate_result should be either a "
+                "single dictionary or a list of dictionaries. Note that these "
+                "dictionaries cannot contain a key 'name'"
             )
         elif 'name' in objective_dict:
             raise ValueError(

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -445,7 +445,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
     def format_objective_dict(self, objective_dict):
         """Format the output of the objective.
-        
+
         This will prefix all keys in the dictionary with `objective_`
         to make the objective part of the results clear.
 
@@ -468,7 +468,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
             )
         elif 'name' in objective_dict:
             raise ValueError(
-                "objective output cannot contain a key 'name'"
+                "objective output cannot contain 'name' key"
             )
         return {
             f'objective_{k}': v for k, v in objective_dict.items()

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -421,7 +421,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
         Returns
         -------
-        objective_value : float or dict {'name': float} or list of dict
+        objective_value : float or dict {str: float} or list of dict
             The value(s) of the objective function. If a dictionary is
             returned, it should at least contain a key `value` associated to a
             scalar value which will be used to detect convergence. With a
@@ -445,7 +445,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
         pass
 
     def format_objective_dict(self, objective_dict):
-        """Format the output of the objective.
+        """Format the output of Objective.evaluate_results.
 
         This will prefix all keys in the dictionary with `objective_`
         to make the objective part of the results clear.
@@ -464,8 +464,9 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
         if not isinstance(objective_dict, dict):
             raise ValueError(
-                "The output of the objective should be a list of dictionary "
-                "with no 'name' key in it"
+                "The output of Objective.evaluate_result should be either a single "
+                "dictionary or a list of dictionaries. Note that these dictionaries "
+                "cannot contain a key 'name'"
             )
         elif 'name' in objective_dict:
             raise ValueError(

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -215,7 +215,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, ABC):
                 .get_runner_instance(solver=self)
             )
             run_once_cb = _Callback(
-                lambda x: {'objective_value': 1},
+                lambda x: [{'objective_value': 1}],
                 solver=self,
                 meta={},
                 stopping_criterion=stopping_criterion
@@ -420,7 +420,7 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
 
         Returns
         -------
-        objective_value : float or dict {'name': float}
+        objective_value : float or dict {'name': float} or list of dict
             The value(s) of the objective function. If a dictionary is
             returned, it should at least contain a key `value` associated to a
             scalar value which will be used to detect convergence. With a

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -490,12 +490,12 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
             objective_list = objective_output
 
         objective_list = [
-            self.format_objective_dict(obj) for obj in objective_list
+            self.format_objective_dict(d) for d in objective_list
         ]
 
         return objective_list
 
-    # Saved
+    # Save the dataset object used to get the objective data so we can avoid
     # hashing the data directly.
     def set_dataset(self, dataset):
         self._dataset = dataset

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -353,7 +353,8 @@ class BaseObjective(ParametrizedNameMixin, DependenciesMixin, ABC):
       If it returns a dictionary, it should at least contain a key
       `value` associated to a scalar value which will be used to
       detect convergence. With a dictionary, multiple metric values can be
-      stored at once instead of running each separately. With a list of dictionaries, these metrics can be computed on different objects.
+      stored at once instead of running each separately. With a list of
+      dictionaries, these metrics can be computed on different objects.
 
     - `get_one_result()`: return one result for which the objective can be
       evaluated. This should be a dictionary where the keys correspond to the

--- a/benchopt/callback.py
+++ b/benchopt/callback.py
@@ -86,12 +86,12 @@ class _Callback:
         Return True if the solver should be stopped.
         """
         result = self.solver.get_result()
-        objective_dict = self.objective(result)
-        self.curve.append(dict(
+        objective_list = self.objective(result)
+        self.curve.extend(dict(
             **self.meta, stop_val=self.it,
             time=self.time_iter,
             **objective_dict, **self.info
-        ))
+        ) for objective_dict in objective_list)
 
         # Check the stopping criterion
         should_stop_res = self.stopping_criterion.should_stop(

--- a/benchopt/plotting/plot_boxplot.py
+++ b/benchopt/plotting/plot_boxplot.py
@@ -68,15 +68,17 @@ def compute_solver_boxplot_data(df, obj_col):
     # By SOLVERS : Compute final time and final objective_value data
     boxplot_by_solver = dict(
         final_times=(
-            df[['idx_rep', 'time']]
-            .groupby('idx_rep')['time']
-            .max()
-        ).tolist(),
+            df[['idx_rep', 'stop_val', 'time']]
+            .groupby('idx_rep').apply(
+                lambda x: x['time'].loc[x['stop_val'] == x['stop_val'].max()]
+            )
+        ).transpose()[0].tolist(),
         final_objective_value=(
-            df[['idx_rep', obj_col]]
-            .groupby('idx_rep')[obj_col]
-            .min()
-        ).tolist()
+            df[['idx_rep', 'stop_val', obj_col]]
+            .groupby('idx_rep').apply(
+                lambda x: x[obj_col].loc[x['stop_val'] == x['stop_val'].max()]
+            )
+        ).transpose()[0].tolist()
     )
 
     # By ITERATIONS : Compute time and objective_value per iteration

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -54,13 +54,15 @@ def run_one_resolution(objective, solver, meta, stop_val):
     solver.run(stop_val)
     delta_t = time.perf_counter() - t_start
     result = solver.get_result()
-    objective_dict = objective(result)
+    objective_list = objective(result)
 
     # Add system info in results
     info = get_sys_info()
 
-    return dict(**meta, stop_val=stop_val, time=delta_t,
-                **objective_dict, **info)
+    return [
+        dict(**meta, stop_val=stop_val, time=delta_t, **objective_dict, **info)
+        for objective_dict in objective_list
+    ]
 
 
 def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
@@ -140,9 +142,10 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             stop_val = stopping_criterion.init_stop_val()
             while not stop:
 
-                cost = run_one_resolution_cached(stop_val=stop_val,
-                                                 **call_args)
-                curve.append(cost)
+                objective_list = run_one_resolution_cached(
+                    stop_val=stop_val, **call_args
+                )
+                curve.extend(objective_list)
 
                 # Check the stopping criterion and update rho if necessary.
                 stop, ctx.status, stop_val = stopping_criterion.should_stop(

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -484,8 +484,8 @@ class SingleRunCriterion(StoppingCriterion):
 
         return super().get_runner_instance(1, timeout, output, solver)
 
-    def check_convergence(self, cost_curve):
-        return True, 1
+    def should_stop(self, stop_val, objective_list):
+        return True, 'done', stop_val
 
 
 class NoCriterion(StoppingCriterion):

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -17,7 +17,7 @@ def test_benchmark_objective(benchmark, dataset_simu):
     # the objective function is a dictionary containing a scalar value for
     # `objective_value`.
     result = objective._get_one_result()
-    objective_dict = objective(result)
+    objective_dict = objective(result)[0]
 
     assert 'objective_value' in objective_dict, (
         "When the output of objective is a dict, it should at least "

--- a/benchopt/tests/test_objective_outputs.py
+++ b/benchopt/tests/test_objective_outputs.py
@@ -43,7 +43,7 @@ def test_objective_bad_name(no_debug_log):
                     *'-s test-solver -d test-dataset -n 1 -r 1 --no-plot'
                     .split()], standalone_mode=False)
 
-    out.check_output("ValueError: objective output cannot be called 'name'")
+    out.check_output("ValueError: objective output cannot contain 'name' key")
 
 
 def test_objective_no_value(no_debug_log):

--- a/benchopt/tests/test_objective_outputs.py
+++ b/benchopt/tests/test_objective_outputs.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 
 from benchopt.cli.main import run
 from benchopt.utils.temp_benchmark import temp_benchmark
@@ -34,7 +35,7 @@ def test_objective_bad_name(no_debug_log):
 
     with temp_benchmark(
             objective=objective,
-            solvers=[MINIMAL_SOLVER]
+            solvers=MINIMAL_SOLVER
     ) as benchmark:
         with pytest.raises(SystemExit, match='1'):
             with CaptureRunOutput() as out:
@@ -61,10 +62,18 @@ def test_objective_no_value(no_debug_log):
             def get_objective(self): return dict(X=0, y=0)
     """
 
-    with temp_benchmark(
-            objective=objective,
-            solvers=[MINIMAL_SOLVER]
-    ) as benchmark:
+    solver = """from benchopt import BaseSolver
+    from benchopt.stopping_criterion import SufficientProgressCriterion
+
+    class Solver(BaseSolver):
+        name = "test-solver"
+        #STOP
+        def set_objective(self, X, y): pass
+        def run(self, n_iter): pass
+        def get_result(self): return dict(beta=1)
+    """
+
+    with temp_benchmark(objective=objective, solvers=solver) as benchmark:
         with pytest.raises(SystemExit, match='1'):
             with CaptureRunOutput() as out:
                 run([str(benchmark.benchmark_dir),
@@ -74,6 +83,32 @@ def test_objective_no_value(no_debug_log):
     out.check_output(
         r"Objective.evaluate_result\(\) should contain a key named 'value'"
     )
+
+    solver_key = solver.replace(
+        "#STOP",
+        "stopping_criterion=SufficientProgressCriterion(key_to_monitor='XXX')"
+    )
+    with temp_benchmark(objective=objective, solvers=solver_key) as benchmark:
+        with pytest.raises(SystemExit, match='1'):
+            with CaptureRunOutput() as out:
+                run([str(benchmark.benchmark_dir),
+                    *'-s test-solver -d test-dataset -n 1 -r 1 --no-plot'
+                    .split()], standalone_mode=False)
+
+    out.check_output(
+        r"Objective.evaluate_result\(\) should contain a key named 'XXX'"
+    )
+
+    # Check that there is no error if the key is present or if using
+    # a solver with strategy run_once.
+    for solver in [MINIMAL_SOLVER, solver_key.replace('XXX', 'test_acc')]:
+        with temp_benchmark(objective=objective, solvers=solver) as benchmark:
+            with CaptureRunOutput() as out:
+                run([str(benchmark.benchmark_dir),
+                    *'-s test-solver -d test-dataset -n 1 -r 1 --no-plot'
+                    .split()], standalone_mode=False)
+
+        out.check_output("done")
 
 
 def test_objective_nonnumeric_values(no_debug_log):
@@ -97,7 +132,7 @@ def test_objective_nonnumeric_values(no_debug_log):
 
     with temp_benchmark(
             objective=objective,
-            solvers=[MINIMAL_SOLVER]
+            solvers=MINIMAL_SOLVER
     ) as benchmark:
         with CaptureRunOutput() as out:
             run([str(benchmark.benchmark_dir),
@@ -111,7 +146,7 @@ def test_objective_nonnumeric_values(no_debug_log):
     )
     with temp_benchmark(
             objective=objective,
-            solvers=[MINIMAL_SOLVER]
+            solvers=MINIMAL_SOLVER
     ) as benchmark:
         with CaptureRunOutput() as out:
             run([str(benchmark.benchmark_dir),
@@ -119,3 +154,35 @@ def test_objective_nonnumeric_values(no_debug_log):
                  .split()], standalone_mode=False)
 
         assert out.result_files[0].endswith('.csv')
+
+
+def test_objective_multiple_points(no_debug_log):
+    # Check that if Obejctive.evaluate_result returns a list, we get
+    # multiple points in the final DataFrame.
+
+    objective = """from benchopt import BaseObjective
+
+        class Objective(BaseObjective):
+            name = "test_obj"
+            min_benchopt_version = "0.0.0"
+
+            def set_data(self, X, y): pass
+            def get_one_result(self): pass
+            def evaluate_result(self, beta):
+                return [dict(value=i) for i in range(3)]
+            def get_objective(self): return dict(X=0, y=0)
+    """
+
+    with temp_benchmark(
+            objective=objective,
+            solvers=MINIMAL_SOLVER
+    ) as benchmark:
+        with CaptureRunOutput(delete_result_files=False) as out:
+            run([str(benchmark.benchmark_dir),
+                *'-s test-solver -d test-dataset -n 1 -r 2 --no-plot'
+                .split()], standalone_mode=False)
+        df = pd.read_parquet(out.result_files[0])
+
+    assert len(df) == 6
+    assert df['objective_value'].unique().tolist() == [0, 1, 2]
+    assert df['idx_rep'].unique().tolist() == [0, 1]

--- a/benchopt/tests/test_objective_outputs.py
+++ b/benchopt/tests/test_objective_outputs.py
@@ -157,7 +157,7 @@ def test_objective_nonnumeric_values(no_debug_log):
 
 
 def test_objective_multiple_points(no_debug_log):
-    # Check that if Obejctive.evaluate_result returns a list, we get
+    # Check that if Objective.evaluate_result returns a list, we get
     # multiple points in the final DataFrame.
 
     objective = """from benchopt import BaseObjective

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -79,7 +79,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/doc/sg_execution_times.rst
+++ b/doc/sg_execution_times.rst
@@ -6,7 +6,7 @@
 
 Computation times
 =================
-**00:04.247** total execution time for 2 files **from all galleries**:
+**00:17.789** total execution time for 2 files **from all galleries**:
 
 .. container::
 
@@ -32,9 +32,9 @@ Computation times
    * - Example
      - Time
      - Mem (MB)
-   * - :ref:`sphx_glr_auto_examples_plot_run_benchmark_python_R.py` (``../examples/plot_run_benchmark_python_R.py``)
-     - 00:02.411
-     - 0.0
    * - :ref:`sphx_glr_auto_examples_plot_run_benchmark.py` (``../examples/plot_run_benchmark.py``)
-     - 00:01.836
+     - 00:13.136
+     - 0.0
+   * - :ref:`sphx_glr_auto_examples_plot_run_benchmark_python_R.py` (``../examples/plot_run_benchmark_python_R.py``)
+     - 00:04.654
      - 0.0

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -112,8 +112,8 @@ final results of a solver.
 
 .. _multiple_evaluation:
 
-Producing multiple evaluation at once
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Producing multiple evaluations at once
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``evaluate_result`` method can be used to produce multiple rows in the
 benchmark result dataframe. This is done by returning a list of dictionaries
@@ -123,14 +123,16 @@ have a key that matches the ``key_to_monitor`` for the solver (see :ref:`stoppin
 
 This feature typically allows to store metrics for each sample in a test set
 or for each fold in a cross-validation setting, allowing to compute aggregated
-statitics at plotting time.
+statistics at plotting time.
 
 .. _save_final_results:
 
 Saving Final Results of a Solver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using the `save_final_results(**results)` method of the objective function to retrieve the results to save. They are saved in `outputs/final_results/` directory and reference is added in the benchmark `.parquet` file.
+Using the `save_final_results(**results)` method of the objective function to
+retrieve the results to save. They are saved in `outputs/final_results/` directory
+and reference is added in the benchmark `.parquet` file.
 
 .. _benchmark_utils_import:
 

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -96,6 +96,41 @@ we get
 
             return False, None
 
+.. _extra_objectives:
+
+Advanced usage of ``Objective`` class
+-------------------------------------
+
+The ``Objective`` class is used to evaluate each method's result, with
+a call to the ``evaluate_result`` method. This method is called with the
+dictionary returned by the solver's ``get_result`` method and should
+return a dictionary, whose keys/values are the names and values of the metrics.
+Each solver's run constitutes a single row in the benchmark result dataframe.
+For more flexibility, the ``Objective`` class can also be used to produce
+multiple rows in the benchmark result dataframe at once, or to save the
+final results of a solver.
+
+.. _multiple_evaluation:
+
+Producing multiple evaluation at once
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``evaluate_result`` method can be used to produce multiple rows in the
+benchmark result dataframe. This is done by returning a list of dictionaries
+instead of a single dictionary. Each dictionary in the list should be a valid
+result dictionary, *i.e.*, it should not contain a ``name`` key and should
+have a key that matches the ``key_to_monitor`` for the solver (see :ref:`stopping_criterion`).
+
+This feature typically allows to store metrics for each sample in a test set
+or for each fold in a cross-validation setting, allowing to compute aggregated
+statitics at plotting time.
+
+.. _save_final_results:
+
+Saving Final Results of a Solver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using the `save_final_results(**results)` method of the objective function to retrieve the results to save. They are saved in `outputs/final_results/` directory and reference is added in the benchmark `.parquet` file.
 
 .. _benchmark_utils_import:
 
@@ -212,10 +247,3 @@ It assumes that the python script is located at the same level as the benchmark 
 
 .. |SlurmExecutor| replace:: ``submitit.SlurmExecutor``
 .. _SlurmExecutor: https://github.com/facebookincubator/submitit/blob/main/submitit/slurm/slurm.py#L214
-
-.. _save_final_results:
-
-Saving Final Results of a Solver
---------------------------------
-
-Using the `save_final_results(**results)` method of the objective function to retrieve the results to save. They are saved in `outputs/final_results/` directory and reference is added in the benchmark `.parquet` file.

--- a/doc/user_guide/performance_curves.rst
+++ b/doc/user_guide/performance_curves.rst
@@ -91,16 +91,18 @@ instance, if a solver needs to be evaluated every 10 iterations, we would have
 
 This example allows to set a linear growth for the solver computational budget, instead of the default geometric growth.
 
+.. _stopping_criterion:
 
 When are the solvers stopped?
 -----------------------------
 
-For each of the sampling strategies above, the solvers continue running (i.e. the callback returns ``True``, the number of iterations passed to ``Solver.run`` increases or the tolerance passed to ``Solver.run`` decreases) until the ``StoppingCriterion.should_stop()`` associated to the solver ``Solver.stopping_criterion`` returns ``True``.
+For each of the sampling strategies above, the solvers continue running (i.e. the callback returns ``True``, the number of iterations/tolerance passed to ``Solver.run`` increases/decreases) until the ``StoppingCriterion.should_stop()`` associated to the solver ``Solver.stopping_criterion`` returns ``True``.
 
 This method takes into account the maximal number of runs given as ``--max-runs``, the timeout given by ``--timeout`` and also tries to stop the solver if it has converged.
 The convergence of a solver is determined by the ``StoppingCriterion.check_convergence()`` method, based on the objective curve so far.
-There are three ``StoppingCriterion`` implemented in benchopt:
+There are four ``StoppingCriterion`` implemented in benchopt:
 
-- ``SufficientDescentCriterion(eps, patience)`` considers that the solver has converged when the relative decrease of the objective was less than a tolerance ``eps`` for more than ``patience`` calls to ``check_convergence``.
-- ``SufficientProgressCriterion(eps, patience)`` considers that the solver has converged when the objective has not decreased by more than a tolerance ``eps`` for more than ``patience`` calls to ``check_convergence``.
 - ``SingleRunCriterion(stop_val)`` only calls the solver once with the given stop_val. This criterion is designed for methods that converge to a given value, when one aims to benchmark final performance of multiple solvers.
+- ``NoCriterion()`` runs the solver for a fixed number of steps, given by the ``--max-runs`` argument. This criterion deactivate the checks for convergence.
+- ``SufficientDescentCriterion(eps, patience, key_to_monitor)`` considers that the solver has converged when the relative decrease of the objective was less than a tolerance ``eps`` for more than ``patience`` calls to ``check_convergence``. The ``key_to_monitor`` is the key of the objective dictionary to monitor. By default, it is set to ``value``.
+- ``SufficientProgressCriterion(eps, patience, key_to_monitor)`` considers that the solver has converged when the objective has not decreased by more than a tolerance ``eps`` for more than ``patience`` calls to ``check_convergence``. The ``key_to_monitor`` is the key of the objective dictionary to monitor. By default, it is set to ``value``.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,9 @@ API
   ``p_obj_|p_solver_|p_dataset_`` to avoid collapse between the different
   components. By `Melvine Nargeot`_  and `Thomas Moreau`_ (:gh:`703`).
 
+- ``Objective`` can now return multiple evaluation at once, to store non-aggregated
+  metrics. See :ref:`multiple_evaluation`. By `Thomas Moreau`_ (:gh:`778`).
+
 FIX
 ---
 


### PR DESCRIPTION
In some cases, we want to be able to flatten the objective output and produce multiple values in the dataframe at once.
This PR allows `Objective.evaluate_result` to output a dict or a list of dict, that are extended with the meta data and appended in the result dataframe.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
