### PR TITLE
ENH add get_parameter_choices hook and param=all expansion

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -177,6 +177,21 @@ def check_conda_env(env_name, benchmark_name=None):
     return env_name
 
 
+def _format_choices(choices):
+    """Render a list of valid parameter values for `benchopt info -v`.
+
+    Lists every value when there are at most 8, otherwise shows the first
+    few and last few with an ellipsis. A total count is always appended.
+    """
+    choices = [str(c) for c in choices]
+    n = len(choices)
+    if n <= 8:
+        listed = ', '.join(choices)
+    else:
+        listed = ', '.join(choices[:5] + ['...'] + choices[-2:])
+    return f"{listed} ({n} total)"
+
+
 def print_info(cls_name_list, cls_list, env_name=None, verbose=False):
     """Print information for each element of input listed
 
@@ -251,6 +266,15 @@ def print_info(cls_name_list, cls_list, env_name=None, verbose=False):
                 for param, value in cls.parameters.items():
                     values = ', '.join(map(str, value))
                     print(f"    {param}: {values}")
+                    # If the class declares an enumerable universe of valid
+                    # values for this parameter (via get_parameter_choices),
+                    # list them too. This is the set expanded by `param=all`.
+                    choices = None
+                    if hasattr(cls, 'get_parameter_choices'):
+                        choices = cls.get_parameter_choices(param)
+                    if choices is not None:
+                        print(f"        valid values: "
+                              f"{_format_choices(choices)}")
 
             print("-" * 10)
 

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -267,11 +267,11 @@ def print_info(cls_name_list, cls_list, env_name=None, verbose=False):
                     values = ', '.join(map(str, value))
                     print(f"    {param}: {values}")
                     # If the class declares an enumerable universe of valid
-                    # values for this parameter (via get_parameter_choices),
+                    # values for this parameter (via get_all_parameter_values),
                     # list them too. This is the set expanded by `param=all`.
                     choices = None
-                    if hasattr(cls, 'get_parameter_choices'):
-                        choices = cls.get_parameter_choices(param)
+                    if hasattr(cls, 'get_all_parameter_values'):
+                        choices = cls.get_all_parameter_values(param)
                     if choices is not None:
                         print(f"        valid values: "
                               f"{_format_choices(choices)}")

--- a/benchopt/cli/tests/test_cmd_info.py
+++ b/benchopt/cli/tests/test_cmd_info.py
@@ -1,0 +1,57 @@
+from benchopt.utils.temp_benchmark import temp_benchmark
+
+from benchopt.tests.utils import CaptureCmdOutput
+
+from benchopt.cli.helpers import info
+
+
+DATASET_WITH_CHOICES = """from benchopt import BaseDataset
+
+    class Dataset(BaseDataset):
+        name = "with-choices"
+        parameters = {'param': ['a']}
+
+        @classmethod
+        def get_all_parameter_values(cls, name):
+            if name == 'param':
+                return ['a', 'b', 'c']
+            return super().get_all_parameter_values(name)
+
+        def get_data(self): return dict(X=0)
+"""
+
+DATASET_NO_CHOICES = """from benchopt import BaseDataset
+
+    class Dataset(BaseDataset):
+        name = "no-choices"
+        parameters = {'param': ['a']}
+
+        def get_data(self): return dict(X=0)
+"""
+
+
+class TestCmdInfo:
+    def test_info_lists_choices(self):
+        # `benchopt info` lists the values declared by
+        # get_all_parameter_values, with a total count.
+        with temp_benchmark(datasets=[DATASET_WITH_CHOICES]) as bench:
+            with CaptureCmdOutput() as out:
+                info(
+                    [str(bench.benchmark_dir), '-d', 'with-choices'],
+                    'benchopt', standalone_mode=False
+                )
+
+        out.check_output("param: a", repetition=1)
+        out.check_output(r"valid values: a, b, c \(3 total\)", repetition=1)
+
+    def test_info_no_choices(self):
+        # Without the hook, `info` does not print a "valid values" line.
+        with temp_benchmark(datasets=[DATASET_NO_CHOICES]) as bench:
+            with CaptureCmdOutput() as out:
+                info(
+                    [str(bench.benchmark_dir), '-d', 'no-choices'],
+                    'benchopt', standalone_mode=False
+                )
+
+        out.check_output("param: a", repetition=1)
+        out.check_output("valid values", repetition=0)

--- a/benchopt/cli/tests/test_helpers.py
+++ b/benchopt/cli/tests/test_helpers.py
@@ -5,10 +5,8 @@ from benchopt.utils.temp_benchmark import temp_benchmark
 from benchopt.utils.terminal_output import TICK, CROSS
 
 
-from benchopt import BaseDataset
 from benchopt.cli.helpers import check_data
 from benchopt.cli.helpers import check_install
-from benchopt.cli.helpers import print_info
 
 
 class TestCheckInstallCmd:
@@ -89,38 +87,3 @@ class TestCheckDataCmd:
 
             out.check_output(CROSS, repetition=1)
             out.check_output("ValueError: Failed to load data", repetition=1)
-
-
-class TestInfoChoices:
-    """Tests for `benchopt info -v` rendering of `get_parameter_choices`."""
-
-    def test_info_lists_choices(self, capsys):
-        # When a class declares an enumerable value set, `info -v` lists it.
-        class _Dataset(BaseDataset):
-            name = "with-choices"
-            parameters = {'dataset_name': ['a']}
-
-            @classmethod
-            def get_parameter_choices(cls, name):
-                if name == 'dataset_name':
-                    return ['a', 'b', 'c']
-                return super().get_parameter_choices(name)
-
-            def get_data(self): pass
-
-        print_info(['all'], [_Dataset], env_name=None, verbose=True)
-        out = capsys.readouterr().out
-        assert "dataset_name: a" in out
-        assert "valid values: a, b, c (3 total)" in out
-
-    def test_info_no_choices(self, capsys):
-        # Without the hook, `info -v` output is unchanged (no valid values).
-        class _Dataset(BaseDataset):
-            name = "no-choices"
-            parameters = {'dataset_name': ['a']}
-            def get_data(self): pass
-
-        print_info(['all'], [_Dataset], env_name=None, verbose=True)
-        out = capsys.readouterr().out
-        assert "dataset_name: a" in out
-        assert "valid values" not in out

--- a/benchopt/cli/tests/test_helpers.py
+++ b/benchopt/cli/tests/test_helpers.py
@@ -5,8 +5,10 @@ from benchopt.utils.temp_benchmark import temp_benchmark
 from benchopt.utils.terminal_output import TICK, CROSS
 
 
+from benchopt import BaseDataset
 from benchopt.cli.helpers import check_data
 from benchopt.cli.helpers import check_install
+from benchopt.cli.helpers import print_info
 
 
 class TestCheckInstallCmd:
@@ -87,3 +89,38 @@ class TestCheckDataCmd:
 
             out.check_output(CROSS, repetition=1)
             out.check_output("ValueError: Failed to load data", repetition=1)
+
+
+class TestInfoChoices:
+    """Tests for `benchopt info -v` rendering of `get_parameter_choices`."""
+
+    def test_info_lists_choices(self, capsys):
+        # When a class declares an enumerable value set, `info -v` lists it.
+        class _Dataset(BaseDataset):
+            name = "with-choices"
+            parameters = {'dataset_name': ['a']}
+
+            @classmethod
+            def get_parameter_choices(cls, name):
+                if name == 'dataset_name':
+                    return ['a', 'b', 'c']
+                return super().get_parameter_choices(name)
+
+            def get_data(self): pass
+
+        print_info(['all'], [_Dataset], env_name=None, verbose=True)
+        out = capsys.readouterr().out
+        assert "dataset_name: a" in out
+        assert "valid values: a, b, c (3 total)" in out
+
+    def test_info_no_choices(self, capsys):
+        # Without the hook, `info -v` output is unchanged (no valid values).
+        class _Dataset(BaseDataset):
+            name = "no-choices"
+            parameters = {'dataset_name': ['a']}
+            def get_data(self): pass
+
+        print_info(['all'], [_Dataset], env_name=None, verbose=True)
+        out = capsys.readouterr().out
+        assert "dataset_name: a" in out
+        assert "valid values" not in out

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -400,6 +400,11 @@ def _expand_all(cls, kwargs, name_type):
     de-duplicated against the declared choices, keeping a stable order
     (explicit values first, then declared choices not already listed).
 
+    A class can instead declare that ``'all'`` is a legitimate literal value
+    for a parameter (rather than the expansion token) by returning ``'all'``
+    from ``get_all_parameter_values(name)``. In that case ``'all'`` is kept
+    as-is, without expansion or warning.
+
     Parameters
     ----------
     cls : ParametrizedNameMixin
@@ -425,7 +430,8 @@ def _expand_all(cls, kwargs, name_type):
         If a parameter requests ``'all'`` but ``cls.get_all_parameter_values``
         returns ``None`` for it (i.e. the class did not opt in by declaring an
         enumerable value set). In that case ``'all'`` is kept as a literal
-        value. Implementing the hook disables the warning.
+        value. Implementing the hook to return the values (or ``'all'``)
+        disables the warning.
 
     Raises
     ------
@@ -452,17 +458,25 @@ def _expand_all(cls, kwargs, name_type):
             expanded[key] = val
             continue
         choices = cls.get_all_parameter_values(key)
+        if choices == 'all':
+            # The class declares that 'all' is a legitimate literal value for
+            # this parameter (rather than the expansion token). Keep it as-is,
+            # without expanding or warning.
+            expanded[key] = val
+            continue
         if choices is None:
             # The class did not opt in by declaring an enumerable value set,
             # so 'all' cannot be expanded. Warn instead of failing, and keep
             # 'all' as a literal value. Implementing get_all_parameter_values
-            # to return the values disables this warning (and enables `=all`).
+            # to return the values enables expansion; returning 'all' marks it
+            # as a literal value and silences this warning.
             warnings.warn(
                 f"Parameter '{key}' of {name_type} '{cls.name}' does not "
                 f"declare an enumerable value set, so '{key}=all' is used as "
                 f"a literal value. Override "
-                f"{cls.__name__}.get_all_parameter_values('{key}') to enable "
-                f"'{key}=all'.",
+                f"{cls.__name__}.get_all_parameter_values('{key}') to return "
+                f"the valid values (to enable '{key}=all') or 'all' (to keep "
+                f"'all' as a literal value and silence this warning).",
                 UserWarning,
             )
             expanded[key] = val

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -1,5 +1,6 @@
 import re
 import ast
+import warnings
 import itertools
 from abc import abstractmethod
 
@@ -378,12 +379,23 @@ def is_matched(name, include_patterns=None, default=True):
     return False
 
 
+def _contains_all(value):
+    """Return True if the literal ``'all'`` appears anywhere in ``value``.
+
+    Recurses into lists and tuples so that ``'all'`` nested inside the value
+    of a coupled parameter (e.g. ``[(0, 1), (1, 'all')]``) is detected.
+    """
+    if isinstance(value, (list, tuple)):
+        return any(_contains_all(v) for v in value)
+    return value == 'all'
+
+
 def _expand_all(cls, kwargs, name_type):
-    """Expand ``'all'`` parameter values using ``get_parameter_choices``.
+    """Expand ``'all'`` parameter values using ``get_all_parameter_values``.
 
     For each parameter whose selected value(s) contain the literal
     ``'all'``, replace ``'all'`` with the full set of valid values declared
-    by ``cls.get_parameter_choices(name)``. Any explicit values passed
+    by ``cls.get_all_parameter_values(name)``. Any explicit values passed
     alongside ``'all'`` (e.g. ``[v1, 'all', v2]``) are preserved and
     de-duplicated against the declared choices, keeping a stable order
     (explicit values first, then declared choices not already listed).
@@ -392,7 +404,7 @@ def _expand_all(cls, kwargs, name_type):
     ----------
     cls : ParametrizedNameMixin
         The class whose parameters are being expanded. Its
-        ``get_parameter_choices`` classmethod declares the valid universe.
+        ``get_all_parameter_values`` classmethod declares the valid universe.
     kwargs : dict
         Mapping of parameter name to selected value(s), as extracted from a
         CLI pattern. Values may be a single value or a list.
@@ -407,33 +419,54 @@ def _expand_all(cls, kwargs, name_type):
         choices. Parameters that do not contain ``'all'`` are passed through
         unchanged.
 
+    Warns
+    -----
+    UserWarning
+        If a parameter requests ``'all'`` but ``cls.get_all_parameter_values``
+        returns ``None`` for it (i.e. the class did not opt in by declaring an
+        enumerable value set). In that case ``'all'`` is kept as a literal
+        value. Implementing the hook disables the warning.
+
     Raises
     ------
     click.BadParameter
-        If a parameter requests ``'all'`` but ``cls.get_parameter_choices``
-        returns ``None`` for it (i.e. the class did not opt in by declaring
-        an enumerable value set), or if ``'all'`` is used on a coupled
-        (comma-joined) parameter, for which expansion is ambiguous.
+        If ``'all'`` appears anywhere in the values of a coupled
+        (comma-joined) parameter, for which expansion is not possible.
     """
     expanded = {}
     for key, val in kwargs.items():
