### PR TITLE
[ENH] Add solver-specific overrides for SLURM executor configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run:
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq -c https://repo.prefix.dev/julia-forge julia[version=">=1.10.0"]
 
-      - name: Install benchopt with [test,slurm] extras on Ubuntu/OSX
+      - name: Install benchopt and its dependencies on POSIX systems
         if: matrix.os != 'windows-latest'
         run: |
           ${{ env.BENCHOPT_CONDA_CMD }} info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,11 +66,19 @@ jobs:
         run:
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq -c https://repo.prefix.dev/julia-forge julia[version=">=1.10.0"]
 
-      - name: Install benchopt and its dependencies
+      - name: Install benchopt with [test,slurm] extras on Ubuntu/OSX
+        if: matrix.os != 'windows-latest'
         run: |
           ${{ env.BENCHOPT_CONDA_CMD }} info
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq pip
-          pip install -e .[test,slurm]
+          pip install -e ".[test,slurm]"
+    
+      - name: Install benchopt with [test] extras on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          ${{ env.BENCHOPT_CONDA_CMD }} info
+          ${{ env.BENCHOPT_CONDA_CMD }} install -yq pip
+          pip install -e ".[test]"
 
       # TODO merge this with previous test if possible
       #last command : Install mamba in base environment to make it accessible test env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           ${{ env.BENCHOPT_CONDA_CMD }} info
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq pip
-          pip install -e .[test, slurm]
+          pip install -e .[test,slurm]
 
       # TODO merge this with previous test if possible
       #last command : Install mamba in base environment to make it accessible test env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           ${{ env.BENCHOPT_CONDA_CMD }} info
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq pip
-          pip install -e .[test]
+          pip install -e .[test, slurm]
 
       # TODO merge this with previous test if possible
       #last command : Install mamba in base environment to make it accessible test env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
           ${{ env.BENCHOPT_CONDA_CMD }} install -yq pip
           pip install -e ".[test,slurm]"
     
