### PR TITLE
FIX install in current env

### DIFF
--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -224,6 +224,10 @@ def install_in_conda_env(*packages, env_name=None, force=False, quiet=False):
     if DEBUG:
         print(f"\ninstalling env packages:\n{'-' * 40}{env}{'-' * 40}")
 
+    # If installing in the current env, get its name.
+    if env_name is None:
+        env_name, _ = list_conda_envs()
+
     with NamedTemporaryFile(mode='w+', prefix='env_', suffix='.yml') as f:
         f.write(env)
         f.flush()


### PR DESCRIPTION
With #772, we use a more complicated way to install in conda env, which is currently broken when installing in the current env. It actually creates a `None` env and install everything to it.
This PR fixes this behavior.