+        # For coupled (comma-joined) parameters, values must stay fixed tuples
+        # that vary together, so 'all' cannot be expanded. Reject it wherever
+        # it appears -- including nested inside the value tuples -- rather than
+        # silently treating it as the literal value 'all'.
+        if ',' in key:
+            if _contains_all(val):
+                raise click.BadParameter(
+                    f"'all' is not supported for coupled parameters "
+                    f"'{key}' of {name_type} '{cls.name}'."
+                )
+            expanded[key] = val
+            continue
         vals = val if isinstance(val, list) else [val]
         if 'all' not in vals:
             expanded[key] = val
             continue
-        if ',' in key:
-            raise click.BadParameter(
-                f"'all' is not supported for coupled parameters "
-                f"'{key}' of {name_type} '{cls.name}'."
-            )
-        choices = cls.get_parameter_choices(key)
+        choices = cls.get_all_parameter_values(key)
         if choices is None:
-            raise click.BadParameter(
+            # The class did not opt in by declaring an enumerable value set,
+            # so 'all' cannot be expanded. Warn instead of failing, and keep
+            # 'all' as a literal value. Implementing get_all_parameter_values
+            # to return the values disables this warning (and enables `=all`).
+            warnings.warn(
                 f"Parameter '{key}' of {name_type} '{cls.name}' does not "
-                f"declare an enumerable value set. Override "
-                f"{cls.__name__}.get_parameter_choices('{key}') to enable "
-                f"'{key}=all'."
+                f"declare an enumerable value set, so '{key}=all' is used as "
+                f"a literal value. Override "
+                f"{cls.__name__}.get_all_parameter_values('{key}') to enable "
+                f"'{key}=all'.",
+                UserWarning,
             )
+            expanded[key] = val
+            continue
         # merge explicit values with the full set, de-duplicated, order-stable
         merged = [v for v in vals if v != 'all'] + [
             c for c in choices if c not in vals
@@ -559,9 +592,9 @@ def _check_patterns(all_classes, patterns, name_type='dataset',
                     f"Unknown parameter {bad_params} for {name_type} "
                     f"{cls.name}.\n{msg}"
                 )
-    params = cls.parameters.copy()
-    params.update(kwargs)
-    params = _expand_all(cls, params, name_type)
+        params = cls.parameters.copy()
+        params.update(kwargs)
+        params = _expand_all(cls, params, name_type)
         all_valid_patterns.append((cls, params))
 
     if not class_only:

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -25,6 +25,13 @@ class ParametrizedNameMixin():
                 setattr(self, k, v)
 
     @classmethod
+    def get_parameter_choices(cls, name):
+        """Return all valid values for parameter `name`, or None when not
+        enumerable. Distinct from `cls.parameters[name]`, which only drives
+        the default sweep grid."""
+        return None  # Default opt-out
+
+    @classmethod
     def get_instance(cls, **parameters):
         """Helper function to instantiate an object and save its parameters.
 
@@ -371,6 +378,70 @@ def is_matched(name, include_patterns=None, default=True):
     return False
 
 
+def _expand_all(cls, kwargs, name_type):
+    """Expand ``'all'`` parameter values using ``get_parameter_choices``.
+
+    For each parameter whose selected value(s) contain the literal
+    ``'all'``, replace ``'all'`` with the full set of valid values declared
+    by ``cls.get_parameter_choices(name)``. Any explicit values passed
+    alongside ``'all'`` (e.g. ``[v1, 'all', v2]``) are preserved and
+    de-duplicated against the declared choices, keeping a stable order
+    (explicit values first, then declared choices not already listed).
+
+    Parameters
+    ----------
+    cls : ParametrizedNameMixin
+        The class whose parameters are being expanded. Its
+        ``get_parameter_choices`` classmethod declares the valid universe.
+    kwargs : dict
+        Mapping of parameter name to selected value(s), as extracted from a
+        CLI pattern. Values may be a single value or a list.
+    name_type : str
+        Type of the class (``'dataset'``, ``'solver'``, ...), used only to
+        build a sensible error message.
+
+    Returns
+    -------
+    expanded : dict
+        Copy of ``kwargs`` with every ``'all'`` replaced by the declared
+        choices. Parameters that do not contain ``'all'`` are passed through
+        unchanged.
+
+    Raises
+    ------
+    click.BadParameter
+        If a parameter requests ``'all'`` but ``cls.get_parameter_choices``
+        returns ``None`` for it (i.e. the class did not opt in by declaring
+        an enumerable value set), or if ``'all'`` is used on a coupled
+        (comma-joined) parameter, for which expansion is ambiguous.
+    """
+    expanded = {}
+    for key, val in kwargs.items():
+        vals = val if isinstance(val, list) else [val]
+        if 'all' not in vals:
+            expanded[key] = val
+            continue
+        if ',' in key:
+            raise click.BadParameter(
+                f"'all' is not supported for coupled parameters "
+                f"'{key}' of {name_type} '{cls.name}'."
+            )
+        choices = cls.get_parameter_choices(key)
+        if choices is None:
+            raise click.BadParameter(
+                f"Parameter '{key}' of {name_type} '{cls.name}' does not "
+                f"declare an enumerable value set. Override "
+                f"{cls.__name__}.get_parameter_choices('{key}') to enable "
+                f"'{key}=all'."
+            )
+        # merge explicit values with the full set, de-duplicated, order-stable
+        merged = [v for v in vals if v != 'all'] + [
+            c for c in choices if c not in vals
+        ]
+        expanded[key] = merged
+    return expanded
+
+
 def _check_patterns(all_classes, patterns, name_type='dataset',
                     class_only=False):
     """Check the patterns and return a list of selected classes and params.
@@ -488,6 +559,7 @@ def _check_patterns(all_classes, patterns, name_type='dataset',
                     f"Unknown parameter {bad_params} for {name_type} "
                     f"{cls.name}.\n{msg}"
                 )
+        kwargs = _expand_all(cls, kwargs, name_type)
         params = cls.parameters.copy()
         params.update(kwargs)
         all_valid_patterns.append((cls, params))

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -559,9 +559,9 @@ def _check_patterns(all_classes, patterns, name_type='dataset',
                     f"Unknown parameter {bad_params} for {name_type} "
                     f"{cls.name}.\n{msg}"
                 )
-        kwargs = _expand_all(cls, kwargs, name_type)
-        params = cls.parameters.copy()
-        params.update(kwargs)
+    params = cls.parameters.copy()
+    params.update(kwargs)
+    params = _expand_all(cls, params, name_type)
         all_valid_patterns.append((cls, params))
 
     if not class_only:

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -25,7 +25,7 @@ class ParametrizedNameMixin():
                 setattr(self, k, v)
 
     @classmethod
-    def get_parameter_choices(cls, name):
+    def get_all_parameter_values(cls, name):
         """Return all valid values for parameter `name`, or None when not
         enumerable. Distinct from `cls.parameters[name]`, which only drives
         the default sweep grid."""

--- a/benchopt/utils/tests/test_parametrized_name_mixin.py
+++ b/benchopt/utils/tests/test_parametrized_name_mixin.py
@@ -1,5 +1,6 @@
 import click
 import pytest
+import warnings
 from joblib import Parallel, delayed
 
 from benchopt import BaseDataset
@@ -297,30 +298,30 @@ class TestParameterChoices:
     @pytest.mark.parametrize("pattern, expected", [
         ("Test-Dataset[param=all]", ['a', 'b', 'c']),
         ("Test-Dataset[param=[c, all]]", ['c', 'a', 'b']),
-        ("Test-Dataset[param=b]", ['b']),
+        ("Test-Dataset[param=b]", 'b'),
     ], ids=["all", "all with other values", "specific value"])
     def test_expand_all(self, pattern, expected):
-
-        class _DatasetChoices(BaseDataset):
-            """Dataset declaring an enumerable value set via the hook."""
+        # `param=all` expands to the declared set; explicit values are kept
+        # first and merged with the remaining choices; values without `all`
+        # are passed through unchanged.
+        class _Dataset(BaseDataset):
             name = "Test-Dataset"
             parameters = {'param': ['a']}
 
             @classmethod
-            def get_all_parameter_values(cls, name): return ['a', 'b', 'c']
+            def get_all_parameter_values(cls, name):
+                if name == 'param':
+                    return ['a', 'b', 'c']
+                return super().get_all_parameter_values(name)
 
-        def get_data(self): pass
+            def get_data(self): pass
 
-        # `param=all` expands to the full set of declared choices.
-        params = self._params(_DatasetChoices, pattern)
-        assert params['param'] == expected
+        assert self._params(_Dataset, pattern)['param'] == expected
 
     def test_missing_hook_warns(self):
         # `param=all` on a class that does not declare choices warns and keeps
         # 'all' as a literal value rather than failing.
-
-        class _DatasetNoChoices(BaseDataset):
-            """Dataset that does not opt in to the choices hook."""
+        class _Dataset(BaseDataset):
             name = "Test-Dataset"
             parameters = {'param': ['a']}
             def get_data(self): pass
@@ -328,17 +329,36 @@ class TestParameterChoices:
         with pytest.warns(
                 UserWarning,
                 match="does not declare an enumerable value set"):
-            params = self._params(_DatasetNoChoices, "Test-Dataset[param=all]")
+            params = self._params(_Dataset, "Test-Dataset[param=all]")
+        assert params['param'] == 'all'
+
+    def test_literal_all_no_warning(self):
+        # Returning 'all' from the hook marks it as a literal value: 'all' is
+        # kept as-is, with no expansion and no warning.
+        class _Dataset(BaseDataset):
+            name = "Test-Dataset"
+            parameters = {'param': ['a']}
+
+            @classmethod
+            def get_all_parameter_values(cls, name):
+                if name == 'param':
+                    return 'all'
+                return super().get_all_parameter_values(name)
+
+            def get_data(self): pass
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            params = self._params(_Dataset, "Test-Dataset[param=all]")
         assert params['param'] == 'all'
 
     @pytest.mark.parametrize("pattern", [
         "Test-Dataset['p1, p2'=all]",
         "Test-Dataset['p1, p2'=[(1, 10), (2, all)]]",
-    ])
+    ], ids=["top-level", "nested"])
     def test_coupled_all_raises(self, pattern):
