### PR TITLE
FIX include benchmark_utils in benchopt archive

### DIFF
--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -27,7 +27,7 @@ from benchopt.utils.terminal_output import BLUE, RED, GREEN, TICK, CROSS
 
 ARCHIVE_ELEMENTS = [
     'README*', '*.yml', 'objective.py',
-    'solvers/*', 'datasets/*', 'utils/**'
+    'solvers/*', 'datasets/*', 'benchmark_utils/**'
 ]
 
 helpers = click.Group(

--- a/benchopt/cli/tests/test_cmd_archive.py
+++ b/benchopt/cli/tests/test_cmd_archive.py
@@ -109,6 +109,23 @@ class TestArchiveCmd:
         assert counts["outputs"] >= 1, counts
         assert counts["__pycache__"] == 0, counts
 
+    def test_benchmark_utils_included(self):
+        # benchmark_utils/ must be included in the archive
+        utils = {"helpers": "def foo(): pass"}
+        with temp_benchmark(benchmark_utils=utils) as bench:
+            with CaptureCmdOutput(delete_result_files=False) as out:
+                archive([str(bench.benchmark_dir)], 'benchopt',
+                        standalone_mode=False)
+            try:
+                assert len(out.result_files) == 1
+                with tarfile.open(out.result_files[0], "r:gz") as tar:
+                    names = [m.name for m in tar.getmembers()]
+            finally:
+                for f in out.result_files:
+                    Path(f).unlink()
+
+        assert any("benchmark_utils" in n for n in names), names
+
     def test_complete_bench(self, bench_completion_cases):  # noqa: F811
         # Completion for benchmark name
         _test_shell_completion(archive, [], bench_completion_cases)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -77,6 +77,9 @@ FIX
 - Fix single dataset benchmark test_dataset_names detection for test env
   creation. By `Thomas moreau`_ (:gh:`951`)
 
+- Fix ``benchopt archive`` not including ``benchmark_utils/`` in the generated
+  archive. By `Thomas Moreau`_ (:gh:`970`)
+
 - Fix ``--profile`` parsing that was resulting in always activated profile.
   By `Thomas Moreau`_ (:gh:`950`)
 


### PR DESCRIPTION
`benchopt archive` tries to include former `utils` instead of `benchmark_utils`. This PR fixes the behavior.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
