### PR TITLE
FIX slurm_config can contain dict

### DIFF
--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -47,6 +47,16 @@ def merge_configs(slurm_config, solver):
     return solver_slurm_params
 
 
+def hashable_pytree(pytree):
+    """Flatten a pytree into a list."""
+    if isinstance(pytree, (list, tuple)):
+        return tuple(hashable_pytree(item) for item in sorted(pytree))
+    elif isinstance(pytree, dict):
+        return tuple((k, hashable_pytree(v)) for k, v in sorted(pytree.items()))
+    else:
+        return pytree
+
+
 def run_on_slurm(
     benchmark, slurm_config, run_one_solver, common_kwargs, all_runs
 ):
@@ -68,7 +78,7 @@ def run_on_slurm(
         for kwargs in all_runs:
             solver = kwargs.get("solver")
             solver_slurm_config = merge_configs(slurm_config, solver)
-            executor_config = tuple(sorted(solver_slurm_config.items()))
+            executor_config = hashable_pytree(solver_slurm_config)
 
             if executor_config not in executors:
                 executor = get_slurm_executor(

--- a/benchopt/utils/slurm_executor.py
+++ b/benchopt/utils/slurm_executor.py
@@ -52,7 +52,9 @@ def hashable_pytree(pytree):
     if isinstance(pytree, (list, tuple)):
         return tuple(hashable_pytree(item) for item in sorted(pytree))
     elif isinstance(pytree, dict):
-        return tuple((k, hashable_pytree(v)) for k, v in sorted(pytree.items()))
+        return tuple(
+            (k, hashable_pytree(v)) for k, v in sorted(pytree.items())
+        )
     else:
         return pytree
 

--- a/benchopt/utils/tests/test_slurm_executor.py
+++ b/benchopt/utils/tests/test_slurm_executor.py
@@ -16,6 +16,10 @@ def dummy_slurm_config():
         "slurm_time": "00:10",
         "slurm_partition": "test_partition",
         "slurm_nodes": 1,
+        "slurm_additional_parameters": {
+            "slurm_mem": "1000MB",
+            "slurm_gres": "gpu:1",
+        },
     }
 
 


### PR DESCRIPTION
In #805 , we did not consider the case where `slurm_config` contains some complex arguments, like `slurm_additional_parameters` which is usually a dict.
This PR tests this case and fix the behavior to make the argument hashable.

Previous behavior resulted in the following error:

```    
                executor_config = tuple(sorted(solver_slurm_config.items()))
    
>               if executor_config not in executors:
E               TypeError: unhashable type: 'dict'

benchopt/utils/slurm_executor.py:84: TypeError
```