-        # `all` on a coupled parameter is ambiguous and rejected.
-        class _DatasetCoupled(BaseDataset):
-            """Dataset with coupled (comma-joined) parameters."""
+        # `all` on a coupled parameter (top-level or nested) is rejected.
+        class _Dataset(BaseDataset):
             name = "Test-Dataset"
             parameters = {'p1, p2': [(1, 10)]}
             def get_data(self): pass
@@ -346,7 +366,7 @@ class TestParameterChoices:
         with pytest.raises(
                 click.BadParameter,
                 match="not supported for coupled parameters"):
-            self._params(_DatasetCoupled, pattern)
+            self._params(_Dataset, pattern)
 
 
 class TestParametrizedNameMixin:

--- a/benchopt/utils/tests/test_parametrized_name_mixin.py
+++ b/benchopt/utils/tests/test_parametrized_name_mixin.py
@@ -1,3 +1,4 @@
+import click
 import pytest
 from joblib import Parallel, delayed
 
@@ -284,6 +285,72 @@ class TestCheckPatterns:
         # invalid use of both positional and keyword parameter
         with pytest.raises(ValueError, match="Invalid name"):
             filt_(["Test-Dataset[41, n_samples=42]"])
+
+
+class TestParameterChoices:
+    """Tests for `param=all` expansion via `get_parameter_choices`."""
+
+    class _DatasetChoices(BaseDataset):
+        """Dataset declaring an enumerable value set via the hook."""
+        name = "Test-Dataset"
+        parameters = {'dataset_name': ['a']}
+
+        @classmethod
+        def get_parameter_choices(cls, name):
+            if name == 'dataset_name':
+                return ['a', 'b', 'c']
+            return super().get_parameter_choices(name)
+
+        def get_data(self): pass
+
+    class _DatasetNoChoices(BaseDataset):
+        """Dataset that does not opt in to the choices hook."""
+        name = "Test-Dataset"
+        parameters = {'dataset_name': ['a']}
+        def get_data(self): pass
+
+    class _DatasetCoupled(BaseDataset):
+        """Dataset with coupled (comma-joined) parameters."""
+        name = "Test-Dataset"
+        parameters = {'a, b': [(1, 10)]}
+        def get_data(self): pass
+
+    def _params(self, cls, pattern):
+        (_, params), = _check_patterns([cls], [pattern])
+        return params
+
+    def test_single_all(self):
+        # `param=all` expands to the full set of declared choices.
+        params = self._params(
+            self._DatasetChoices, "Test-Dataset[dataset_name=all]")
+        assert params['dataset_name'] == ['a', 'b', 'c']
+
+    def test_list_with_all(self):
+        # Explicit values are kept first, then the remaining choices, deduped.
+        params = self._params(
+            self._DatasetChoices, "Test-Dataset[dataset_name=[c, all]]")
+        assert params['dataset_name'] == ['c', 'a', 'b']
+
+    def test_no_all_unchanged(self):
+        # Values without `all` are passed through untouched.
+        params = self._params(
+            self._DatasetChoices, "Test-Dataset[dataset_name=b]")
+        assert params['dataset_name'] == 'b'
+
+    def test_missing_hook_raises(self):
+        # `param=all` on a class that does not declare choices errors out.
+        with pytest.raises(
+                click.BadParameter,
+                match="does not declare an enumerable value set"):
+            self._params(
+                self._DatasetNoChoices, "Test-Dataset[dataset_name=all]")
+
+    def test_coupled_all_raises(self):
+        # `all` on a coupled parameter is ambiguous and rejected.
+        with pytest.raises(
+                click.BadParameter,
+                match="not supported for coupled parameters"):
+            self._params(self._DatasetCoupled, "Test-Dataset['a, b'=all]")
 
 
 class TestParametrizedNameMixin:

