### PR TITLE
ENH custom plotting

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -283,6 +283,10 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, ABC):
         """
         ...
 
+    @staticmethod
+    def plot_data(df):
+        return {}
+
     def _get_data(self):
         "Wrapper to make sure the returned results are correctly formated."
 

--- a/benchopt/constants.py
+++ b/benchopt/constants.py
@@ -4,5 +4,5 @@ PLOT_KINDS = {
     'relative_suboptimality_curve': 'plot_relative_suboptimality_curve',
     'bar_chart': 'plot_bar_chart',
     'boxplot': 'plot_boxplot',
-    'custom': 'none'  # TODO handle custom plots
+    'custom': 'plot_custom'
 }

--- a/benchopt/constants.py
+++ b/benchopt/constants.py
@@ -3,5 +3,6 @@ PLOT_KINDS = {
     'suboptimality_curve': 'plot_suboptimality_curve',
     'relative_suboptimality_curve': 'plot_relative_suboptimality_curve',
     'bar_chart': 'plot_bar_chart',
-    'boxplot': 'plot_boxplot'
+    'boxplot': 'plot_boxplot',
+    'custom': 'none'  # TODO handle custom plots
 }

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -243,7 +243,7 @@ def shape_solvers_for_html(df, objective_column, custom_plot_func):
         # compute median of 'time' and objective_column
         fields = ["time", objective_column]
         groupby_stop_val_median_unfiltered = (
-            df_filtered.groupby('stop_val')[fields]
+            df_filtered.groupby('stop_val')
             .median(numeric_only=True)
         )
         groupby_stop_val_median = groupby_stop_val_median_unfiltered[fields]

--- a/benchopt/plotting/plot_custom.py
+++ b/benchopt/plotting/plot_custom.py
@@ -1,0 +1,31 @@
+import matplotlib.pyplot as plt
+
+
+def plot_custom(df, plot_func):
+    """Plot objective curve for a given benchmark and dataset.
+
+    Plot the objective value F(x) as a function of the time.
+
+    Parameters
+    ----------
+    df : instance of pandas.DataFrame
+        The benchmark results.
+    obj_col : str
+        Column to select in the DataFrame for the plot.
+    suboptimality : bool
+        If set to True, remove the optimal objective value F(x^*). Here the
+        value of F(x^*) is taken as the smallest value reached across all
+        solvers.
+    relative : bool
+        If set to True, scale the objective value by 1 / F_0 where F_0 is
+        computed as the largest objective value accross all initialization.
+
+    Returns
+    -------
+    fig : matplotlib.Figure
+        The rendered figure.
+    """
+
+    fig = plt.figure()
+
+    return fig

--- a/examples/minimal_benchmark/datasets/simulated.py
+++ b/examples/minimal_benchmark/datasets/simulated.py
@@ -18,3 +18,13 @@ class Dataset(BaseDataset):
         The dictionary's keys are the kwargs passed to ``Objective.set_data``.
         """
         return dict(X=np.random.randn(10, 2))
+
+    def plot_data(df):
+        return {
+            'name': 'custom test',
+            'type': 'scatter',
+            'y_axis': 'Custom objective',
+            'y': df['objective_value'].tolist(),
+            'x_axis': 'custom time',
+            'x': df['time'].tolist(),
+        }


### PR DESCRIPTION
This PR adds custom plotting for datasets. You can now override ```plot_data``` in the base Dataset class to create custom plots. This function takes as input the groupedby dataframe and returns a plot specification, for instance:

```python
def plot_data(df):
        return {
            'name': 'custom test',
            'type': 'scatter',
            'y_axis': 'Custom objective',
            'y': df['objective_value'].tolist(),
            'x_axis': 'custom time',
            'x': df['time'].tolist(),
        }
```

Currently, only scatter plots are supported, but extending this to other types (e.g., box plots, tables) should be straightforward.

At the moment, only a single custom plot can be defined. Supporting multiple plots would likely require significant changes to the existing codebase, so I'm not sure if this would be a good idea.

This is still an early-stage feature, but I’d appreciate your feedback.


### Checks before merging PR
- [ ] added documentation for any new feature
- [ ] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
