### PR TITLE
CLI --profile not properly parsed

### DIFF
--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -159,7 +159,7 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               help="Launch a debugger if there is an error. This will launch "
               "ipdb if it is installed and default to pdb otherwise.")
 @click.option('--profile',
-              flag_value='True', default=False,
+              is_flag=True,
               help="Will do line profiling on all functions with @profile "
                    "decorator. Requires the line-profiler package. "
                    "The profile decorator needs to be imported "

--- a/benchopt/cli/tests/test_cmd_run.py
+++ b/benchopt/cli/tests/test_cmd_run.py
@@ -258,7 +258,7 @@ class TestRunCmd:
         out.check_output('GET_DATA#2,1', repetition=1)
         out.check_output('GET_DATA#3,', repetition=2)
 
-    def test_profiling(self, test_env_name, no_debug_log):
+    def test_profiling(self, no_debug_log):
         # Run this test in a subprocess as calling the profiler in the same
         # process breaks the coverage collection.
         solver = """from benchopt.utils.temp_benchmark import TempSolver
@@ -275,8 +275,7 @@ class TestRunCmd:
         with temp_benchmark(solvers=solver) as bench, \
                 CaptureCmdOutput() as out:
             run(
-                f"{bench.benchmark_dir} --env-name {test_env_name} "
-                "-s test-solver -n 1 -r 1 --profile --no-plot".split(),
+                f"{bench.benchmark_dir} -n 1 -r 1 --profile --no-plot".split(),
                 'benchopt', standalone_mode=False
             )
         out.check_output('using profiling', repetition=1)
@@ -286,6 +285,15 @@ class TestRunCmd:
         ]), repetition=1)
         out.check_output(r"def run\(self, n_iter\):", repetition=1)
         out.check_output(r"time.sleep\(0.1\)", repetition=1)
+
+        # Check that profile is only activated when the option is specified
+        with temp_benchmark(solvers=solver) as bench, \
+                CaptureCmdOutput() as out:
+            run(
+                f"{bench.benchmark_dir} -n 1 -r 1 --no-plot".split(),
+                'benchopt', standalone_mode=False
+            )
+        out.check_output('using profiling', repetition=0)
 
     @pytest.mark.parametrize('n_rep', [1, 2, 4])
     def test_caching(self, n_rep):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -23,6 +23,13 @@ TST
   make sure to install test_datasets when creating a test env.
   By `Thomas Moreau`_ (:gh:`944`)
 
+
+FIX
+~~~
+
+- Fix ``--profile`` parsing that was resulting in always activated profile.
+  By `Thomas Moreau`_ (:gh:`950`)
+
 .. _changes_1_9_1:
 
 Version 1.9.1 -- 28/05/2026


### PR DESCRIPTION
Profile seems to be always activated, this PR fixes this.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