-      - name: Install benchopt with [test] extras on Windows
+      - name: Install benchopt and its dependencies on Windows
         if: matrix.os == 'windows-latest'
         run: |
           ${{ env.BENCHOPT_CONDA_CMD }} info

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -67,13 +67,13 @@ def run_on_slurm(
     with ExitStack() as stack:
         for kwargs in all_runs:
             solver = kwargs.get("solver")
-            solver_slurm_params = merge_configs(slurm_config, solver)
-            executor_config = tuple(sorted(solver_slurm_params.items()))
+            solver_slurm_config = merge_configs(slurm_config, solver)
+            executor_config = tuple(sorted(solver_slurm_config.items()))
 
             if executor_config not in executors:
                 executor = get_slurm_executor(
                     benchmark,
-                    solver_slurm_params,
+                    solver_slurm_config,
                     timeout=common_kwargs["timeout"],
                 )
                 stack.enter_context(executor.batch())

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -24,21 +24,20 @@ def get_slurm_launch():
 
 
 def get_slurm_executor(benchmark, slurm_config, timeout=100, solver=None):
-
     with open(slurm_config, "r") as f:
         config = yaml.safe_load(f)
 
     # Apply solver-specific overrides if the solver has slurm_params
-    if solver and hasattr(solver, 'slurm_params'):
+    if solver and hasattr(solver, "slurm_params"):
         config.update(solver.slurm_params)
 
     # If the job timeout is not specified in the config file, use 1.5x the
     # benchopt timeout. This value is a trade-off between helping the
     # scheduler (low slurm_time allow for faster accept) and avoiding
     # killing the job too early.
-    if 'slurm_time' not in config:
+    if "slurm_time" not in config:
         # Timeout is in second in benchopt
-        config['slurm_time'] = f"00:{int(1.5*timeout)}"
+        config["slurm_time"] = f"00:{int(1.5 * timeout)}"
 
     slurm_folder = benchmark.get_slurm_folder()
     executor = submitit.AutoExecutor(slurm_folder)
@@ -47,13 +46,8 @@ def get_slurm_executor(benchmark, slurm_config, timeout=100, solver=None):
 
 
 def run_on_slurm(
-    benchmark,
-    slurm_config,
-    run_one_solver,
-    common_kwargs,
-    all_runs
+    benchmark, slurm_config, run_one_solver, common_kwargs, all_runs
 ):
-
     if not _SLURM_INSTALLED:
         raise ImportError(
             "Benchopt needs submitit and rich to launch computation on a "

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -40,8 +40,6 @@ def get_slurm_executor(benchmark, config, timeout=100):
 
 def merge_configs(slurm_config, solver):
     """Merge the slurm config with solver-specific slurm params."""
-    with open(slurm_config, "r") as f:
-        slurm_config = yaml.safe_load(f)
     solver_slurm_params = {
         **slurm_config,
         **getattr(solver, "slurm_params", {}),
@@ -61,6 +59,10 @@ def run_on_slurm(
 
     executors = {}
     tasks = []
+
+    # Load the slurm config from a file if provided
+    with open(slurm_config, "r") as f:
+        slurm_config = yaml.safe_load(f)
 
     with ExitStack() as stack:
         for kwargs in all_runs:

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -67,14 +67,24 @@ def run_on_slurm(
     with ExitStack() as stack:
         for kwargs in all_runs:
             solver = kwargs.get("solver")
-            override = tuple(sorted(getattr(solver, "slurm_params", {}).items())) if solver and hasattr(solver, "slurm_params") else ()
+            override = (
+                tuple(sorted(getattr(solver, "slurm_params", {}).items()))
+                if solver and hasattr(solver, "slurm_params")
+                else ()
+            )
 
             if override not in executors:
-                executor = get_slurm_executor(benchmark, slurm_config, common_kwargs["timeout"], solver)
+                executor = get_slurm_executor(
+                    benchmark, slurm_config, common_kwargs["timeout"], solver
+                )
                 stack.enter_context(executor.batch())
                 executors[override] = executor
 
-            future = executors[override].submit(run_one_solver, **common_kwargs, **kwargs)
+            future = executors[override].submit(
+                run_one_solver,
+                **common_kwargs,
+                **kwargs,
+            )
             tasks.append(future)
 
     print(f"First job id: {tasks[0].job_id}")

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -41,6 +41,14 @@ def get_slurm_executor(benchmark, slurm_config, timeout=100):
     return executor
 
 
+def merge_configs(slurm_config, solver):
+    solver_slurm_params = {
+        **slurm_config,
+        **getattr(solver, "slurm_params", {}),
+    }
+    return tuple(sorted(solver_slurm_params.items()))
+
+
 def run_on_slurm(
     benchmark, slurm_config, run_one_solver, common_kwargs, all_runs
 ):
@@ -61,7 +69,7 @@ def run_on_slurm(
                 **slurm_config,
                 **getattr(solver, "slurm_params", {}),
             }
-            executor_config = tuple(sorted(solver_slurm_params.items()))
+            executor_config = merge_configs(slurm_config, solver)
 
             if executor_config not in executors:
                 executor = get_slurm_executor(

--- a/benchopt/utils/temp_benchmark.py
+++ b/benchopt/utils/temp_benchmark.py
@@ -1,4 +1,5 @@
 import os
+import yaml
 import inspect
 import tempfile
 import contextlib
@@ -42,9 +43,10 @@ def temp_benchmark(
     solvers: str | list of str | None (default=None)
         Content of the solver.py file(s). If None, defaults to solvers of
         ``benchopt.tests.DUMMY_BENCHMARK``.
-    config: str | None (default=None)
-        Content of configuration file for running the Benchmark. If None,
-        no config file is created.
+    config: str | dict(fname->str) | None (default=None)
+        Configuration files for running the Benchmark. If only one str is
+        passed, this creates only one `config.yml` file. If None, no config
+        file is created.
     benchmark_utils: dict(fname->str) | None (default=None)
     """
     if objective is None:
@@ -76,8 +78,15 @@ def temp_benchmark(
                 f.write(inspect.cleandoc(dataset))
 
         if config is not None:
-            with open(temp_path / "config.yml", "w", encoding='utf-8') as f:
-                f.write(config)
+            if not isinstance(config, dict):
+                config = {"config.yml": config}
+            for fname, content in config.items():
+                if isinstance(content, dict):
+                    # If content is a dict, write it as YAML
+                    content = yaml.dump(content)
+                config_path = (temp_path / fname).with_suffix(".yml")
+                with open(config_path, "w", encoding='utf-8') as f:
+                    f.write(content)
 
         if benchmark_utils is not None:
             benchmark_utils_dir = (temp_path / "benchmark_utils")

--- a/benchopt/utils/tests/test_slurm_executor.py
+++ b/benchopt/utils/tests/test_slurm_executor.py
@@ -1,0 +1,72 @@
+import pytest
+import yaml
+from benchopt.tests import DUMMY_BENCHMARK
+from benchopt.utils.slurm_executor import (
+    get_slurm_executor,
+    run_on_slurm,
+)
+from submitit.slurm.test_slurm import mocked_slurm
+
+
+@pytest.fixture
+def dummy_slurm_config(tmp_path):
+    config = {
+        "slurm_time": "00:10",
+        "slurm_partition": "test_partition",
+        "slurm_nodes": 1,
+    }
+    config_path = tmp_path / "slurm.yaml"
+    config_path.write_text(yaml.dump(config))
+    return config_path
+
+
+@pytest.fixture
+def dummy_solver():
+    class DummySolver:
+        slurm_params = {
+            "slurm_time": "00:01",
+            "slurm_nodes": 2,
+            "slurm_mem": "1234MB",
+        }
+
+    return DummySolver()
+
+
+def test_get_slurm_executor(dummy_slurm_config, dummy_solver):
+    # Test witthout solver overrides
+    with mocked_slurm():
+        executor = get_slurm_executor(
+            DUMMY_BENCHMARK, dummy_slurm_config, solver=None
+        )
+    assert executor._executor.parameters["time"] == "00:10"
+    assert executor._executor.parameters["partition"] == "test_partition"
+    assert executor._executor.parameters["nodes"] == 1
+
+    # Test with solver overrides
+    with mocked_slurm():
+        executor_override = get_slurm_executor(
+            DUMMY_BENCHMARK, dummy_slurm_config, solver=dummy_solver
+        )
+    assert executor_override._executor.parameters["time"] == "00:01"
+    assert (
+        executor_override._executor.parameters["partition"] == "test_partition"
+    )
+    assert executor_override._executor.parameters["nodes"] == 2
+    assert executor_override._executor.parameters["mem"] == "1234MB"
+
+
+def test_run_on_slurm(dummy_slurm_config, dummy_solver):
+    def dummy_solver_runner(*args, **kwargs):
+        return "done"
+
+    # Run the function
+    res = run_on_slurm(
+        benchmark=DUMMY_BENCHMARK,
+        slurm_config=dummy_slurm_config,
+        run_one_solver=dummy_solver_runner,
+        common_kwargs={"timeout": None},
+        all_runs=[{"solver": dummy_solver}],
+    )
+
+    assert len(res) == 1
+    assert res[0] == "done"

--- a/benchopt/utils/tests/test_slurm_executor.py
+++ b/benchopt/utils/tests/test_slurm_executor.py
@@ -5,7 +5,9 @@ from benchopt.utils.slurm_executor import (
     get_slurm_executor,
     run_on_slurm,
 )
-from submitit.slurm.test_slurm import mocked_slurm
+
+submitit = pytest.importorskip("submitit")
+from submitit.slurm.test_slurm import mocked_slurm  # noqa: E402
 
 
 @pytest.fixture

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -61,10 +61,10 @@ As we rely on ``joblib.Memory`` for caching the results, the cache should work
 exactly as if you were running the computation sequentially, as long as you have
 a shared file-system between the nodes used for the computations.
 
-Overriding the SLURM parameters
--------------------------------
-
 .. _slurm_override:
+
+Overriding the SLURM parameters for one solver
+----------------------------------------------
 
 You can also override the SLURM parameters for a specific solver by
 defining a ``slurm_params`` attribute in the solver class. This allows to
@@ -98,7 +98,8 @@ The parameters defined in the ``slurm_params`` should be compatible with
 the `submitit` library, as they are passed to the `submitit.AutoExecutor`
 class. For more information on the available parameters, please refer to
 the `submitit documentation <https://github.com/facebookincubator/submitit>`_.
-
+Note that in this case, the jobs with different SLURM parameters will be  
+launched as one job array per configuration.  
 
 .. _skipping_solver:
 

--- a/doc/user_guide/advanced.rst
+++ b/doc/user_guide/advanced.rst
@@ -61,6 +61,45 @@ As we rely on ``joblib.Memory`` for caching the results, the cache should work
 exactly as if you were running the computation sequentially, as long as you have
 a shared file-system between the nodes used for the computations.
 
+Overriding the SLURM parameters
+-------------------------------
+
+.. _slurm_override:
+
+You can also override the SLURM parameters for a specific solver by
+defining a ``slurm_params`` attribute in the solver class. This allows to
+specify a different SLURM partition, resources, or other parameters that
+are specific to that solver. The parameters defined in the solver class
+will override the global SLURM config defined in the config file:
+
+.. code-block:: python
+
+    class Solver(BaseSolver):
+        """GPU-based solver that needs GPU partition and specific resources."""
+        name = 'GPU-Solver'
+        
+        parameters = {...}
+        
+        # Override global SLURM config for this solver
+        slurm_params = {
+            'slurm_partition': 'gpu',
+            'slurm_gres': 'gpu:1',
+            'slurm_time': '02:00:00',
+            'slurm_cpus_per_task': 8,
+            'slurm_mem': '16GB',
+        }
+        
+        requirements = ['torch']
+        
+        def set_objective(self, X, y):
+            ...
+
+The parameters defined in the ``slurm_params`` should be compatible with
+the `submitit` library, as they are passed to the `submitit.AutoExecutor`
+class. For more information on the available parameters, please refer to
+the `submitit documentation <https://github.com/facebookincubator/submitit>`_.
+
+
 .. _skipping_solver:
 
 Skipping a solver for a given problem

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -31,6 +31,9 @@ CLI
 API
 ---
 
+- Add ``slurm_params`` attribute to ``Solver`` to allow overriding the
+  default SLURM config. By `Pierre-Louis Barbarant`_ (:gh:`805`)
+
 - Support ``requirements`` being a dictionary with keys ``"gpu"`` and ``"cpu"``, for
   classes whose install differ on GPU and CPU.
   By `Mathurin Massias`_ (:gh:`793`)


### PR DESCRIPTION
This PR enables solver-specific overriding of the global `--slurm` config by adding a new `slurm_params` keyword. The syntax is as follows:
```python
class Solver(BaseSolver):
    """GPU-based solver that needs GPU partition and specific resources."""
    name = 'GPU-Solver'
    
    parameters = {...}
    
    # Override global SLURM config for this solver
    slurm_params = {
        'slurm_partition': 'gpu',
        'slurm_gres': 'gpu:1',
        'slurm_time': '02:00:00',
        'slurm_cpus_per_task': 8,
        'slurm_mem': '16GB',
    }
    
    requirements = ['torch']
    
    def set_objective(self, X, y):
        ...
```
TODO:
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)