### PR TITLE
FIX benchopt test no pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,28 @@ jobs:
       - name: Install benchopt and its dependencies
         run: pip install -e .
 
-      - name: Run benchopt without conda
+      - name: Run benchopt run without conda
         run: benchopt run examples/minimal_benchmark -r 1 -n 10 --no-plot
+
+  test_no_pytest:
+    name: Test benchopt test without pytest installed
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: 'testcondaenv'
+          python-version: 3.12
+          # Use miniforge to only get conda-forge as default channel.
+          miniforge-version: latest
+
+      - name: Install benchopt and its dependencies
+        run: pip install -e .
+
+      - name: Run benchopt test without pytest
+        run: benchopt test examples/minimal_benchmark --env-name test_benchopt --skip-install
 
   test_benchopt_reqs:
     name: Test benchopt requirements detection

--- a/benchopt/cli/tests/test_cmd_test.py
+++ b/benchopt/cli/tests/test_cmd_test.py
@@ -7,6 +7,7 @@ from benchopt.utils.temp_benchmark import temp_benchmark
 
 
 from benchopt.tests.utils import CaptureCmdOutput
+from benchopt.utils.shell_cmd import _run_shell_in_conda_env
 
 from benchopt.cli.main import test as benchopt_test
 
@@ -40,13 +41,15 @@ class TestCmdTest:
         out.check_output("PASSED", repetition=8)
         out.check_output("SKIPPED", repetition=1)
 
-    def test_valid_call_in_env_no_pytest(self, test_env_name):
-        with temp_benchmark() as bench, CaptureCmdOutput():
+    def test_valid_call_in_env_no_pytest(self, test_env_name, no_pytest):
+        with temp_benchmark() as bench:
             msg = f"pytest is not installed in conda env {test_env_name}"
             with pytest.raises(ModuleNotFoundError, match=msg):
+                assert 1 == _run_shell_in_conda_env(
+                    "which pytest", env_name=test_env_name
+                )
                 benchopt_test(
-                   f"{bench.benchmark_dir} --skip-install "
-                   f"--env-name {test_env_name}".split(),
+                   f"{bench.benchmark_dir} --env-name {test_env_name}".split(),
                    'benchopt', standalone_mode=False
                 )
 

--- a/benchopt/cli/tests/test_cmd_test.py
+++ b/benchopt/cli/tests/test_cmd_test.py
@@ -40,6 +40,16 @@ class TestCmdTest:
         out.check_output("PASSED", repetition=8)
         out.check_output("SKIPPED", repetition=1)
 
