### PR TITLE
FIX Windows shell handling under bash shell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,12 +127,8 @@ jobs:
         run: benchopt run examples/minimal_benchmark -r 1 -n 10 --no-plot
 
   test_windows_bash:
-    # Regression test for shell handling on Windows when the CI step runs under
-    # a bash shell (the common `shell: bash` setup in downstream benchmarks).
-    # In that case $SHELL is a git-bash path, which used to make benchopt emit a
-    # bash script containing `CALL conda` and break conda env management. See
-    # https://github.com/benchopt/benchopt for the fix. Unlike the `cmd`-based
-    # `test_benchopt` Windows leg, this exercises the bash-shell code path.
+    # Regression test for shell handling on Windows when using a bash shell
+    # instead of cmd.
     name: Test Windows with bash shell
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,9 @@ jobs:
         run: benchopt run examples/minimal_benchmark -r 1 -n 10 --no-plot
 
   test_windows_bash:
-    # Regression test for shell handling on Windows when using a bash shell
-    # instead of cmd.
+    # Regression test: when the CI step runs under bash, $SHELL is a git-bash
+    # path. benchopt must ignore it and drive conda through `cmd /c` rather than
+    # emitting a broken bash script, so `install`/`test` keep working.
     name: Test Windows with bash shell
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
     # bash script containing `CALL conda` and break conda env management. See
     # https://github.com/benchopt/benchopt for the fix. Unlike the `cmd`-based
     # `test_benchopt` Windows leg, this exercises the bash-shell code path.
-    name: Test Windows under bash shell
+    name: Test Windows with bash shell
     runs-on: windows-latest
     defaults:
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,46 @@ jobs:
       - name: Run benchopt run without conda
         run: benchopt run examples/minimal_benchmark -r 1 -n 10 --no-plot
 
+  test_windows_bash:
+    # Regression test for shell handling on Windows when the CI step runs under
+    # a bash shell (the common `shell: bash` setup in downstream benchmarks).
+    # In that case $SHELL is a git-bash path, which used to make benchopt emit a
+    # bash script containing `CALL conda` and break conda env management. See
+    # https://github.com/benchopt/benchopt for the fix. Unlike the `cmd`-based
+    # `test_benchopt` Windows leg, this exercises the bash-shell code path.
+    name: Test Windows under bash shell
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -el {0}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          activate-environment: 'testcondaenv'
+          python-version: "3.12"
+          # Use miniforge to only get conda-forge as default channel.
+          miniforge-version: latest
+
+      - name: Show the shell benchopt sees
+        run: echo "SHELL=$SHELL"
+
+      - name: Install benchopt and its dependencies
+        run: pip install -e ".[test]"
+
+      - name: Create a conda env for the benchmark under bash
+        # Exercises create_conda_env / `CONDA_CMD env create` on Windows while
+        # $SHELL is a bash path.
+        run: benchopt install examples/minimal_benchmark --env-name bench_win_bash
+
+      - name: Run the benchmark in that env under bash
+        # Exercises `CALL conda activate` via _run_shell_in_conda_env.
+        run: >
+          benchopt run examples/minimal_benchmark
+          --env-name bench_win_bash -r 1 -n 10 --no-plot
+
   test_no_pytest:
     name: Test benchopt test without pytest installed
     runs-on: ubuntu-latest
@@ -176,16 +216,18 @@ jobs:
 
   report_test:
     if: ${{ always() }}
-    needs: [test_benchopt, test_no_conda]
+    needs: [test_benchopt, test_no_conda, test_windows_bash]
     runs-on: ubuntu-latest
     env:
       TEST_BENCHOPT: ${{ needs.test_benchopt.result }}
       TEST_NO_CONDA: ${{ needs.test_no_conda.result }}
+      TEST_WINDOWS_BASH: ${{ needs.test_windows_bash.result }}
 
     steps:
       - name: "Gather test results."
         run: |
-          if [[ $TEST_BENCHOPT == 'success' && $TEST_NO_CONDA == 'success' ]]; then
+          if [[ $TEST_BENCHOPT == 'success' && $TEST_NO_CONDA == 'success' \
+                && $TEST_WINDOWS_BASH == 'success' ]]; then
             exit 0;
           else
             exit 1;

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -55,9 +55,7 @@ particular for logging, warnings and errors. The available options are:
 * ``shell``, *str*: can be used to specify the shell to use. On POSIX systems
   it defaults to the ``SHELL`` env var if it exists and
   ``'bash --norc --noprofile'`` otherwise. On Windows it defaults to
