### PR TITLE
CLN rename output->terminal in runner

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -563,7 +563,7 @@ class Benchmark:
             )
 
     def get_all_runs(self, solvers=None, forced_solvers=None,
-                     datasets=None, objectives=None, output=None):
+                     datasets=None, objectives=None, terminal=None):
         """Generator with all combinations to run for the benchmark.
 
         Parameters
@@ -580,8 +580,8 @@ class Benchmark:
         objectives : list | None
             Filters to select specific objective parameters. If None,
             all objective parameters are tested
-        output : TerminalOutput or None
-            Object to manage the output in the terminal.
+        terminal : TerminalOutput or None
+            Object to format string to display the terminal.
 
         Yields
         ------
@@ -595,25 +595,25 @@ class Benchmark:
             _list_parametrized_classes(*solvers)
         )
         for dataset, is_installed in all_datasets:
-            output.set(dataset=dataset)
+            terminal.set(dataset=dataset)
             if not is_installed:
-                output.show_status('not installed', dataset=True)
+                terminal.show_status('not installed', dataset=True)
                 continue
-            output.display_dataset()
+            terminal.display_dataset()
             all_objectives = _list_parametrized_classes(
                 *objectives, check_installed=False
             )
             for objective, is_installed in all_objectives:
-                output.set(objective=objective)
+                terminal.set(objective=objective)
                 if not is_installed:
-                    output.show_status('not installed', objective=True)
+                    terminal.show_status('not installed', objective=True)
                     continue
-                output.display_objective()
+                terminal.display_objective()
                 for i_solver, (solver, is_installed) in enumerate(all_solvers):
-                    output.set(solver=solver, i_solver=i_solver)
+                    terminal.set(solver=solver, i_solver=i_solver)
 
                     if not is_installed:
-                        output.show_status('not installed')
+                        terminal.show_status('not installed')
                         continue
 
                     force = is_matched(
@@ -621,7 +621,7 @@ class Benchmark:
                     )
                     yield dict(
                         dataset=dataset, objective=objective, solver=solver,
-                        force=force, output=output.clone()
+                        force=force, terminal=terminal.clone()
                     )
                 all_solvers = solvers_buffer
 

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -77,7 +77,7 @@ class StoppingCriterion():
             else f'objective_{key_to_monitor}'
         )
 
-    def get_runner_instance(self, max_runs=1, timeout=None, output=None,
+    def get_runner_instance(self, max_runs=1, timeout=None, terminal=None,
                             solver=None):
         """Copy the stopping criterion and set the parameters that depends on
         how benchopt runner is called.
@@ -89,7 +89,7 @@ class StoppingCriterion():
             the convergence curve.
         timeout : float
             The maximum duration in seconds of the solver run.
-        output : TerminalOutput or None
+        terminal : TerminalOutput or None
             Object to format string to display the progress of the solver.
         solver : BaseSolver
             The solver for which this stopping criterion is called. Used to get
@@ -130,7 +130,7 @@ class StoppingCriterion():
         stopping_criterion.rho = RHO
         stopping_criterion.timeout = timeout
         stopping_criterion.max_runs = max_runs
-        stopping_criterion.output = output
+        stopping_criterion.terminal = terminal
         stopping_criterion.solver = solver
 
         # Override get_next_stop_val if ``get_next`` is implemented for solver.
@@ -285,13 +285,13 @@ class StoppingCriterion():
 
     def debug(self, msg):
         """Helper to print debug messages."""
-        if self.output is not None:
-            self.output.debug(msg)
+        if self.terminal is not None:
+            self.terminal.debug(msg)
 
     def progress(self, progress):
         """Helper to print progress messages."""
-        if self.output is not None:
-            self.output.progress(progress)
+        if self.terminal is not None:
+            self.terminal.progress(progress)
 
     @staticmethod
     def _reconstruct(klass, kwargs, runner_kwargs):
@@ -304,7 +304,7 @@ class StoppingCriterion():
         )
         runner_kwargs = dict(
             max_runs=self.max_runs, timeout=self.timeout,
-            output=self.output, solver=self.solver
+            terminal=self.terminal, solver=self.solver
         )
         return self._reconstruct, (self.__class__, kwargs, runner_kwargs)
 
@@ -479,10 +479,10 @@ class SingleRunCriterion(StoppingCriterion):
     def init_stop_val(self):
         return self.stop_val
 
-    def get_runner_instance(self, max_runs=1, timeout=None, output=None,
+    def get_runner_instance(self, max_runs=1, timeout=None, terminal=None,
                             solver=None):
 
-        return super().get_runner_instance(1, timeout, output, solver)
+        return super().get_runner_instance(1, timeout, terminal, solver)
 
     def should_stop(self, stop_val, objective_list):
         return True, 'done', stop_val

--- a/benchopt/utils/pdb_helpers.py
+++ b/benchopt/utils/pdb_helpers.py
@@ -13,12 +13,12 @@ class StatusHandler(object):
 
 
 @contextmanager
-def exception_handler(output, pdb=False):
+def exception_handler(terminal, pdb=False):
     """Context manager to handle exception with option to open a debugger.
 
     Parameter
     ---------
-    output : TerminalOutput
+    terminal : TerminalOutput
         Object to format string to display the progress of the solver.
     pdb : bool
         If set to True, open a debugger if an error is raised.
@@ -28,13 +28,13 @@ def exception_handler(output, pdb=False):
         yield ctx
     except KeyboardInterrupt:
         ctx.status = 'interrupted'
-        output.show_status('interrupted')
+        terminal.show_status('interrupted')
         raise SystemExit(1)
     except BaseException:
         ctx.status = 'error'
 
         if pdb:
-            output.show_status('error')
+            terminal.show_status('error')
             traceback.print_exc()
             # Use ipdb if it is available and default to pdb otherwise.
             try:
@@ -44,7 +44,7 @@ def exception_handler(output, pdb=False):
             post_mortem()
 
         if DEBUG:
-            output.show_status('error')
+            terminal.show_status('error')
             raise
         else:
             print()


### PR DESCRIPTION
`output` is confusing in the code as it is not clear if it is the result file or the terminal.
Use a clearer naming.