### PR TITLE
CI update to use miniforge instead of mambaforge in install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Get conda running
           command: |
 
-            wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh -O ~/miniconda.sh;
+            wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -O ~/miniconda.sh;
             chmod +x ~/miniconda.sh;
             ~/miniconda.sh -b -p ~/miniconda;
             echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;


### PR DESCRIPTION
Fixes #780 