--- a/benchopt/utils/tests/test_parametrized_name_mixin.py
+++ b/benchopt/utils/tests/test_parametrized_name_mixin.py
@@ -290,79 +290,63 @@ class TestCheckPatterns:
 class TestParameterChoices:
     """Tests for `param=all` expansion via `get_all_parameter_values`."""
 
-    class _DatasetChoices(BaseDataset):
-        """Dataset declaring an enumerable value set via the hook."""
-        name = "Test-Dataset"
-        parameters = {'param': ['a']}
-
-        @classmethod
-        def get_all_parameter_values(cls, name):
-            if name == 'param':
-                return ['a', 'b', 'c']
-            return super().get_all_parameter_values(name)
-
-        def get_data(self): pass
-
-    class _DatasetNoChoices(BaseDataset):
-        """Dataset that does not opt in to the choices hook."""
-        name = "Test-Dataset"
-        parameters = {'param': ['a']}
-        def get_data(self): pass
-
-    class _DatasetCoupled(BaseDataset):
-        """Dataset with coupled (comma-joined) parameters."""
-        name = "Test-Dataset"
-        parameters = {'a, b': [(1, 10)]}
-        def get_data(self): pass
-
     def _params(self, cls, pattern):
         (_, params), = _check_patterns([cls], [pattern])
         return params
 