-  ``'cmd /c'`` and the ``SHELL`` env var is ignored (a POSIX ``SHELL`` set by
-  Git Bash or MSYS would otherwise break conda handling); override it
-  explicitly with the ``BENCHOPT_SHELL`` env var or this setting.
+  ``'cmd /c'`` and the ``SHELL`` env var is ignored as it is not reliable.
 * ``cache``, *str*: can be used to specify where the cache for the benchmarks
   should be stored. By default, the cache files are stored in the benchmark
   directory, under the folder __cache__. Setting this configuration would

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -55,7 +55,7 @@ particular for logging, warnings and errors. The available options are:
 * ``shell``, *str*: can be used to specify the shell to use. On POSIX systems
   it defaults to the ``SHELL`` env var if it exists and
   ``'bash --norc --noprofile'`` otherwise. On Windows it defaults to
-  ``'cmd /c'``. The ``SHELL`` env var is ignored as it is a less reliable default.
+  ``'cmd /c'``. The ``SHELL`` env var is ignored as it is an unreliable default.
 * ``cache``, *str*: can be used to specify where the cache for the benchmarks
   should be stored. By default, the cache files are stored in the benchmark
   directory, under the folder __cache__. Setting this configuration would

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -55,7 +55,8 @@ particular for logging, warnings and errors. The available options are:
 * ``shell``, *str*: can be used to specify the shell to use. On POSIX systems
   it defaults to the ``SHELL`` env var if it exists and
   ``'bash --norc --noprofile'`` otherwise. On Windows it defaults to
-  ``'cmd /c'``. The ``SHELL`` env var is ignored as it is an unreliable default.
+  ``'cmd /c'``. The ``SHELL`` env var is ignored as it is an less reliable
+  default (running conda with it often fails).
 * ``cache``, *str*: can be used to specify where the cache for the benchmarks
   should be stored. By default, the cache files are stored in the benchmark
   directory, under the folder __cache__. Setting this configuration would

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -55,7 +55,7 @@ particular for logging, warnings and errors. The available options are:
 * ``shell``, *str*: can be used to specify the shell to use. On POSIX systems
   it defaults to the ``SHELL`` env var if it exists and
   ``'bash --norc --noprofile'`` otherwise. On Windows it defaults to
