### PR TITLE
API support requirements as dict

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -407,7 +407,8 @@ class Benchmark:
 
     def install_all_requirements(self, include_solvers, include_datasets,
                                  minimal=False, env_name=None,
-                                 force=False, quiet=False, download=False):
+                                 force=False, quiet=False, download=False,
+                                 gpu=False):
         """Install all classes that are required for the run.
 
         Parameters
@@ -427,6 +428,9 @@ class Benchmark:
             If True, silences the output of install commands.
         download : bool (default: False)
             If True, make sure the data are downloaded on the computer.
+        gpu : bool (default: False)
+            If True and the requirements of a class are a dict, install
+            requirements["gpu"] instead of requirements["cpu"].
         """
         # Collect all classes matching one of the patterns
         print("Collecting packages...", end='', flush=True)
@@ -447,7 +451,7 @@ class Benchmark:
         to_install = itertools.chain(include_datasets, include_solvers)
         for klass in to_install:
             reqs, scripts, hooks, missing = (
-                klass.collect(env_name=env_name, force=force)
+                klass.collect(env_name=env_name, force=force, gpu=gpu)
             )
             # If a class is not importable but has no requirements,
             # it might be because the requirements are specified

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -417,10 +417,14 @@ def run(config_file=None, **kwargs):
               help="If this flag is set, no confirmation will be asked "
               "to the user to install requirements in the current environment."
               " Useless with options `-e/--env` or `--env-name`.")
+@click.option('--gpu', is_flag=True, default=False,
+              help="Use this flag to install requirements['gpu'] for solvers "
+                   "and datasets that have different requirements for GPU and "
+                   "CPU.")
 def install(
         benchmark, minimal, solver_names, dataset_names, config_file=None,
         force=False, recreate=False, env_name='False', confirm=False,
-        quiet=False, download=False):
+        quiet=False, download=False, gpu=False):
 
     if config_file is not None:
         with open(config_file, "r") as f:
@@ -432,7 +436,7 @@ def install(
             forced_solvers = config.get("force-solver", tuple())
             solver_names = list(set(solver_names).union(set(forced_solvers)))
 
-    # Instanciate the benchmark
+    # Instantiate the benchmark
     benchmark = Benchmark(benchmark)
 
     # Get a list of all conda envs
@@ -502,7 +506,7 @@ def install(
     benchmark.install_all_requirements(
         include_solvers=solvers, include_datasets=datasets,
         minimal=minimal, env_name=env_name, force=force, quiet=quiet,
-        download=download
+        download=download, gpu=gpu,
     )
 
 

--- a/benchopt/tests/test_install.py
+++ b/benchopt/tests/test_install.py
@@ -74,7 +74,7 @@ def test_gpu_flag(no_debug_log):
 
     class Solver(BaseSolver):
         name = "solver1"
-        requirements = {"wrong_key": 1, "cpu": 2}
+        requirements = {"wrong_key": 1, "cpu": []}
     """
 
     solver2 = """from benchopt import BaseSolver
@@ -97,8 +97,15 @@ def test_gpu_flag(no_debug_log):
                         solvers=[solver1, solver2],
                         datasets=[dataset]) as benchmark:
         err = ("keys should be `cpu` and `gpu`, got ['wrong_key', 'cpu']")
-        with CaptureRunOutput() as out:
+        with CaptureRunOutput():
             with pytest.raises(ValueError, match=re.escape(err)):
                 install([str(benchmark.benchmark_dir),
                         *'-y -f -s solver1 --gpu'.split()],
                         standalone_mode=False)
+
+        # installing without gpu flag install requirements["cpu"], hence OK
+        with CaptureRunOutput() as out:
+            install([str(benchmark.benchmark_dir),
+                     *'-y -f -s solver1'.split()],
+                     standalone_mode=False)
+        out.check_output("All required solvers are already installed.")

--- a/benchopt/tests/test_install.py
+++ b/benchopt/tests/test_install.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 
 from benchopt.cli.main import install
@@ -95,7 +96,9 @@ def test_gpu_flag(no_debug_log):
     with temp_benchmark(objective=objective,
                         solvers=[solver1, solver2],
                         datasets=[dataset]) as benchmark:
-        with CaptureRunOutput():
-            install([str(benchmark.benchmark_dir),
-                     *'-y -s solver1 --gpu'.split()],
-                     standalone_mode=False)
+        err = ("keys should be `cpu` and `gpu`, got ['wrong_key', 'cpu']")
+        with CaptureRunOutput() as out:
+            with pytest.raises(ValueError, match=re.escape(err)):
+                install([str(benchmark.benchmark_dir),
+                        *'-y -f -s solver1 --gpu'.split()],
+                        standalone_mode=False)

--- a/benchopt/tests/test_install.py
+++ b/benchopt/tests/test_install.py
@@ -92,21 +92,19 @@ def test_gpu_flag(no_debug_log):
         with CaptureRunOutput():
             with pytest.raises(ValueError, match=re.escape(err)):
                 install([str(benchmark.benchmark_dir),
-                        *'-y -f -s solver1 --gpu'.split()],
+                         *'-y -f -s solver1 --gpu'.split()],
                         standalone_mode=False)
 
         # installing without gpu flag installs requirements["cpu"], hence OK
         with CaptureRunOutput() as out:
             install([str(benchmark.benchmark_dir),
                      *'-y -f -s solver1'.split()],
-                     standalone_mode=False)
+                    standalone_mode=False)
         out.check_output("All required solvers are already installed.")
