### PR TITLE
FIX: split sys info for numpy in parquet file

### DIFF
--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -116,7 +116,7 @@ def get_sys_info():
 
     # Info on dependency libs
     info["version-cuda"] = get_cuda_version()
-    info["version-numpy"] = np.__version__,
+    info["version-numpy"] = np.__version__
     info["version-numpy-libs"] = _get_numpy_libs()
     info["version-scipy"] = scipy.__version__
 

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -116,7 +116,8 @@ def get_sys_info():
 
     # Info on dependency libs
     info["version-cuda"] = get_cuda_version()
-    info["version-numpy"] = (np.__version__, _get_numpy_libs())
+    info["version-numpy"] = np.__version__, 
+    info["version-numpy-libs"] = _get_numpy_libs()
     info["version-scipy"] = scipy.__version__
 
     # Info on benchmark version

--- a/benchopt/utils/sys_info.py
+++ b/benchopt/utils/sys_info.py
@@ -116,7 +116,7 @@ def get_sys_info():
 
     # Info on dependency libs
     info["version-cuda"] = get_cuda_version()
-    info["version-numpy"] = np.__version__, 
+    info["version-numpy"] = np.__version__,
     info["version-numpy-libs"] = _get_numpy_libs()
     info["version-scipy"] = scipy.__version__
 


### PR DESCRIPTION
See #734