+    def test_valid_call_in_env_no_pytest(self, test_env_name):
+        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+            msg = f"pytest is not installed in conda env {test_env_name}"
+            with pytest.raises(ModuleNotFoundError, match=msg):
+                benchopt_test(
+                   f"{bench.benchmark_dir} --skip-install "
+                   f"--env-name {test_env_name}".split(),
+                   'benchopt', standalone_mode=False
+                )
+
     def test_skip_test(self):
         test_config = """import pytest
 

--- a/benchopt/cli/tests/test_cmd_test.py
+++ b/benchopt/cli/tests/test_cmd_test.py
@@ -41,7 +41,7 @@ class TestCmdTest:
         out.check_output("SKIPPED", repetition=1)
 
     def test_valid_call_in_env_no_pytest(self, test_env_name):
-        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+        with temp_benchmark() as bench, CaptureCmdOutput():
             msg = f"pytest is not installed in conda env {test_env_name}"
             with pytest.raises(ModuleNotFoundError, match=msg):
                 benchopt_test(

--- a/benchopt/tests/__init__.py
+++ b/benchopt/tests/__init__.py
@@ -1,5 +1,0 @@
-from joblib.externals.cloudpickle import register_pickle_by_value
-
-# Make sure the test cases in test_runner are pickleable as dynamic classes
-from benchopt.tests import test_runner  # noqa: E402
-register_pickle_by_value(test_runner)

--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -165,15 +165,15 @@ def no_pytest(test_env_name):
     cmd = "which pytest\npip uninstall -qqy pytest"
 
     exitcode = _run_shell_in_conda_env(cmd, env_name=test_env_name)
-    print(f"Exit code: {exitcode}")
     yield
     # If pytest was not installed before, exit code is 1 so do not reinstall
     # otherwise, reinstall it
     if exitcode == 0:
-        _run_shell_in_conda_env(
-            "pip install -qqy pytest", env_name=test_env_name,
-            capture_output=False
+        exitcode, output = _run_shell_in_conda_env(
+            "pip install -q pytest", env_name=test_env_name,
+            return_output=True
         )
+        assert exitcode == 0, output
 
 
 @pytest.fixture(scope='session')

--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -165,6 +165,7 @@ def no_pytest(test_env_name):
     cmd = "which pytest\npip uninstall -qqy pytest"
 
     exitcode = _run_shell_in_conda_env(cmd, env_name=test_env_name)
+    print(f"Exit code: {exitcode}")
     yield
     # If pytest was not installed before, exit code is 1 so do not reinstall
     # otherwise, reinstall it

--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -160,6 +160,20 @@ def uninstall_dummy_package(test_env_name):
     )
 
 
+@pytest.fixture(scope='function')
+def no_pytest(test_env_name):
+    cmd = "which pytest\npip uninstall -qqy pytest"
+
+    exitcode = _run_shell_in_conda_env(cmd, env_name=test_env_name)
+    yield
+    # If pytest was not installed before, exit code is 1 so do not reinstall
+    # otherwise, reinstall it
+    if exitcode == 0:
+        _run_shell_in_conda_env(
+            "pip install -qqy pytest", env_name=test_env_name
+        )
+
+
 @pytest.fixture(scope='session')
 def empty_env_name(request):
     global _EMPTY_ENV_NAME

--- a/benchopt/tests/fixtures.py
+++ b/benchopt/tests/fixtures.py
@@ -171,7 +171,8 @@ def no_pytest(test_env_name):
     # otherwise, reinstall it
     if exitcode == 0:
         _run_shell_in_conda_env(
-            "pip install -qqy pytest", env_name=test_env_name
+            "pip install -qqy pytest", env_name=test_env_name,
+            capture_output=False
         )
 
 

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -95,7 +95,7 @@ def create_conda_env(
         print("done")
         return
 
-    force = "--force" if recreate else ""
+    force = " --force" if recreate else ""
 
     benchopt_requirement, benchopt_editable = get_benchopt_requirement(pytest)
 
@@ -119,7 +119,7 @@ def create_conda_env(
         if not quiet:
             print()
         _run_shell(
-            f"{CONDA_CMD} env create {force} -n {env_name} -f {env_yaml.name}",
+            f"{CONDA_CMD} env create -yn{force} {env_name} -f {env_yaml.name}",
             capture_stdout=quiet, raise_on_error=True
         )
         # the channels priorities cannot be set through the yaml file,
@@ -174,7 +174,7 @@ def get_benchopt_version_in_env(env_name):
 def delete_conda_env(env_name):
     """Delete a conda env with name env_name."""
 
-    _run_shell(f"{CONDA_CMD} env remove -n {env_name}",
+    _run_shell(f"{CONDA_CMD} env remove -yn {env_name}",
                capture_stdout=True)
 
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -32,6 +32,9 @@ API
 FIX
 ---
 
+- Fix running ``benchopt test`` when ``pytest`` is not installed
+  in the conda env. By `Thomas Moreau`_ (:gh:`838`)
+
 - Fix ``--download`` option in ``benchopt install`` when using multiple datasets.
   By `Thomas Moreau`_ (:gh:`821`)
 


### PR DESCRIPTION
A regression introduce in #673 make running `benchopt test` in an environment without `pytest` fails.
This PR fixes this and adds some non-regression test

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