-
 
         # all good with requirements["cpu"] for solver2, hence no error
         with CaptureRunOutput() as out:
             install([str(benchmark.benchmark_dir),
                      *'-y -f -s solver2 --gpu'.split()],
-                     standalone_mode=False)
+                    standalone_mode=False)
         out.check_output("All required solvers are already installed.")
-

--- a/benchopt/tests/test_install.py
+++ b/benchopt/tests/test_install.py
@@ -102,7 +102,7 @@ def test_gpu_flag(no_debug_log):
                     standalone_mode=False)
         out.check_output("All required solvers are already installed.")
 
-        # all good with requirements["cpu"] for solver2, hence no error
+        # all good with requirements["gpu"] for solver2, hence no error
         with CaptureRunOutput() as out:
             install([str(benchmark.benchmark_dir),
                      *'-y -f -s solver2 --gpu'.split()],

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -17,7 +17,7 @@ from benchopt.benchmark import _extract_parameters
 from benchopt.benchmark import _list_parametrized_classes
 from benchopt.utils.temp_benchmark import temp_benchmark
 from benchopt.tests.utils import CaptureRunOutput
-from benchopt.cli.main import run
+from benchopt.cli.main import run, install
 
 
 @pytest.mark.parametrize('n_jobs', [1, 2, 4])
@@ -453,3 +453,51 @@ def test_prefix_with_same_parameters():
         assert "s" in df['p_solver_type'].unique()
         assert "s" not in df['p_dataset_type'].unique()
         assert "d" in df['p_dataset_type'].unique()
+
+
+
+def test_gpu_flag(no_debug_log):
+
+    objective = """from benchopt import BaseObjective
+
+        class Objective(BaseObjective):
+            name = "test_obj"
+            min_benchopt_version = "0.0.0"
+
+            def set_data(self, X, y): pass
+            def get_one_result(self): pass
+            def evaluate_result(self, beta): return dict(value=1)
+            def get_objective(self): return dict(X=0, y=0)
+    """
+
+    solver1 = """from benchopt import BaseSolver
+
+    class Solver(BaseSolver):
+        name = "failing-solver"
+        requirements = {"wrong_key": 1, "cpu": 2}
+    """
+
+    solver2 = """from benchopt import BaseSolver
+
+    class Solver(BaseSolver):
+        name = "normal-solver"
+        sampling_strategy = 'iteration'
+        requirements = []
+    """
+
+    dataset = """from benchopt import BaseDataset
+
+    class Dataset(BaseDataset):
+        name = "dataset"
+        def get_data(self):
+            return dict(X=0, y=1)
+    """
+
+    with temp_benchmark(objective=objective,
+                        solvers=[solver1, solver2],
+                        datasets=[dataset]) as benchmark:
+        with CaptureRunOutput() as out:
+            install([str(benchmark.benchmark_dir),
+                *' -s solver1 --gpu --env'.split()],
+                standalone_mode=False)
+

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -196,7 +196,8 @@ class DependenciesMixin:
                 conda_reqs = getattr(cls, "requirements", [])
                 if isinstance(conda_reqs, dict):
                     try:
-                        conda_reqs = conda_reqs["gpu"] if gpu else conda_reqs["cpu"]
+                        conda_reqs = (conda_reqs["gpu"] if gpu
+                                      else conda_reqs["cpu"])
                     except KeyError:
                         raise ValueError(
                             "If `requirements` is a dict, its keys should be "

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -159,7 +159,7 @@ class DependenciesMixin:
         return is_installed
 
     @classmethod
-    def collect(cls, env_name=None, force=False):
+    def collect(cls, env_name=None, force=False, gpu=False):
         """Collect info for global installation of all classes in an env.
 
         Parameters
@@ -194,6 +194,13 @@ class DependenciesMixin:
                 ]
             else:
                 conda_reqs = getattr(cls, "requirements", [])
+                if isinstance(conda_reqs, dict):
+                    try:
+                        conda_reqs = conda_reqs["gpu"] if gpu else conda_reqs["cpu"]
+                    except KeyError:
+                        raise ValueError(
+                            "If `requirements` is a dict, its keys should be "
+                            f"`cpu` and `gpu`, got {list(conda_reqs.keys())}")
                 if not is_installed and len(conda_reqs) == 0:
                     missing_deps = cls
             post_install_hooks = [cls._post_install_hook]

--- a/benchopt/utils/dependencies_mixin.py
+++ b/benchopt/utils/dependencies_mixin.py
@@ -200,7 +200,8 @@ class DependenciesMixin:
                     except KeyError:
                         raise ValueError(
                             "If `requirements` is a dict, its keys should be "
-                            f"`cpu` and `gpu`, got {list(conda_reqs.keys())}")
+                            f"`cpu` and `gpu`, got {list(conda_reqs.keys())}"
+                        )
                 if not is_installed and len(conda_reqs) == 0:
                     missing_deps = cls
             post_install_hooks = [cls._post_install_hook]

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,7 +20,7 @@ CLI
 ---
 
 - Add `--gpu` flag to handle different requirements for GPU and CPU.
-  By `Mathurin Massias_` (:gh:`793`)
+  By `Mathurin Massias`_ (:gh:`793`)
 
 API
 ---

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -13,21 +13,21 @@ Version 1.7 - in development
 Major change
 ------------
 
-- Benchopt is now supported on Windows!! \o/
+- Benchopt is now supported on Windows!! \\o/
   By `Wassim Mazouz`_, `Mathurin Massias`_ and `Thomas Moreau`_ (:gh:`717`)
 
 CLI
 ---
 
-- Add `--gpu` flag to handle different requirements for GPU and CPU.
-  By `Mathurin Massias`_ (:gh:`793`)
+- Add ``--gpu`` flag to ``benchopt install``, to handle different requirements
+  for GPU and CPU. By `Mathurin Massias`_ (:gh:`793`)
 
 API
 ---
 
-- Support `requirements` being a dictionary with keys `gpu` and `cpu`, for
+- Support ``requirements`` being a dictionary with keys ``"gpu"`` and ``"cpu"``, for
   classes whose install differ on GPU and CPU.
-  By `Mathurin Massias_` (:gh:`793`)
+  By `Mathurin Massias`_ (:gh:`793`)
 
 - Change channel specification in requirements, replacing the split format
   with ``::`` instead of ``:``. This allow specifying URL channels.
@@ -50,7 +50,7 @@ FIX
 - Fix the ``skip`` API for objectives that was leading to a display error.
   By `Thomas Moreau`_ (:gh:`763`)
 
-- Fix the ``info`` command By `Pierre-Antoine Comby`_ (:gh:`&67`)
+- Fix the ``info`` command. By `Pierre-Antoine Comby`_ (:gh:`768`)
 
 .. _changes_1_6:
 
@@ -60,7 +60,7 @@ Version 1.6 - 15/07/2024
 API
 ~~~
 
-- Add a `save_final_results` method to Objective. If implemented it is run
+- Add a ``save_final_results`` method to Objective. If implemented it is run
   after the last solver iteration, to get desired outputs to be saved to file
   system. By `Pierre-Antoine Comby`_ (:gh:`722`)
 
@@ -105,7 +105,7 @@ FIX
 DOC
 ~~~
 
-- Add documentation for the `run_once` sampling strategy.
+- Add documentation for the ``run_once`` sampling strategy.
   By `Mathieu Dagréou`_ (:gh:`700`).
 
 .. _changes_1_5_1:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,8 +19,15 @@ Major change
 CLI
 ---
 
+- Add `--gpu` flag to handle different requirements for GPU and CPU.
+  By `Mathurin Massias_` (:gh:`793`)
+
 API
 ---
+
+- Support `requirements` being a dictionary with keys `gpu` and `cpu`, for
+  classes whose install differ on GPU and CPU.
+  By `Mathurin Massias_` (:gh:`793`)
 
 - Change channel specification in requirements, replacing the split format
   with ``::`` instead of ``:``. This allow specifying URL channels.


### PR DESCRIPTION
Useful to have both gpu/cpu requirements, and avoid having dynamically defined `Solver.requirements`, which is blocking for #788 
