### PR TITLE
FIX global skills

### DIFF
--- a/benchopt/cli/skills.py
+++ b/benchopt/cli/skills.py
@@ -1,4 +1,3 @@
-import os
 import json
 import shutil
 import click

--- a/benchopt/cli/skills.py
+++ b/benchopt/cli/skills.py
@@ -67,9 +67,8 @@ def _link_or_copy(target, source):
             target.unlink()
         else:
             shutil.rmtree(target)
-    rel = os.path.relpath(source, target.parent)
     try:
-        target.symlink_to(rel, target_is_directory=True)
+        target.symlink_to(source.resolve(), target_is_directory=True)
         return "symlink"
     except (OSError, NotImplementedError):
         # e.g. Windows without developer mode: copy instead.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,7 +10,6 @@ What's new
 Version 1.10.0 -- in development
 --------------------------------
 
-<<<<<<< ENH_agent_skills
 CLI
 ~~~
 
@@ -18,7 +17,7 @@ CLI
   standard) as package data and add ``benchopt sync-skills`` to install them
   into a project's ``.agents/skills/`` (or globally with ``--global``), with a
   ``.claude/skills/`` mirror for Claude Code. By `Thomas Moreau`_ (:gh:`959`)
-=======
+
 PLOT
 ~~~~
 
@@ -29,7 +28,6 @@ PLOT
 - Improve the html report table, now rendered with `Grid.js
   <https://gridjs.io/>`_: sortable by any column, filter by solver name,
   hide/show any columns. By `Hippolyte Verninas`_ (:gh:`953`)
->>>>>>> main
 
 API
 ~~~
@@ -65,6 +63,9 @@ TST
 FIX
 ~~~
 
+- Fix ``benchopt sync-skills`` symlink with global install for Claude.
+  By `Thomas Moreau`_ (:gh:`969`)
+
 - Fix ``get_seed`` failing during ``benchopt prepare`` when a dataset's
   ``get_data`` uses it. ``prepare`` now sets up a seeding context and accepts a
   ``--seed`` option that is part of the preparation cache. Datasets whose
@@ -73,7 +74,7 @@ FIX
   By `Thomas Moreau`_ (:gh:`962`)
 
 - Fix single dataset benchmark test_dataset_names detection for test env
-  creation. By `Thomas moreau`_ (:gh:`951`)
+  creation. By `Thomas Moreau`_ (:gh:`951`)
 
 - Fix ``--profile`` parsing that was resulting in always activated profile.
   By `Thomas Moreau`_ (:gh:`950`)


### PR DESCRIPTION
Installing benchopt user skills globally failed due to relative path. This fixes the install steps.