### PR TITLE
FIX move `run_statistics.extend` inside `try` block (WIP)

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -15,6 +15,15 @@ from .utils.terminal_output import TerminalOutput
 
 
 FAILURE_STATUS = ['diverged', 'error', 'interrupted']
+SUCCESS_STATUS = ['done', 'max_runs', 'timeout']
+
+
+class FailedRun(RuntimeError):
+    """Exception raised when a solver run fails."""
+    def __init__(self, status):
+        super().__init__()
+        self.status = status
+
 
 ##################################
 # Time one run of a solver
@@ -97,10 +106,6 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
     status : 'done' | 'diverged' | 'timeout' | 'max_runs'
         The status on which the solver was stopped.
     """
-
-    # The warm-up step called for each repetition bit only run once.
-    solver._warm_up()
-
     curve = []
 
     # Augment the metadata with final_results if necessary.
@@ -117,6 +122,8 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
         meta["final_results"] = str(final_results)
 
     with exception_handler(terminal, pdb=pdb) as ctx:
+        # The warm-up step called for each repetition bit only run once.
+        solver._warm_up()
 
         if solver._solver_strategy == "callback":
 
@@ -160,7 +167,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
                 with open(meta["final_results"], 'wb') as f:
                     pickle.dump(to_save, f)
     if ctx.status in FAILURE_STATUS:
-        raise RuntimeError(ctx.status)
+        raise FailedRun(ctx.status)
     return curve, ctx.status
 
 
@@ -281,13 +288,14 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
                 **args_run_one_to_cvg
             )
             run_statistics.extend(curve)
-        except RuntimeError as e:
-            status = e.args[0]
-        if status in ['diverged', 'error', 'interrupted', 'not run yet']:
+        except FailedRun as e:
+            status = e.status
+
+        # Handle the status for which we do not want to try other repetitions
+        if status not in SUCCESS_STATUS:
             run_statistics = []
             break
         states.append(status)
-        run_statistics.extend(curve)
 
     else:
         if 'max_runs' in states:

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -277,12 +277,12 @@ def run_one_solver(benchmark, dataset, objective, solver, n_repetitions,
             curve, status = run_one_to_cvg_cached(
                 **args_run_one_to_cvg
             )
+            run_statistics.extend(curve)
         except RuntimeError as e:
             status = e.args[0]
         if status in ['diverged', 'error', 'interrupted', 'not run yet']:
             run_statistics = []
             break
-        run_statistics.extend(curve)
         states.append(status)
 
     else:

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -43,3 +43,5 @@
 .. _Rémi Flamary: https://remi.flamary.com/
 
 .. _Lionel Kusch: https://www.linkedin.com/in/lionel-kusch-0439b310a/
+
+.. _Johan Larsson: https://jolars.co

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -73,6 +73,9 @@ FIX
 - Fix ``get_data_path`` not working with parallel runs.
   By `Thomas Moreau`_ (:gh:`815`)
 
+- Fix ``UnboundedLocalError`` when RuntimeError on ``warm_up``.
+  By `Johan Larsson`_ (:gh:`809`)
+
 .. _changes_1_6:
 
 Version 1.6 - 15/07/2024


### PR DESCRIPTION
`curve` may otherwise be unbound. Closes #808.

This fix is untested and it seems reasonable to me, but I'm not sure it's sufficient. The only way we end up in `run_statistics.extend(curve)` and do not have correct `curve` is when there is a runtime error that's not caught and at the time there's no proper curve object.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
