### PR TITLE
FIX slow parallel run when large parameter space

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -899,8 +899,7 @@ def _get_used_parameters(klass, params):
             default.update(update)
             if default not in used_parameters:  # avoid duplicates
                 used_parameters.append(default)
-
-    return used_parameters
+                yield default
 
 
 def buffer_iterator(it):


### PR DESCRIPTION
When the parameter space is too large but each run is very fast, we can have a bottleneck in generating the list of parameters.
This PR avoids this by not creating the list but consuming the parameters as they come.