### PR TITLE
FIX caching save final results

### DIFF
--- a/benchopt/callback.py
+++ b/benchopt/callback.py
@@ -52,6 +52,7 @@ class _Callback:
         self.solver = solver
         self.meta = meta
         self.stopping_criterion = stopping_criterion
+        self._last_result = None
 
         # Initialize local variables
         self.info = get_sys_info()
@@ -87,6 +88,7 @@ class _Callback:
         """
         self._last_it_log = self.it
         result = self.solver.get_result()
+        self._last_result = result
         objective_list = self.objective(result)
         self.curve.extend(dict(
             **self.meta, stop_val=self.it,
@@ -123,4 +125,4 @@ class _Callback:
                 self.log_value()
             # Update the status to done
             self.status = 'done'
-        return self.curve, self.status
+        return self.curve, self.status, self._last_result

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -85,7 +85,7 @@ def run_one_resolution(objective, solver, meta, stop_val):
     return [
         dict(**meta, stop_val=stop_val, time=delta_t, **objective_dict, **info)
         for objective_dict in objective_list
-    ]
+    ], result
 
 
 def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
@@ -136,14 +136,19 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             solver.pre_run_hook(callback)
             callback.start()
             solver.run(callback)
-            curve, ctx.status = callback.get_results()
+            curve, ctx.status, last_result = callback.get_results()
         else:
 
             # Create a Memory object to cache the computations in the benchmark
             # folder and handle cases where we force the run.
-            run_one_resolution_cached = benchmark.cache(
-                run_one_resolution, force
-            )
+            # Skip caching if the sampling strategy is 'run_once' since there
+            # the call to this function is a single call to run_one_resolution.
+            if solver._solver_strategy != "run_once":
+                run_one_resolution_cached = benchmark.cache(
+                    run_one_resolution, force,
+                )
+            else:
+                run_one_resolution_cached = run_one_resolution
 
             # compute initial value
             call_args = dict(objective=objective, solver=solver, meta=meta)
@@ -152,7 +157,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
             stop_val = stopping_criterion.init_stop_val()
             while not stop:
 
-                objective_list = run_one_resolution_cached(
+                objective_list, last_result = run_one_resolution_cached(
                     stop_val=stop_val, **call_args
                 )
                 curve.extend(objective_list)
@@ -164,7 +169,7 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
 
         # Save final results if the run did not fail.
         if ctx.status not in FAILURE_STATUS:
-            to_save = objective.save_final_results(**solver.get_result())
+            to_save = objective.save_final_results(**last_result)
             if to_save is not None:
                 curve[-1]["final_results"] = to_save
     if ctx.status in FAILURE_STATUS:

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -141,14 +141,13 @@ def run_one_to_cvg(benchmark, objective, solver, meta, stopping_criterion,
 
             # Create a Memory object to cache the computations in the benchmark
             # folder and handle cases where we force the run.
-            # Skip caching if the sampling strategy is 'run_once' since there
+            # TODO: Skip caching if the sampling strategy is 'run_once' since
             # the call to this function is a single call to run_one_resolution.
-            if solver._solver_strategy != "run_once":
-                run_one_resolution_cached = benchmark.cache(
-                    run_one_resolution, force,
-                )
-            else:
-                run_one_resolution_cached = run_one_resolution
+            # this needs to be done once stopping criterion does not depend on
+            # the terminal anymore.
+            run_one_resolution_cached = benchmark.cache(
+                run_one_resolution, force,
+            )
 
             # compute initial value
             call_args = dict(objective=objective, solver=solver, meta=meta)

--- a/benchopt/stopping_criterion.py
+++ b/benchopt/stopping_criterion.py
@@ -314,9 +314,9 @@ class StoppingCriterion():
         if self.terminal is not None:
             self.terminal.progress(progress)
 
-    @staticmethod
-    def _reconstruct(klass, kwargs, runner_kwargs):
-        criterion = klass(**kwargs)
+    @classmethod
+    def _reconstruct(cls, kwargs, runner_kwargs):
+        criterion = cls(**kwargs)
         if runner_kwargs:
             return criterion.get_runner_instance(**runner_kwargs)
         return criterion

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -335,6 +335,61 @@ def test_objective_save_final_results(no_debug_log):
     assert final_results == "test_value"
 
 
+@pytest.mark.parametrize("sampling_strategy", ['run_once', 'iteration'])
+def test_save_final_results_with_caching(no_debug_log, sampling_strategy):
+    """Non-regression: save_final_results must work when results are cached.
+
+    When get_result() depends on the solver state, calling solver.get_result()
+    after a cache hit (solver not re-run) raises an AttributeError. The fix
+    stores last_result directly from run_one_resolution's return value.
+    For run_once solvers, caching is disabled entirely to avoid the same issue.
+    """
+    save_final = """
+    from benchopt.utils.temp_benchmark import TempObjective
+
+    class Objective(TempObjective):
+        def save_final_results(self, beta):
+            return beta
+    """
+
+    solver_code = f"""
+    from benchopt.utils.temp_benchmark import TempSolver
+    import numpy as np
+
+    class Solver(TempSolver):
+        name = "stateful-solver"
+        sampling_strategy = '{sampling_strategy}'
+
+        def run(self, stop_val):
+            # Store state that get_result() depends on.
+            self.result = np.random.rand(10)
+
+        def get_result(self):
+            # Raises AttributeError if run() was never called in this session.
+            return dict(beta=self.result)
+    """
+
+    common_args = [
+        '-s', 'stateful-solver', '-d', 'test-dataset',
+        '-n', '5', '--no-plot'
+    ]
+
+    with temp_benchmark(objective=save_final, solvers=[solver_code]) as bench:
+        # First run fills the cache.
+        with CaptureCmdOutput():
+            run([str(bench.benchmark_dir), "-r", 2] + common_args,
+                standalone_mode=False)
+        # Second run should use cached results but still call
+        # save_final_results correctly (was broken before the fix).
+        with CaptureCmdOutput(delete_result_files=False) as out:
+            run([str(bench.benchmark_dir), "-r", 3] + common_args,
+                standalone_mode=False)
+        data = read_results(out.result_files[0])
+        final_results = data["final_results"].dropna()
+    # save_final_results must have been called and returned a non-null value.
+    assert len(final_results) >= 1
+
+
 @pytest.mark.parametrize("n_iter", [1, 2, 5])
 def test_run_once_iteration(n_iter):
 

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -379,6 +379,7 @@ def test_save_final_results_with_caching(no_debug_log, sampling_strategy):
         with CaptureCmdOutput():
             run([str(bench.benchmark_dir), "-r", 2] + common_args,
                 standalone_mode=False)
+
         # Second run should use cached results but still call
         # save_final_results correctly (was broken before the fix).
         with CaptureCmdOutput(delete_result_files=False) as out:

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -231,8 +231,7 @@ class TestCache:
 
         class Solver(TempSolver):
             name = "failing-solver"
-            def run(self, n_iter):
-                raise ValueError('Failing solver.')
+            def run(self, _): raise ValueError('Failing solver.')
         """
 
         with temp_benchmark(solvers=[self.solver, solver_fail],
@@ -269,6 +268,25 @@ class TestCache:
         # when using multiple repetitions
         out.check_output("#RUN_SOLVER", repetition=n_reps)
         out.check_output("#RUN_2SOLVER", repetition=n_reps)
+
+    def test_caching_with_max_runs(self, no_debug_log):
+
+        solver = """from benchopt.utils.temp_benchmark import TempSolver
+
+        class Solver(TempSolver):
+            sampling_strategy = 'iteration'
+            def run(self, n_iter): print(f"#RUN:{n_iter}")
+        """
+
+        with temp_benchmark(solvers=solver, datasets=self.dataset) as bench:
+            with CaptureCmdOutput() as out:
+                for it in range(3):
+                    run(f"{bench.benchmark_dir} --no-plot -n {it}".split(),
+                        standalone_mode=False)
+
+        # error message should be displayed twice
+        for it in range(3):
+            out.check_output(f"#RUN:{it}", repetition=1)
 
     @pytest.mark.parametrize('n_reps', [1, 4])
     def test_cache_invalid(self, no_debug_log, n_reps):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -66,6 +66,9 @@ FIX
 - When passing un-supported extension to ``--output``, benchopt now fallback
   to parquet and raise a warning instead of an error. By `Thomas Moreau`_ (:gh:`926`)
 
+- Fix ``save_last_result`` behavior when using cache results.
+  By `Thomas Moreau`_ (:gh:`931`)
+
 .. _changes_1_9:
 
 Version 1.9 - 15/03/2026


### PR DESCRIPTION
When using `save_final_result` with caching, there is an error for solver not using `callback` as the cached solver is never run but we call `get_result` on it.
This PR fixes this behavior and introduce a non-regression test.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