-    def test_single_all(self):
+    @pytest.mark.parametrize("pattern, expected", [
+        ("Test-Dataset[param=all]", ['a', 'b', 'c']),
+        ("Test-Dataset[param=[c, all]]", ['c', 'a', 'b']),
+        ("Test-Dataset[param=b]", ['b']),
+    ], ids=["all", "all with other values", "specific value"])
+    def test_expand_all(self, pattern, expected):
+
+        class _DatasetChoices(BaseDataset):
+            """Dataset declaring an enumerable value set via the hook."""
+            name = "Test-Dataset"
+            parameters = {'param': ['a']}
+
+            @classmethod
+            def get_all_parameter_values(cls, name): return ['a', 'b', 'c']
+
+        def get_data(self): pass
+
         # `param=all` expands to the full set of declared choices.
-        params = self._params(
-            self._DatasetChoices, "Test-Dataset[param=all]")
-        assert params['param'] == ['a', 'b', 'c']
-
-    def test_list_with_all(self):
-        # Explicit values are kept first, then the remaining choices, deduped.
-        params = self._params(
-            self._DatasetChoices, "Test-Dataset[param=[c, all]]")
-        assert params['param'] == ['c', 'a', 'b']
-
-    def test_no_all_unchanged(self):
-        # Values without `all` are passed through untouched.
-        params = self._params(
-            self._DatasetChoices, "Test-Dataset[param=b]")
-        assert params['param'] == 'b'
+        params = self._params(_DatasetChoices, pattern)
+        assert params['param'] == expected
 
     def test_missing_hook_warns(self):
         # `param=all` on a class that does not declare choices warns and keeps
         # 'all' as a literal value rather than failing.
