### PR TITLE
MNT use base image for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: cimg/python:3.12-browsers
+      - image: cimg/base:current
     steps:
       - checkout
       - restore_cache:
@@ -31,8 +31,6 @@ jobs:
             # Make sure the environment is used in subsequent steps
             echo "source ~/miniconda/etc/profile.d/conda.sh" >> $BASH_ENV
             echo "conda activate benchopt-docs" >> $BASH_ENV
-            # rpy2 loads libR.so + libicui18n.so.78 from the conda env, not system ones
-            echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
 
       - save_cache:
           key: pkgs-cache
@@ -78,7 +76,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.12-browsers
+      - image: cimg/base:current
     steps:
       - attach_workspace:
           at: /tmp/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,8 @@ jobs:
             # Make sure the environment is used in subsequent steps
             echo "source ~/miniconda/etc/profile.d/conda.sh" >> $BASH_ENV
             echo "conda activate benchopt-docs" >> $BASH_ENV
+            # rpy2 loads libR.so + libicui18n.so.78 from the conda env, not system ones
+            echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $BASH_ENV
 
       - save_cache:
           key: pkgs-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build_docs:
     docker:
-      - image: cimg/python:3.10-browsers
+      - image: cimg/python:3.12-browsers
     steps:
       - checkout
       - restore_cache:
@@ -76,7 +76,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.10-browsers
+      - image: cimg/python:3.12-browsers
     steps:
       - attach_workspace:
           at: /tmp/build


### PR DESCRIPTION
Not sure why we were using a python 3.10 image, since we install python with mamba afterwards.