### PR TITLE
Fix result page css

### DIFF
--- a/benchopt/plotting/html/static/hover_index.css
+++ b/benchopt/plotting/html/static/hover_index.css
@@ -120,6 +120,7 @@
 
 /* Default color */
 figure.effect-ruby {
+  height: 150px;
   background-color: #2c3e50;
 }
 

--- a/benchopt/plotting/html/templates/index.mako.html
+++ b/benchopt/plotting/html/templates/index.mako.html
@@ -35,7 +35,6 @@
 <div class="grid">
 % for benchmark in benchmarks:
     <figure class="effect-ruby">
-      <img src="https://via.placeholder.com/250x150/1E90FF" alt="backgrd"/>
       <figcaption>
         <h2>${benchmark.pretty_name}</h2>
         <p>${benchmark.n_runs} files available</p>


### PR DESCRIPTION
Fix the following css bug of the result web page as shown in the screen below.

<img width="1512" alt="Capture d’écran 2025-04-02 à 18 04 52" src="https://github.com/user-attachments/assets/38167977-bc8c-4e4d-99f6-cfc6660898a3" />

Removed an old image reached by its URL that is not available anymore and frozen the height of items with the same height as the old image.