+
+        class _DatasetNoChoices(BaseDataset):
+            """Dataset that does not opt in to the choices hook."""
+            name = "Test-Dataset"
+            parameters = {'param': ['a']}
+            def get_data(self): pass
+
         with pytest.warns(
                 UserWarning,
                 match="does not declare an enumerable value set"):
-            params = self._params(
-                self._DatasetNoChoices, "Test-Dataset[param=all]")
+            params = self._params(_DatasetNoChoices, "Test-Dataset[param=all]")
         assert params['param'] == 'all'
 
-    def test_coupled_all_raises(self):
+    @pytest.mark.parametrize("pattern", [
+        "Test-Dataset['p1, p2'=all]",
+        "Test-Dataset['p1, p2'=[(1, 10), (2, all)]]",
+    ])
+    def test_coupled_all_raises(self, pattern):
         # `all` on a coupled parameter is ambiguous and rejected.
-        with pytest.raises(
-                click.BadParameter,
-                match="not supported for coupled parameters"):
-            self._params(self._DatasetCoupled, "Test-Dataset['a, b'=all]")
+        class _DatasetCoupled(BaseDataset):
+            """Dataset with coupled (comma-joined) parameters."""
+            name = "Test-Dataset"
+            parameters = {'p1, p2': [(1, 10)]}
+            def get_data(self): pass
 
-    def test_coupled_nested_all_raises(self):
-        # `all` nested inside a coupled parameter's tuples is also rejected,
-        # rather than being silently treated as the literal value 'all'.
         with pytest.raises(
                 click.BadParameter,
                 match="not supported for coupled parameters"):
-            self._params(
-                self._DatasetCoupled,
-                "Test-Dataset['a, b'=[(1, 10), (2, all)]]")
+            self._params(_DatasetCoupled, pattern)
 
 
 class TestParametrizedNameMixin:

--- a/benchopt/utils/tests/test_parametrized_name_mixin.py
+++ b/benchopt/utils/tests/test_parametrized_name_mixin.py
@@ -293,7 +293,7 @@ class TestParameterChoices:
     class _DatasetChoices(BaseDataset):
         """Dataset declaring an enumerable value set via the hook."""
         name = "Test-Dataset"
-        parameters = {'dataset_name': ['a']}
+        parameters = {'param': ['a']}
 
         @classmethod
         def get_parameter_choices(cls, name):

--- a/benchopt/utils/tests/test_parametrized_name_mixin.py
+++ b/benchopt/utils/tests/test_parametrized_name_mixin.py
@@ -288,7 +288,7 @@ class TestCheckPatterns:
 
 
 class TestParameterChoices:
-    """Tests for `param=all` expansion via `get_parameter_choices`."""
+    """Tests for `param=all` expansion via `get_all_parameter_values`."""
 
     class _DatasetChoices(BaseDataset):
         """Dataset declaring an enumerable value set via the hook."""
@@ -296,17 +296,17 @@ class TestParameterChoices:
         parameters = {'param': ['a']}
 
         @classmethod
-        def get_parameter_choices(cls, name):
-            if name == 'dataset_name':
+        def get_all_parameter_values(cls, name):
+            if name == 'param':
                 return ['a', 'b', 'c']
-            return super().get_parameter_choices(name)
+            return super().get_all_parameter_values(name)
 
         def get_data(self): pass
 
     class _DatasetNoChoices(BaseDataset):
         """Dataset that does not opt in to the choices hook."""
         name = "Test-Dataset"
-        parameters = {'dataset_name': ['a']}
+        parameters = {'param': ['a']}
         def get_data(self): pass
 
     class _DatasetCoupled(BaseDataset):
