### PR TITLE
CI fix broken install of conda due to existing directory in cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
             wget -q https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh -O ~/miniconda.sh;
             chmod +x ~/miniconda.sh;
-            ~/miniconda.sh -b -p ~/miniconda;
+            ~/miniconda.sh -u -b -p ~/miniconda;
             echo "export PATH=~/miniconda/bin:$PATH" >> $BASH_ENV;
 
       - run:


### PR DESCRIPTION
In PR #787, I get the following error of the installation of miniconda (circle ci step: Get conda running)
```
ERROR: File or directory already exists: '/home/circleci/miniconda'
If you want to update an existing installation, use the -u option.

Exited with code exit status 1
```

The error is due to that the cache is based on a previous version of conda.

### Checks before merging PR
- [ ] added documentation for any new feature
- [ ] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)