-  ``'cmd /c'`` and the ``SHELL`` env var is ignored as it is not reliable.
+  ``'cmd /c'``. The ``SHELL`` env var is ignored as it is a less reliable default.
 * ``cache``, *str*: can be used to specify where the cache for the benchmarks
   should be stored. By default, the cache files are stored in the benchmark
   directory, under the folder __cache__. Setting this configuration would

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -27,8 +27,11 @@ DEFAULT_GLOBAL_CONFIG = {
     'github_token': None,
     'hf_token': None,
     'data_dir': './data/',
-    'conda_cmd': 'conda' if sys.platform != 'win32' else 'call conda',
-    'shell': os.environ.get('SHELL', DEFAULT_SHELL),
+    'conda_cmd': 'conda',
+    'shell': (
+        os.environ.get('SHELL', DEFAULT_SHELL)
+        if sys.platform != 'win32' else DEFAULT_SHELL
+    ),
     'cache': None,
     'default_timeout': 100,
     'warn_nonunique_files': True,
@@ -49,8 +52,12 @@ particular for logging, warnings and errors. The available options are:
 * ``conda_cmd``, *str*: can be used to give the path to ``conda`` if it is
   not directly installed on ``$PATH``. This can also be used to use ``mamba``
   to install benchmarks instead of conda. See :ref:`config_mamba`.
-* ``shell``, *str*: can be used to specify the shell to use. Default to
-  `SHELL` from env if it exists and ``'bash'`` otherwise.
+* ``shell``, *str*: can be used to specify the shell to use. On POSIX systems
+  it defaults to the ``SHELL`` env var if it exists and
+  ``'bash --norc --noprofile'`` otherwise. On Windows it defaults to
+  ``'cmd /c'`` and the ``SHELL`` env var is ignored (a POSIX ``SHELL`` set by
+  Git Bash or MSYS would otherwise break conda handling); override it
+  explicitly with the ``BENCHOPT_SHELL`` env var or this setting.
 * ``cache``, *str*: can be used to specify where the cache for the benchmarks
   should be stored. By default, the cache files are stored in the benchmark
   directory, under the folder __cache__. Setting this configuration would

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -14,25 +14,14 @@ from ..config import DEBUG
 from ..config import get_setting
 
 SHELL = get_setting('shell')
+CONDA_CMD = get_setting('conda_cmd')
 
-
-def _conda_cmd(conda_cmd, is_cmd):
-    """Prefix the conda command with ``CALL`` when running under cmd.
-
-    Under cmd, calling conda without ``call`` exits the batch script:
-    https://github.com/conda/conda/issues/12418
-
-    This is gated on `is_cmd` (whether benchopt is generating a cmd/.bat
-    script) rather than ``sys.platform``, so the prefix stays consistent with
-    the shell the script actually runs in; a bash shell on Windows gets a plain
-    ``conda`` in a bash script.
-    """
-    if is_cmd and not conda_cmd.lower().startswith('call'):
-        return f"CALL {conda_cmd}"
-    return conda_cmd
-
-
-CONDA_CMD = _conda_cmd(get_setting('conda_cmd'), IS_CMD)
+# In CMD, calling conda without `call` exits the batch script:
+# https://github.com/conda/conda/issues/12418
+# Gate this on the shell benchopt generates scripts for (IS_CMD) rather than
+# `sys.platform`, so a bash shell on Windows gets a plain `conda`.
+if IS_CMD and not CONDA_CMD.lower().startswith('call'):
+    CONDA_CMD = f"CALL {CONDA_CMD}"
 
 DEFAULT_PYTHON_VERSION = '3.12'
 

--- a/benchopt/utils/conda_env_cmd.py
+++ b/benchopt/utils/conda_env_cmd.py
@@ -1,11 +1,11 @@
 import os
 import re
-import sys
 import warnings
 from pathlib import Path
 
 import benchopt
 
+from .shell_cmd import IS_CMD
 from .shell_cmd import _run_shell
 from .shell_cmd import _run_shell_in_conda_env
 from .misc import get_benchopt_requirement, NamedTemporaryFile
@@ -14,12 +14,25 @@ from ..config import DEBUG
 from ..config import get_setting
 
 SHELL = get_setting('shell')
-CONDA_CMD = get_setting('conda_cmd')
 
-# On windows, calling conda without call exit the cmd script:
-# https://github.com/conda/conda/issues/12418
-if sys.platform == 'win32' and not CONDA_CMD.lower().startswith('call'):
-    CONDA_CMD = f"CALL {CONDA_CMD}"
+
+def _conda_cmd(conda_cmd, is_cmd):
+    """Prefix the conda command with ``CALL`` when running under cmd.
+
+    Under cmd, calling conda without ``call`` exits the batch script:
+    https://github.com/conda/conda/issues/12418
+
+    This is gated on `is_cmd` (whether benchopt is generating a cmd/.bat
+    script) rather than ``sys.platform``, so the prefix stays consistent with
+    the shell the script actually runs in; a bash shell on Windows gets a plain
+    ``conda`` in a bash script.
+    """
+    if is_cmd and not conda_cmd.lower().startswith('call'):
+        return f"CALL {conda_cmd}"
+    return conda_cmd
+
+
+CONDA_CMD = _conda_cmd(get_setting('conda_cmd'), IS_CMD)
 
 DEFAULT_PYTHON_VERSION = '3.12'
 

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -18,10 +18,7 @@ def _split_shell(shell):
     """Split a shell setting into its program and arguments.
 
     The `shell` setting carries arguments by design (e.g. ``'cmd /c'`` or
-    ``'bash --norc --noprofile'``), so it cannot be quoted as a whole. Split it
-    into a list suitable for `subprocess.run` without an extra `shell=True`
-    layer, which also handles a shell *path* that contains spaces (e.g. Git
-    Bash on Windows).
+    ``'bash --norc --noprofile'``), so it cannot be quoted as a whole.
     """
     # posix=False keeps Windows backslashes intact but retains surrounding
     # quotes on each token, so strip them there.

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -91,8 +91,8 @@ def _run_shell(script, raise_on_error=None, capture_stdout=True,
     if raise_on_error is True:
         raise_on_error = "{output}"
 
-    # Invoke the script directly with the configured shell, without going
-    # through an extra `shell=True` layer that would re-parse the command line.
+    # Pass the shell and script as an argument list so subprocess invokes them
+    # directly, without re-parsing (and mangling) a shell path that has spaces.
     command = [*_split_shell(SHELL), tmp.name]
 
     if capture_stdout:

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -96,7 +96,7 @@ def _run_shell(script, raise_on_error=None, capture_stdout=True,
     command = [*_split_shell(SHELL), tmp.name]
 
     if capture_stdout:
-        # Merge stderr into stdout (preserving order, as getstatusoutput did)
+        # Merge stderr into stdout, and strip empty line
         # so callers parsing the last output line as JSON keep working.
         res = subprocess.run(
             command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,

--- a/benchopt/utils/shell_cmd.py
+++ b/benchopt/utils/shell_cmd.py
@@ -1,3 +1,5 @@
+import sys
+import shlex
 import subprocess
 
 from ..config import DEBUG
@@ -10,6 +12,23 @@ SHELL = get_setting('shell')
 
 IS_FISH = 'fish' in f"{SHELL}"
 IS_CMD = 'cmd' in f"{SHELL}"
+
+
+def _split_shell(shell):
+    """Split a shell setting into its program and arguments.
+
+    The `shell` setting carries arguments by design (e.g. ``'cmd /c'`` or
+    ``'bash --norc --noprofile'``), so it cannot be quoted as a whole. Split it
+    into a list suitable for `subprocess.run` without an extra `shell=True`
+    layer, which also handles a shell *path* that contains spaces (e.g. Git
+    Bash on Windows).
+    """
+    # posix=False keeps Windows backslashes intact but retains surrounding
+    # quotes on each token, so strip them there.
+    parts = shlex.split(shell, posix=(sys.platform != 'win32'))
+    if sys.platform == 'win32':
+        parts = [p.strip('"') for p in parts]
+    return parts
 
 
 def _run_shell(script, raise_on_error=None, capture_stdout=True,
@@ -72,13 +91,30 @@ def _run_shell(script, raise_on_error=None, capture_stdout=True,
     if raise_on_error is True:
         raise_on_error = "{output}"
 
-    command = f'{SHELL} "{tmp.name}"'
+    # Invoke the script directly with the configured shell, without going
+    # through an extra `shell=True` layer that would re-parse the command line.
+    command = [*_split_shell(SHELL), tmp.name]
 
     if capture_stdout:
-        exit_code, output = subprocess.getstatusoutput(command)
+        # Merge stderr into stdout (preserving order, as getstatusoutput did)
+        # so callers parsing the last output line as JSON keep working.
+        res = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, errors='replace',
+        )
+        exit_code = res.returncode
+        output = res.stdout
+        if output.endswith('\n'):
+            output = output[:-1]
     else:
-        exit_code = subprocess.run(command, shell=True, stdin=None).returncode
-        output = ""
+        # Let stdout stream to the console, but capture stderr when we might
+        # raise so the underlying error is surfaced instead of being lost.
+        res = subprocess.run(
+            command, stderr=subprocess.PIPE if raise_on_error else None,
+            text=True, errors='replace',
+        )
+        exit_code = res.returncode
+        output = res.stderr if (raise_on_error and res.stderr) else ""
     if raise_on_error is not None and exit_code != 0:
         if isinstance(raise_on_error, str):
             raise RuntimeError(raise_on_error.format(output=output))

--- a/benchopt/utils/tests/test_conda_env_cmd.py
+++ b/benchopt/utils/tests/test_conda_env_cmd.py
@@ -1,8 +1,43 @@
+import pytest
+
+from benchopt.utils.shell_cmd import _split_shell
+from benchopt.utils.conda_env_cmd import _conda_cmd
 from benchopt.utils.conda_env_cmd import get_env_file_from_requirements
 from benchopt.config import get_setting
 
 
 CONDA_CMD = get_setting("conda_cmd")
+
+
+@pytest.mark.parametrize("shell, expected", [
+    ("cmd /c", ["cmd", "/c"]),
+    ("bash --norc --noprofile", ["bash", "--norc", "--noprofile"]),
+    ("bash", ["bash"]),
+])
+def test_split_shell(shell, expected):
+    # The shell setting carries its arguments, so it must be split (not quoted
+    # as a whole) before being handed to subprocess.
+    assert _split_shell(shell) == expected
+
+
+def test_split_shell_spaced_path(monkeypatch):
+    # A shell path that contains spaces (e.g. Git Bash on Windows) must be
+    # expressible by quoting it, and the quotes stripped so it resolves.
+    monkeypatch.setattr("benchopt.utils.shell_cmd.sys.platform", "win32")
+    shell = '"C:\\Program Files\\Git\\bin\\bash.EXE" --norc'
+    assert _split_shell(shell) == [
+        "C:\\Program Files\\Git\\bin\\bash.EXE", "--norc"
+    ]
+
+
+def test_conda_cmd_call_prefix():
+    # Under cmd, conda is prefixed with CALL; otherwise it is left untouched,
+    # so the prefix always matches the shell the script runs in.
+    assert _conda_cmd("conda", is_cmd=True) == "CALL conda"
+    assert _conda_cmd("conda", is_cmd=False) == "conda"
+    assert _conda_cmd("mamba", is_cmd=True) == "CALL mamba"
+    # An explicit `call conda` is not doubled.
+    assert _conda_cmd("call conda", is_cmd=True) == "call conda"
 
 
 def test_requirements_conda():

--- a/benchopt/utils/tests/test_conda_env_cmd.py
+++ b/benchopt/utils/tests/test_conda_env_cmd.py
@@ -1,7 +1,6 @@
 import pytest
 
 from benchopt.utils.shell_cmd import _split_shell
-from benchopt.utils.conda_env_cmd import _conda_cmd
 from benchopt.utils.conda_env_cmd import get_env_file_from_requirements
 from benchopt.config import get_setting
 
@@ -28,16 +27,6 @@ def test_split_shell_spaced_path(monkeypatch):
     assert _split_shell(shell) == [
         "C:\\Program Files\\Git\\bin\\bash.EXE", "--norc"
     ]
-
-
-def test_conda_cmd_call_prefix():
-    # Under cmd, conda is prefixed with CALL; otherwise it is left untouched,
-    # so the prefix always matches the shell the script runs in.
-    assert _conda_cmd("conda", is_cmd=True) == "CALL conda"
-    assert _conda_cmd("conda", is_cmd=False) == "conda"
-    assert _conda_cmd("mamba", is_cmd=True) == "CALL mamba"
-    # An explicit `call conda` is not doubled.
-    assert _conda_cmd("call conda", is_cmd=True) == "call conda"
 
 
 def test_requirements_conda():

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -68,6 +68,14 @@ TST
 FIX
 ~~~
 
+- Fix shell handling on Windows so ``benchopt install``/``test`` work with a
+  bash-like ``SHELL`` (e.g. GitHub ``shell: bash`` runners). The shell is now
+  invoked as an argument list (handling spaces in the shell path), the conda
+  ``CALL`` prefix is kept consistent with the shell benchopt generates scripts
+  for, on Windows the ``SHELL`` env var no longer overrides the ``cmd /c``
+  default (use ``BENCHOPT_SHELL`` to override), and the underlying error is now
+  surfaced instead of swallowed. By `Johan Larsson`_
+
 - Fix ``benchopt sync-skills`` symlink with global install for Claude.
   By `Thomas Moreau`_ (:gh:`969`)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -69,12 +69,10 @@ FIX
 ~~~
 
 - Fix shell handling on Windows so ``benchopt install``/``test`` work with a
-  bash-like ``SHELL`` (e.g. GitHub ``shell: bash`` runners). The shell is now
-  invoked as an argument list (handling spaces in the shell path), the conda
-  ``CALL`` prefix is kept consistent with the shell benchopt generates scripts
-  for, on Windows the ``SHELL`` env var no longer overrides the ``cmd /c``
-  default (use ``BENCHOPT_SHELL`` to override), and the underlying error is now
-  surfaced instead of swallowed. By `Johan Larsson`_
+  bash-like shell (e.g. GitHub ``shell: bash`` runners).
+  On Windows the ``SHELL`` env var is now ignored, use ``BENCHOPT_SHELL``
+  to override it. Underlying shell errors are also better reported,
+  instead of being swallowed. By `Johan Larsson`_ (:gh:`974`)
 
 - Fix ``benchopt sync-skills`` symlink with global install for Claude.
   By `Thomas Moreau`_ (:gh:`969`)


### PR DESCRIPTION
`benchopt install`/`test` broke on Windows when the CI step ran under a bash shell (e.g. `shell: bash`), where `$SHELL` is a git-bash path. benchopt then emitted a bash script containing `CALL conda` and invoked it with an unquoted, space-bearing path, and swallowed the real error.

Here are the changes:

- Invoke the shell as an argument list (`_split_shell`), handling spaces in the shell path and dropping the redundant `shell=True` layer.
- Gate the conda `CALL` prefix on cmd detection (`_conda_cmd`) instead of `sys.platform`, so it matches the shell benchopt generates scripts for.
- On Windows, ignore a bash-like `$SHELL` and default to `cmd /c`; override with `BENCHOPT_SHELL`.
- Surface the underlying error when `capture_stdout=False` instead of raising an empty `RuntimeError`.
- Add a `test_windows_bash` CI job that reproduces the scenario, plus unit tests for the new helpers.

I used Claude to out with the PR as well as the PR summary above.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