@@ -322,28 +322,30 @@ class TestParameterChoices:
     def test_single_all(self):
         # `param=all` expands to the full set of declared choices.
         params = self._params(
-            self._DatasetChoices, "Test-Dataset[dataset_name=all]")
-        assert params['dataset_name'] == ['a', 'b', 'c']
+            self._DatasetChoices, "Test-Dataset[param=all]")
+        assert params['param'] == ['a', 'b', 'c']
 
     def test_list_with_all(self):
         # Explicit values are kept first, then the remaining choices, deduped.
         params = self._params(
-            self._DatasetChoices, "Test-Dataset[dataset_name=[c, all]]")
-        assert params['dataset_name'] == ['c', 'a', 'b']
+            self._DatasetChoices, "Test-Dataset[param=[c, all]]")
+        assert params['param'] == ['c', 'a', 'b']
 
     def test_no_all_unchanged(self):
         # Values without `all` are passed through untouched.
         params = self._params(
-            self._DatasetChoices, "Test-Dataset[dataset_name=b]")
-        assert params['dataset_name'] == 'b'
+            self._DatasetChoices, "Test-Dataset[param=b]")
+        assert params['param'] == 'b'
 
-    def test_missing_hook_raises(self):
-        # `param=all` on a class that does not declare choices errors out.
-        with pytest.raises(
-                click.BadParameter,
+    def test_missing_hook_warns(self):
+        # `param=all` on a class that does not declare choices warns and keeps
+        # 'all' as a literal value rather than failing.
+        with pytest.warns(
+                UserWarning,
                 match="does not declare an enumerable value set"):
-            self._params(
-                self._DatasetNoChoices, "Test-Dataset[dataset_name=all]")
+            params = self._params(
+                self._DatasetNoChoices, "Test-Dataset[param=all]")
+        assert params['param'] == 'all'
 
     def test_coupled_all_raises(self):
         # `all` on a coupled parameter is ambiguous and rejected.
@@ -351,6 +353,16 @@ class TestParameterChoices:
                 click.BadParameter,
                 match="not supported for coupled parameters"):
             self._params(self._DatasetCoupled, "Test-Dataset['a, b'=all]")
+
+    def test_coupled_nested_all_raises(self):
+        # `all` nested inside a coupled parameter's tuples is also rejected,
+        # rather than being silently treated as the literal value 'all'.
+        with pytest.raises(
+                click.BadParameter,
+                match="not supported for coupled parameters"):
+            self._params(
+                self._DatasetCoupled,
+                "Test-Dataset['a, b'=[(1, 10), (2, all)]]")
 
 
 class TestParametrizedNameMixin:

--- a/doc/names.inc
+++ b/doc/names.inc
@@ -53,3 +53,5 @@
 .. _Hippolyte Verninas: https://www.linkedin.com/in/hippolyte-verninas
 
 .. _Damien Lesens: https://damienlesens.github.io/
+
+.. _Eduardo Montesuma: https://eddardd.github.io/

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -124,8 +124,10 @@ Once declared, the choices enable two things:
   ``get_all_parameter_values``. Explicit values can be mixed in, e.g.
   ``dataset_name=[m4_weekly, all]``; they are merged and de-duplicated.
   Using ``=all`` on a parameter whose class does not override the hook
-  emits a warning and keeps ``'all'`` as a literal value; implementing
-  ``get_all_parameter_values`` enables the expansion and silences the warning.
+  emits a warning and keeps ``'all'`` as a literal value. Implementing
+  ``get_all_parameter_values`` to return the valid values enables the
+  expansion; implementing it as a no-op that returns ``'all'`` for that
+  parameter silences the warning and keeps ``'all'`` as a literal value.
 
 - **Discovering the values** through ``benchopt info -v``, which lists them
   (with a total count) alongside the default grid.

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -134,7 +134,6 @@ Once declared, the choices enable two things:
    ``get_parameter_choices`` is strict opt-in. Existing classes are
    unaffected, and ``=all`` is only available for parameters that declare a
    value set. It is not supported for grouped (comma-separated) parameters.
-
 .. _managing_dependencies:
 
 Managing dependencies

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -84,6 +84,58 @@ For more complex experiment definitions, the same parameter overrides can be
 expressed in the run configuration file described in
 :ref:`Run a benchmark <run_benchmark>`.
 
+.. _parameter_choices:
+
+Declaring the full set of valid values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``parameters`` dictionary defines the *default sweep grid*: the
+combinations that run when no override is passed. It is deliberately kept
+small so that ``benchopt run`` stays fast by default. This is distinct from
+the *full set of valid values* a parameter can take, which may be much larger
+-- for instance, a dataset class that wraps a collection of named
+sub-datasets through a single parameter.
+
+To declare this full set, override the optional classmethod
+``get_parameter_choices``. It returns the list of valid values for a given
+parameter, or ``None`` (the default) when the parameter has no enumerable
+choice set:
+
+.. code-block:: python
+
+   class Dataset(BaseDataset):
+       name = "GiftEval"
+       parameters = {"dataset_name": ["m4_weekly"]}  # small default grid
+
+       @classmethod
+       def get_parameter_choices(cls, name):
+           if name == "dataset_name":
+               return ["m4_weekly", "m4_daily", ...]  # all valid values
+           return super().get_parameter_choices(name)
+
+Once declared, the choices enable two things:
+
+- **Sweeping all values** with the ``=all`` shorthand on the command line:
+
+  .. prompt:: bash $
+
+     benchopt run . -d "GiftEval[dataset_name=all]"
+
+  This expands ``dataset_name`` to every value returned by
+  ``get_parameter_choices``. Explicit values can be mixed in, e.g.
+  ``dataset_name=[m4_weekly, all]``; they are merged and de-duplicated.
+  Using ``=all`` on a parameter whose class does not override the hook
+  raises an error pointing you at ``get_parameter_choices``.
+
+- **Discovering the values** through ``benchopt info -v``, which lists them
+  (with a total count) alongside the default grid.
+
+.. note::
+
+   ``get_parameter_choices`` is strict opt-in. Existing classes are
+   unaffected, and ``=all`` is only available for parameters that declare a
+   value set. It is not supported for grouped (comma-separated) parameters.
+
 .. _managing_dependencies:
 
 Managing dependencies

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -129,11 +129,6 @@ Once declared, the choices enable two things:
 - **Discovering the values** through ``benchopt info -v``, which lists them
   (with a total count) alongside the default grid.
 
