### PR TITLE
Fix prepare interation with seed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = benchmarks,__cache__,doc/,communication_materials/,results/,.venv/
+exclude = benchmarks,__cache__,doc/,communication_materials/,results/,.venv/,worktrees/
 per-file-ignores =
     examples/*: E402

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -340,7 +340,9 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
         deduplication when running preparation in parallel.
         Use the special value ``"all"`` to ignore every parameter (i.e.
         preparation runs at most once per dataset class regardless of
-        parameterization).
+        parameterization). The reserved name ``"base_seed"`` (also implied by
+        ``"all"``) drops the benchmark ``--seed`` from the prepare cache key,
+        for datasets whose preparation does not depend on the seed.
     """
 
     _base_class_name = 'Dataset'
@@ -368,6 +370,17 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
               class Dataset(BaseDataset):
                   parameters = {'n_samples': [100, 1000], 'seed': [0, 1, 2]}
                   prepare_cache_ignore = ('seed',)  # 2 calls instead of 6
+        - The benchmark ``--seed`` is part of the prepare cache key, so
+          preparing with a different seed re-runs preparation. Pass the same
+          ``--seed`` to ``benchopt prepare`` and ``benchopt run`` so the
+          prepared data matches the run. If preparation does not depend on the
+          seed, drop it from the cache key with
+          ``prepare_cache_ignore = ('base_seed',)`` (also implied by ``"all"``).
+        - At preparation time only the dataset is known, so ``get_seed`` (in
+          ``prepare`` or in the ``get_data`` it triggers) may only be called
+          with ``use_dataset=True``. Requesting the objective, solver or
+          repetition seed raises a ``ValueError``, as they are not yet defined.
+          See :ref:`controlling_randomness`.
         """
         pass
 
@@ -433,7 +446,16 @@ def _prepare_one(benchmark, dataset, force=False):
     success or the caught exception on failure.
     """
     exc = None
-    cached_prepare = benchmark.cache(BaseDataset._prepare, force=force)
+    # Datasets whose preparation does not depend on the seed can drop it from
+    # the cache key by listing 'base_seed' in prepare_cache_ignore,
+    # handle this separately.
+    cache_ignore = getattr(type(dataset), 'prepare_cache_ignore', ())
+    ignore = ['base_seed'] if (
+        cache_ignore == "all" or 'base_seed' in cache_ignore
+    ) else None
+    cached_prepare = benchmark.cache(
+        BaseDataset._prepare, ignore=ignore, force=force
+    )
     print(f"Preparing {dataset} ...", end=' ', flush=True)
     try:
         cached_prepare(dataset=dataset, base_seed=benchmark.seed)

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -374,8 +374,8 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
           preparing with a different seed re-runs preparation. Pass the same
           ``--seed`` to ``benchopt prepare`` and ``benchopt run`` so the
           prepared data matches the run. If preparation does not depend on the
-          seed, drop it from the cache key with
-          ``prepare_cache_ignore = ('base_seed',)`` (also implied by ``"all"``).
+          seed, it can be ignored adding ``base_seed`` in
+          ``prepare_cache_ignore`` (included in ``"all"``).
         - At preparation time only the dataset is known, so ``get_seed`` (in
           ``prepare`` or in the ``get_data`` it triggers) may only be called
           with ``use_dataset=True``. Requesting the objective, solver or

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -404,8 +404,18 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
         return self._data
 
     @staticmethod
-    def _prepare(dataset):
-        """Preparation function, to map to prepare or get_data."""
+    def _prepare(dataset, base_seed=0):
+        """Preparation function, to map to prepare or get_data.
+
+        ``base_seed`` is part of the joblib cache key. Note that only
+        use_dataset is known at this point; requesting the objective/solver/
+        repetition seed raises an error.
+        """
+        from .utils.run_context import RunContext
+        RunContext(
+            base_seed=str(base_seed),
+            dataset_name=str(dataset),
+        ).attach(objective=None, dataset=dataset, solver=None)
         if type(dataset).prepare is not BaseDataset.prepare:
             dataset.prepare()
         else:
@@ -426,7 +436,7 @@ def _prepare_one(benchmark, dataset, force=False):
     cached_prepare = benchmark.cache(BaseDataset._prepare, force=force)
     print(f"Preparing {dataset} ...", end=' ', flush=True)
     try:
-        cached_prepare(dataset=dataset)
+        cached_prepare(dataset=dataset, base_seed=benchmark.seed)
         print("done")
     except Exception as e:
         print("FAILED")

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -427,8 +427,14 @@ def run(config_file=None, **kwargs):
               shell_complete=complete_conda_envs,
               help="Run preparation in the conda environment "
               "named <env_name>.")
+@click.option('--seed',
+              metavar="<seed>", type=int, default=None,
+              help="Seed to control the stochasticity of the data "
+              "preparation. Use the same seed as `benchopt run` to make sure "
+              "the prepared data matches the one used during the run.")
 def prepare(benchmark, dataset_names, config_file=None,
-            force=False, n_jobs=None, parallel_config=None, env_name='False'):
+            force=False, n_jobs=None, parallel_config=None, env_name='False',
+            seed=None):
 
     if config_file is not None:
         with open(config_file, "r") as f:
@@ -436,7 +442,7 @@ def prepare(benchmark, dataset_names, config_file=None,
         if not dataset_names:
             dataset_names = config.get("dataset", tuple())
 
-    benchmark = Benchmark(benchmark)
+    benchmark = Benchmark(benchmark, seed=seed)
 
     # Resolve env name (same logic as install)
     if env_name == 'False':

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -255,6 +255,29 @@ class TestPrepareCmd:
                 )
             out.check_output("#PREPARED", repetition=1)
 
+    @pytest.mark.parametrize('ignore', ["('base_seed',)", "'all'"])
+    def test_cache_ignore_base_seed(self, ignore):
+        """prepare_cache_ignore can drop the seed from the prepare cache key."""
+        dataset = f"""from benchopt import BaseDataset
+            class Dataset(BaseDataset):
+                name = "dataset"
+                prepare_cache_ignore = {ignore}
+                def prepare(self): print('#PREPARED')
+                def get_data(self): return dict(X=0, y=1)
+        """
+        with temp_benchmark(datasets=dataset) as bench:
+            # A different seed must not invalidate the cache.
+            with CaptureCmdOutput() as out:
+                prepare_cmd(
+                    f"{bench.benchmark_dir} --seed 0".split(),
+                    'benchopt', standalone_mode=False
+                )
+                prepare_cmd(
+                    f"{bench.benchmark_dir} --seed 1".split(),
+                    'benchopt', standalone_mode=False
+                )
+            out.check_output("#PREPARED", repetition=1)
+
     def test_force_flag(self, tmp_path):
         """--force re-runs preparation even when cached."""
         with temp_benchmark(datasets=self.dataset) as bench:

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -257,7 +257,7 @@ class TestPrepareCmd:
 
     @pytest.mark.parametrize('ignore', ["('base_seed',)", "'all'"])
     def test_cache_ignore_base_seed(self, ignore):
-        """prepare_cache_ignore can drop the seed from the prepare cache key."""
+        """prepare_cache_ignore drop the seed from the prepare cache key."""
         dataset = f"""from benchopt import BaseDataset
             class Dataset(BaseDataset):
                 name = "dataset"

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -184,7 +184,7 @@ class TestPrepareCmd:
         'use_objective=True', 'use_solver=True', 'use_repetition=True',
     ])
     def test_get_seed_non_dataset_raises(self, seed_arg):
-        """get_seed() depending on objective/solver/repetition fails in prepare.
+        """get_seed() depending on objective/solver/rep fails in prepare.
 
         These dimensions are unknown at preparation time, so prepare must fail
         with a clear error instead of the run_context-not-initialized error.
@@ -226,7 +226,7 @@ class TestPrepareCmd:
         assert seeds[0] != seeds[1]
 
     def test_cache_per_seed(self):
-        """Prepare is cached per-seed: same seed hits cache, new seed re-runs."""
+        """Prepare cached per-seed: same seed hits cache, new seed re-runs."""
         dataset = """from benchopt import BaseDataset
             class Dataset(BaseDataset):
                 name = "dataset"

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -162,6 +162,99 @@ class TestPrepareCmd:
         out.check_output("#PREPARED", repetition=1)
         out.check_output("1/2 datasets ready", repetition=1)
 
+    def test_get_seed_dataset_ok(self):
+        """get_data() may call get_seed(use_dataset=True) during prepare."""
+        dataset = """from benchopt import BaseDataset
+            class Dataset(BaseDataset):
+                name = "dataset"
+                def get_data(self):
+                    print('#SEED=', self.get_seed(use_dataset=True))
+                    return dict(X=0, y=1)
+        """
+        with temp_benchmark(datasets=dataset) as bench:
+            with CaptureCmdOutput() as out:
+                prepare_cmd(
+                    [str(bench.benchmark_dir)],
+                    'benchopt', standalone_mode=False
+                )
+            out.check_output(r"#SEED=", repetition=1)
+            out.check_output("Summary: 1/1 datasets ready.")
+
+    @pytest.mark.parametrize('seed_arg', [
+        'use_objective=True', 'use_solver=True', 'use_repetition=True',
+    ])
+    def test_get_seed_non_dataset_raises(self, seed_arg):
+        """get_seed() depending on objective/solver/repetition fails in prepare.
+
+        These dimensions are unknown at preparation time, so prepare must fail
+        with a clear error instead of the run_context-not-initialized error.
+        """
+        dataset = f"""from benchopt import BaseDataset
+            class Dataset(BaseDataset):
+                name = "dataset"
+                def get_data(self):
+                    self.get_seed({seed_arg})
+                    return dict(X=0, y=1)
+        """
+        with temp_benchmark(datasets=dataset) as bench:
+            with CaptureCmdOutput(exit=1) as out:
+                prepare_cmd(
+                    [str(bench.benchmark_dir)],
+                    'benchopt', standalone_mode=False
+                )
+        out.check_output("is defined in the current run context")
+        out.check_output("FAILED")
+
+    def test_seed_passed_to_get_seed(self):
+        """The --seed value controls the seed available during prepare."""
+        dataset = """from benchopt import BaseDataset
+            class Dataset(BaseDataset):
+                name = "dataset"
+                def get_data(self):
+                    print('#SEED=', self.get_seed(use_dataset=True))
+                    return dict(X=0, y=1)
+        """
+        seeds = []
+        with temp_benchmark(datasets=dataset) as bench:
+            for seed in [0, 1]:
+                with CaptureCmdOutput() as out:
+                    prepare_cmd(
+                        f"{bench.benchmark_dir} --seed {seed}".split(),
+                        'benchopt', standalone_mode=False
+                    )
+                seeds += out.check_output(r"#SEED= (\d+)", repetition=1)
+        assert seeds[0] != seeds[1]
+
+    def test_cache_per_seed(self):
+        """Prepare is cached per-seed: same seed hits cache, new seed re-runs."""
+        dataset = """from benchopt import BaseDataset
+            class Dataset(BaseDataset):
+                name = "dataset"
+                def prepare(self):
+                    print('#PREPARED', self.get_seed(use_dataset=True))
+                def get_data(self): return dict(X=0, y=1)
+        """
+        with temp_benchmark(datasets=dataset) as bench:
+            # Same seed twice: prepare runs once, second call hits the cache.
+            with CaptureCmdOutput() as out:
+                prepare_cmd(
+                    f"{bench.benchmark_dir} --seed 0".split(),
+                    'benchopt', standalone_mode=False
+                )
+                prepare_cmd(
+                    f"{bench.benchmark_dir} --seed 0".split(),
+                    'benchopt', standalone_mode=False
+                )
+            out.check_output("#PREPARED", repetition=1)
+
+            # A different seed invalidates the cache and re-runs prepare.
+            with CaptureCmdOutput() as out:
+                prepare_cmd(
+                    f"{bench.benchmark_dir} --seed 1".split(),
+                    'benchopt', standalone_mode=False
+                )
+            out.check_output("#PREPARED", repetition=1)
+
     def test_force_flag(self, tmp_path):
         """--force re-runs preparation even when cached."""
         with temp_benchmark(datasets=self.dataset) as bench:

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -54,9 +54,10 @@ def test_dataset_get_data(benchmark, dataset_class):
     config = get_configs(dataset_class)[0]
     dataset = dataset_class.get_instance(**config['dataset'])
 
-    # ensure classes calling `get_seed` work properly
+    # ensure classes calling `get_seed` work properly. Use placeholder
+    # objective/solver names to mimic known dimension at runtime.
     RunContext().set_run_context(
-        None, dataset, None, repetition=0, base_seed=0
+        "dummy", dataset, "dummy", repetition=0, base_seed=0
     )
 
     data = dataset._get_data()
@@ -80,9 +81,10 @@ def test_benchmark_objective(benchmark, test_dataset_name):
     dataset = dataset_class.get_instance(**config['dataset'])
     objective = objective_class.get_instance(**config['objective'])
 
-    # ensure classes calling `get_seed` work properly
+    # ensure classes calling `get_seed` work properly. Use a placeholder
+    # solver name so all methods can use any seed dimension.
     RunContext().set_run_context(
-        objective, dataset, None, repetition=0, base_seed=0
+        objective, dataset, "dummy", repetition=0, base_seed=0
     )
 
     # get one value for the objective, with the test_dataset
@@ -216,10 +218,11 @@ def test_solver_stopping_criterion(benchmark, solver_class, test_dataset_name):
             "'objective_'."
         )
 
-        # ensure classes calling `get_seed` work properly
+        # ensure classes calling `get_seed` work properly.
         dataset = dataset_class.get_instance(**config['dataset'])
         RunContext().set_run_context(
-            objective, dataset, None, repetition=0, base_seed=benchmark.seed
+            objective, dataset, solver_class.name, repetition=0,
+            base_seed=benchmark.seed
         )
 
         objective._set_dataset(dataset)

--- a/benchopt/utils/run_context.py
+++ b/benchopt/utils/run_context.py
@@ -2,6 +2,7 @@ import re
 import hashlib
 from pathlib import Path
 from dataclasses import dataclass, replace as dc_replace
+from .run_context_mixin import RunContextMixin
 
 
 def _sanitize_path_component(name):
@@ -34,24 +35,37 @@ class RunContext:
     # Config fields — set once per benchmark invocation
     run_output_base: Path | None = None
     pdb: bool = False
-    # Per-run fields — cloned/updated for each (dataset, obj, solver, rep)
+    # Per-run fields — cloned/updated for each (dataset, obj, solver, rep).
+    # A field left as None means the corresponding component is not available
+    # in this context (e.g. objective/solver/repetition during prepare) and
+    # requesting its seed raises a clear error in get_seed.
     base_seed: str = ""
-    objective_name: str = ""
-    dataset_name: str = ""
-    solver_name: str = ""
-    repetition: int = 0
+    objective_name: str | None = None
+    dataset_name: str | None = None
+    solver_name: str | None = None
+    repetition: int | None = None
 
     def get_seed(self, class_name, use_objective=False, use_dataset=False,
                  use_solver=False, use_repetition=False):
         """Compute a deterministic integer seed for a given component."""
+        repetition = None if self.repetition is None else str(self.repetition)
         use_flags = {
             "base_seed": (True, self.base_seed),
             "objective": (use_objective, self.objective_name),
             "dataset": (use_dataset, self.dataset_name),
             "solver": (use_solver, self.solver_name),
-            "repetition": (use_repetition, str(self.repetition)),
+            "repetition": (use_repetition, repetition),
             "class": (True, class_name.lower()),
         }
+        for component, (use, value) in use_flags.items():
+            if use and value is None:
+                raise ValueError(
+                    f"get_seed(use_{component}=True) was called but no "
+                    f"{component} is defined in the current run context. This "
+                    "happens for instance during `benchopt prepare`, where "
+                    "only the dataset is available. Make sure the seed only "
+                    "depends on components defined where get_seed() is called."
+                )
         hash_list = [v if use else "*" for use, v in use_flags.values()]
         digest = hashlib.sha256("_".join(hash_list).encode()).hexdigest()
         return int(digest, 16) % (2**32 - 1)
@@ -90,5 +104,5 @@ class RunContext:
     def attach(self, objective, dataset, solver):
         """Assign ctx to each run component."""
         for klass in [objective, dataset, solver]:
-            if klass is not None:
+            if isinstance(klass, RunContextMixin):
                 klass._run_context = self

--- a/doc/benchmark_workflow/run_benchmark.rst
+++ b/doc/benchmark_workflow/run_benchmark.rst
@@ -40,7 +40,9 @@ Preparation is triggered by the dedicated command::
 Benchopt calls the :func:`~benchopt.BaseDataset.prepare()` method of every
 dataset and caches the result with `joblib`, so re-running the command is a
 no-op when nothing has changed. Use ``--force`` to bypass the cache and re-run
-preparation unconditionally.
+preparation unconditionally. Note that for datasets that rely on
+:ref:`seeding <controlling_randomness>`, the same ``--seed`` must be passed to
+``prepare`` and ``run`` so the prepared data matches the run.
 
 Preparation can also be parallelised across datasets using the same options as
 :ref:`benchopt run <parallel_run>`.

--- a/doc/benchmark_workflow/write_benchmark.rst
+++ b/doc/benchmark_workflow/write_benchmark.rst
@@ -185,7 +185,8 @@ Optional features
 ~~~~~~~~~~~~~~~~~
 
 - :func:`~benchopt.BaseDataset.prepare`: expensive one-time setup (downloads,
-  extraction, preprocessing), cached by joblib.
+  extraction, preprocessing), cached by joblib. Default to ``get_data()`` if
+  not implemented.
   See :ref:`prepare_datasets` for details and usage.
 - **Custom data paths**: expose configurable file paths to benchmark users via
   :func:`benchopt.config.get_data_path`. See :ref:`data_paths` for

--- a/doc/user_guide/controlling_randomness.rst
+++ b/doc/user_guide/controlling_randomness.rst
@@ -72,6 +72,15 @@ Do **not** call it at import time or during class definition — at that stage,
 the benchmark runner has not yet created the correct runtime context, and the
 seed has not been initialized.
 
+.. note::
+
+    When ``get_data`` is called by :ref:`benchopt prepare <prepare_datasets>`,
+    only the dataset is known. A ``Dataset`` may therefore only call
+    ``get_seed(use_dataset=True)`` from ``get_data``; requesting the objective,
+    solver or repetition seed raises an error, since these are not defined at
+    preparation time. Use the same ``--seed`` for ``prepare`` and ``run`` so the
+    prepared data matches the run.
+
 Examples
 ~~~~~~~~
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -39,6 +39,13 @@ TST
 FIX
 ~~~
 
+- Fix ``get_seed`` failing during ``benchopt prepare`` when a dataset's
+  ``get_data`` uses it. ``prepare`` now sets up a seeding context and accepts a
+  ``--seed`` option that is part of the preparation cache. Datasets whose
+  preparation does not depend on the seed can drop it from the cache key with
+  ``prepare_cache_ignore = ('base_seed',)``.
+  By `Thomas Moreau`_ (:gh:`962`)
+
 - Fix single dataset benchmark test_dataset_names detection for test env
   creation. By `Thomas moreau`_ (:gh:`951`)
 


### PR DESCRIPTION
The interaction between prepare and `get_seed` was not working. This fixes the behavior, allowing to prepare a dataset as long as the seed only depends on the dataset and raise a sensible error otherwise.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
