### PR TITLE
FIX error handling solver setup

### DIFF
--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -117,19 +117,20 @@ def run_one_to_cvg(benchmark, objective, solver, meta, timeout, max_runs,
         meta['solver_name']
     )
 
-    skip, reason = solver._set_objective(objective)
-    if skip:
-        return [], run_key, 'skip', reason
-
-    stopping_criterion = solver._stopping_criterion.get_runner_instance(
-        solver=solver,
-        max_runs=max_runs,
-        timeout=timeout,
-        terminal=terminal,
-        run_key=run_key,
-    )
-
     with exception_handler(terminal, pdb=pdb) as ctx:
+
+        skip, reason = solver._set_objective(objective)
+        if skip:
+            return [], run_key, 'skip', reason
+
+        stopping_criterion = solver._stopping_criterion.get_runner_instance(
+            solver=solver,
+            max_runs=max_runs,
+            timeout=timeout,
+            terminal=terminal,
+            run_key=run_key,
+        )
+
         # The warm-up step called for each repetition bit only run once.
         solver._warm_up()
 

--- a/benchopt/tests/test_benchmark_features.py
+++ b/benchopt/tests/test_benchmark_features.py
@@ -184,11 +184,12 @@ def test_objective_no_cv(no_debug_log):
 
     msg = "To use `Objective.get_split`, Objective must define a cv"
     with temp_benchmark(objective=no_cv) as benchmark:
-        with pytest.raises(ValueError, match=msg):
+        with CaptureCmdOutput(exit=1) as out:
             run([
                 str(benchmark.benchmark_dir),
                 *'-s test-solver -d test-dataset -n 1 -r 1 --no-plot'.split()
             ], standalone_mode=False)
+        out.check_output(msg, repetition=1)
 
 
 def test_objective_cv_splitter(no_debug_log):

--- a/benchopt/tests/test_solvers.py
+++ b/benchopt/tests/test_solvers.py
@@ -167,3 +167,29 @@ def test_solver_return_early_callback(eval_every):
         out.check_output("EVAL#0", repetition=1)
         out.check_output("EVAL#2", repetition=1)
         out.check_output("EVAL#3", repetition=0)
+
+
+def test_solver_setup_error(no_debug_log):
+
+    solver_fail = """from benchopt.utils.temp_benchmark import TempSolver
+
+    class Solver(TempSolver):
+        name = 'fail-solver'
+        def set_objective(self, X, y, lmbd):
+            raise ValueError("Setup error")
+    """
+    solver = """from benchopt.utils.temp_benchmark import TempSolver
+    class Solver(TempSolver):
+        name = 'test-solver'
+    """
+    with temp_benchmark(solvers=[solver_fail, solver]) as bench:
+        with CaptureCmdOutput() as out:
+            run(
+                f"{bench.benchmark_dir} -d simulated -n 0 "
+                "--no-plot".split(),
+                'benchopt', standalone_mode=False
+            )
+        out.check_output("ValueError: Setup error", repetition=1)
+        out.check_output("fail-solver: error", repetition=1)
+        out.check_output("test-solver: done", repetition=1)
+        print(out.output)

--- a/benchopt/tests/test_stopping_criterion.py
+++ b/benchopt/tests/test_stopping_criterion.py
@@ -247,11 +247,11 @@ def test_dual_strategy(no_debug_log):
     """
 
     with temp_benchmark(solvers=[solver]) as benchmark:
-        with pytest.raises(AssertionError, match="Only set it once."):
-            with CaptureCmdOutput():
-                run([str(benchmark.benchmark_dir),
-                    *('-s test-solver -d test-dataset --no-plot').split()],
-                    standalone_mode=False)
+        with CaptureCmdOutput(exit=1) as out:
+            run([str(benchmark.benchmark_dir),
+                *('-s test-solver -d test-dataset --no-plot').split()],
+                standalone_mode=False)
+        out.check_output("Only set it once.", repetition=1)
 
 
 def test_objective_equals_zero(no_debug_log):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,13 @@ TST
   make sure to install test_datasets when creating a test env.
   By `Thomas Moreau`_ (:gh:`944`)
 
+FIX
+~~~
+
+- Fix error reporting when ``Solver.set_objective`` fails, which was
+  preventing the run to finish normally.
+  By `Thomas Moreau`_ (:gh:`949`)
+
 .. _changes_1_9_1:
 
 Version 1.9.1 -- 28/05/2026


### PR DESCRIPTION
changes in #860 changed the way we report error from `run_one_to_cvg` and break the way we report error when calling `set_objective`.
Fix this and add a non regression test.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