-.. note::
-
-   ``get_parameter_choices`` is strict opt-in. Existing classes are
-   unaffected, and ``=all`` is only available for parameters that declare a
-   value set. It is not supported for grouped (comma-separated) parameters.
 .. _managing_dependencies:
 
 Managing dependencies

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -111,7 +111,6 @@ choice set:
        def get_parameter_choices(cls, name):
            if name == "dataset_name":
                return ["m4_weekly", "m4_daily", ...]  # all valid values
-           return super().get_parameter_choices(name)
 
 Once declared, the choices enable two things:
 

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -97,7 +97,7 @@ the *full set of valid values* a parameter can take, which may be much larger
 sub-datasets through a single parameter.
 
 To declare this full set, override the optional classmethod
-``get_parameter_choices``. It returns the list of valid values for a given
+``get_all_parameter_values``. It returns the list of valid values for a given
 parameter, or ``None`` (the default) when the parameter has no enumerable
 choice set:
 
@@ -108,7 +108,7 @@ choice set:
        parameters = {"dataset_name": ["m4_weekly"]}  # small default grid
 
        @classmethod
-       def get_parameter_choices(cls, name):
+       def get_all_parameter_values(cls, name):
            if name == "dataset_name":
                return ["m4_weekly", "m4_daily", ...]  # all valid values
 
@@ -121,10 +121,11 @@ Once declared, the choices enable two things:
      benchopt run . -d "GiftEval[dataset_name=all]"
 
   This expands ``dataset_name`` to every value returned by
-  ``get_parameter_choices``. Explicit values can be mixed in, e.g.
+  ``get_all_parameter_values``. Explicit values can be mixed in, e.g.
   ``dataset_name=[m4_weekly, all]``; they are merged and de-duplicated.
   Using ``=all`` on a parameter whose class does not override the hook
-  raises an error pointing you at ``get_parameter_choices``.
+  emits a warning and keeps ``'all'`` as a literal value; implementing
+  ``get_all_parameter_values`` enables the expansion and silences the warning.
 
 - **Discovering the values** through ``benchopt info -v``, which lists them
   (with a total count) alongside the default grid.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -15,7 +15,7 @@ CLI
 
 - Add ``param=all`` shorthand to sweep every valid value of a parameter,
   e.g. ``-d "Foo[x=all]"``. The valid values are declared per class through
-  the new opt-in ``get_parameter_choices`` classmethod, and are also listed
+  the ``get_all_parameter_values`` classmethod, and are also listed
   by ``benchopt info -v``. By `Eduardo Montesuma`_
 
 .. _1_9_1:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -7,6 +7,17 @@ What's new
 
 .. _dev:
 
+Version 1.10.0 -- in development
+--------------------------------
+
+CLI
+~~~
+
+- Add ``param=all`` shorthand to sweep every valid value of a parameter,
+  e.g. ``-d "Foo[x=all]"``. The valid values are declared per class through
+  the new opt-in ``get_parameter_choices`` classmethod, and are also listed
+  by ``benchopt info -v``. By `Eduardo Montesuma`_
+
 Version 1.9.1 -- 28/05/2026
 ---------------------------
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -18,6 +18,7 @@ CLI
   the new opt-in ``get_parameter_choices`` classmethod, and are also listed
   by ``benchopt info -v``. By `Eduardo Montesuma`_
 
+.. _1_9_1:
 Version 1.9.1 -- 28/05/2026
 ---------------------------
 


### PR DESCRIPTION
## ENH add `get_parameter_choices` hook and `param=all` expansion

### What

Adds an optional, opt-in classmethod `get_parameter_choices(name)` on
`ParametrizedNameMixin` that declares the **full set of valid values** for a
parameter, separately from the default sweep grid in `parameters`. Wires it into:

1. **CLI value expansion** — `-d "Foo[x=all]"` expands `x` to every value from
   `get_parameter_choices('x')`. Explicit values can be mixed in
   (`x=[v1, all, v2]`); they're merged and de-duplicated, explicit values first.
2. **`benchopt info -v`** — lists the declared values (with a total count)
   alongside the default grid.

```python
class Dataset(BaseDataset):
    name = "GiftEval"
    parameters = {"dataset_name": ["m4_weekly"]}   # small default grid

    @classmethod
    def get_parameter_choices(cls, name):
        if name == "dataset_name":
            return GIFT_EVAL_NAMES                  # full valid universe (28)
        return super().get_parameter_choices(name)
```

### Why

There's currently no way to (a) discover the universe of valid values for a
parameter, or (b) sweep all of them with a single shorthand. Benchmarks where a
dataset class wraps a *collection* of named sub-datasets (e.g. GIFT-Eval's 28
sub-datasets behind one `dataset_name`) need both. Putting the full list in
`parameters` isn't an option, since `parameters` also drives the default grid —
every `benchopt run -d Foo` would then expand by the full count.

### Behavior

- **Strict opt-in.** Default `get_parameter_choices` returns `None`; existing
  classes are unaffected.
- `=all` on a class that doesn't override the hook raises `BadParameter`
  pointing the user at `get_parameter_choices`.
- `=all` on grouped (comma-joined) parameters is rejected with a clear error.

### Out of scope

- No change to how `parameters` drives the default grid.
- No change to existing class-level `-d all` / `-s all` semantics.

### Checklist

- [x] Documentation (`doc/user_guide/class_customization.rst`)
- [x] Unit tests (`TestParameterChoices`, `TestInfoChoices`)
- [x] What's new entry


### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
