### PR TITLE
ENH skip dispatching parallel jobs for cached run/prepare

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -437,6 +437,37 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
             dataset.get_data()
 
 
+def _ignore_base_seed(dataset):
+    """Datasets whose preparation does not depend on the seed can drop it
+    from the cache key by listing 'base_seed' in prepare_cache_ignore."""
+    cache_ignore = getattr(type(dataset), 'prepare_cache_ignore', ())
+    if cache_ignore == "all" or 'base_seed' in cache_ignore:
+        return ['base_seed']
+    return None
+
+
+def _cached_prepare(benchmark, dataset, force=False):
+    """Single source of truth for the cached ``_prepare`` of a dataset, so the
+    cache lookup (`_check_prepare_in_cache`) and the actual call (`_prepare_one`)
+    can never drift on the func/ignore that define the cache key."""
+    return benchmark.cache(
+        BaseDataset._prepare, ignore=_ignore_base_seed(dataset), force=force,
+    )
+
+
+def _check_prepare_in_cache(benchmark, dataset, force=False):
+    """Cheap, frontal-node cache lookup for a dataset preparation.
+
+    Mirrors the cache key built in `_prepare_one`, so `parallel_run` can skip
+    dispatching an already-prepared dataset as a job. `force` is ignored here:
+    it does not change the cache key, and `parallel_run` already gates the
+    skip on `not force` so a forced run is always dispatched.
+    """
+    return _cached_prepare(benchmark, dataset).check_call_in_cache(
+        dataset=dataset, base_seed=benchmark.seed
+    )
+
+
 def _prepare_one(benchmark, dataset, force=False):
     """Prepare one dataset instance; used as the unit of work in parallel_run.
 
@@ -446,16 +477,7 @@ def _prepare_one(benchmark, dataset, force=False):
     success or the caught exception on failure.
     """
     exc = None
-    # Datasets whose preparation does not depend on the seed can drop it from
-    # the cache key by listing 'base_seed' in prepare_cache_ignore,
-    # handle this separately.
-    cache_ignore = getattr(type(dataset), 'prepare_cache_ignore', ())
-    ignore = ['base_seed'] if (
-        cache_ignore == "all" or 'base_seed' in cache_ignore
-    ) else None
-    cached_prepare = benchmark.cache(
-        BaseDataset._prepare, ignore=ignore, force=force
-    )
+    cached_prepare = _cached_prepare(benchmark, dataset, force=force)
     print(f"Preparing {dataset} ...", end=' ', flush=True)
     try:
         cached_prepare(dataset=dataset, base_seed=benchmark.seed)
@@ -467,6 +489,9 @@ def _prepare_one(benchmark, dataset, force=False):
     finally:
         print(end='', flush=True)
         return (str(dataset), exc)
+
+
+_prepare_one.check_call_in_cache = _check_prepare_in_cache
 
 
 class BaseObjective(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,

--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -6,6 +6,7 @@ from .stopping_criterion import SingleRunCriterion
 from .stopping_criterion import SufficientProgressCriterion
 
 from .utils.misc import NamedTemporaryFile
+from .utils.terminal_output import colorify, CYAN
 from .utils.class_property import classproperty
 from .utils.dependencies_mixin import DependenciesMixin
 from .utils.parametrized_name_mixin import ParametrizedNameMixin
@@ -478,10 +479,14 @@ def _prepare_one(benchmark, dataset, force=False):
     """
     exc = None
     cached_prepare = _cached_prepare(benchmark, dataset, force=force)
+    # `force` recomputes even on a cache hit, so only flag genuine cache loads.
+    cached = not force and cached_prepare.check_call_in_cache(
+        dataset=dataset, base_seed=benchmark.seed
+    )
     print(f"Preparing {dataset} ...", end=' ', flush=True)
     try:
         cached_prepare(dataset=dataset, base_seed=benchmark.seed)
-        print("done")
+        print("done" + (colorify(" (cached)", CYAN) if cached else ""))
     except Exception as e:
         print("FAILED")
         print_exc()

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -495,47 +495,38 @@ class Benchmark:
 
         return Path(benchopt_cache_dir) / self.name
 
-    def cache(self, func, force=False, ignore=None, collect=False):
+    def cache(self, func, force=False, ignore=None):
         """Create a cached function for the given function.
 
         A special behavior is enforced for the 'force' kwargs. If it is present
-        and True, the function will always be recomputed.
-
-        If the collect flag is set to True, the function will return the result
-        if it exists, or None if it does not. This is useful to gather results
-        that are already in cache.
+        and True, the function will always be recomputed. The returned function
+        exposes `check_call_in_cache` to test for a cache hit without running.
         """
         if self.no_cache:
-            assert not collect, "Cannot collect when using `--no-cache`."
-            return func
+            # Wrap `func` so we can expose a cache lookup that always reports a
+            # miss (callers can query it uniformly without guarding for its
+            # absence) without mutating the shared module-level `func`.
+            def _func_no_cache(**kwargs):
+                return func(**kwargs)
+
+            _func_no_cache.check_call_in_cache = lambda **kwargs: False
+            return _func_no_cache
 
         # Create a cached version of `func` and handle cases where we force
         # the run.
         func_cached = self.mem.cache(func, ignore=ignore)
         if force:
-            assert not collect, "Cannot collect and force computation."
-
             def _func_cached(**kwargs):
                 return func_cached.call(**kwargs)[0]
-        elif collect:
-            def _func_cached(**kwargs):
-                assert not kwargs.get('force', False), (
-                    "Cannot collect and force computation."
-                )
-                if func_cached.check_call_in_cache(**kwargs):
-                    return func_cached(**kwargs)
-                key = (
-                    kwargs['meta']['dataset_name'],
-                    kwargs['meta']['objective_name'],
-                    kwargs['meta']['solver_name']
-                )
-                return ([], key, 'not run yet', "")
         else:
             def _func_cached(**kwargs):
                 if kwargs.get('force', False):
                     return func_cached.call(**kwargs)[0]
                 return func_cached(**kwargs)
 
+        # Expose the cache lookup so callers can detect already-computed runs
+        # on the frontal node and avoid dispatching them as parallel jobs.
+        _func_cached.check_call_in_cache = func_cached.check_call_in_cache
         return _func_cached
 
     #####################################################
@@ -833,7 +824,7 @@ class Benchmark:
             config=parallel_config,
         )
 
-        n_failed = sum(1 for _, err in results if err is not None)
+        n_failed = sum(1 for _, (_, err) in results if err is not None)
         if n_failed:
             print(
                 f"Summary: {n_total - n_failed}/{n_total} datasets ready, "

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -503,9 +503,8 @@ class Benchmark:
         exposes `check_call_in_cache` to test for a cache hit without running.
         """
         if self.no_cache:
-            # Wrap `func` so we can expose a cache lookup that always reports a
-            # miss (callers can query it uniformly without guarding for its
-            # absence) without mutating the shared module-level `func`.
+            # Wrap `func` to expose a cache lookup without mutating the
+            # shared module-level `func`.
             def _func_no_cache(**kwargs):
                 return func(**kwargs)
 
@@ -524,8 +523,7 @@ class Benchmark:
                     return func_cached.call(**kwargs)[0]
                 return func_cached(**kwargs)
 
-        # Expose the cache lookup so callers can detect already-computed runs
-        # on the frontal node and avoid dispatching them as parallel jobs.
+        # Expose the cache lookup to collect and avoid unneeded dispatch.
         _func_cached.check_call_in_cache = func_cached.check_call_in_cache
         return _func_cached
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -822,7 +822,7 @@ class Benchmark:
             config=parallel_config,
         )
 
-        n_failed = sum(1 for _, (_, err) in results if err is not None)
+        n_failed = sum(1 for _, err, _cached in results if err is not None)
         if n_failed:
             print(
                 f"Summary: {n_total - n_failed}/{n_total} datasets ready, "

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -230,6 +230,11 @@ def run(config_file=None, **kwargs):
             'You cannot specify both --timeout and --no-timeout options.'
         )
 
+    if collect and no_cache:
+        raise click.BadParameter(
+            'You cannot use --collect with --no-cache.'
+        )
+
     if not no_timeout:
         if timeout is None:
             timeout = get_setting('default_timeout')

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -278,6 +278,89 @@ class TestPrepareCmd:
                 )
             out.check_output("#PREPARED", repetition=1)
 
+    def test_prepared_datasets_not_dispatched(self, monkeypatch):
+        # A cached dataset prep must be detected on the frontal node (the
+        # main process) and not dispatched to a worker, mirroring
+        # test_cached_runs_not_dispatched for the run() path.
+        import os
+        from benchopt import benchmark as benchmark_module
+
+        main_pid = os.getpid()
+        orig_cache = benchmark_module.Benchmark.cache
+
+        def cache_reporting_pid(self, func, *args, **kwargs):
+            cached = orig_cache(self, func, *args, **kwargs)
+            check = cached.check_call_in_cache
+
+            def check_call_in_cache(**kw):
+                print(f"#CHECK_PID:{os.getpid()}")
+                return check(**kw)
+
+            cached.check_call_in_cache = check_call_in_cache
+            return cached
+
+        monkeypatch.setattr(
+            benchmark_module.Benchmark, "cache", cache_reporting_pid
+        )
+
+        orig_prepare_one = benchmark_module._prepare_one
+
+        def prepare_one_reporting_pid(*args, **kwargs):
+            print(f"#PREPARE_PID:{os.getpid()}")
+            return orig_prepare_one(*args, **kwargs)
+
+        # Forward check_call_in_cache, same as _prepare_one itself exposes,
+        # so the dispatch-skip logic in parallel_run still sees it.
+        prepare_one_reporting_pid.check_call_in_cache = (
+            orig_prepare_one.check_call_in_cache
+        )
+        monkeypatch.setattr(
+            benchmark_module, "_prepare_one", prepare_one_reporting_pid
+        )
+
+        with temp_benchmark(datasets=self.dataset) as bench:
+            cmd = f"{bench.benchmark_dir} -j 2"
+            with CaptureCmdOutput() as out_first:
+                prepare_cmd(cmd.split(), 'benchopt', standalone_mode=False)
+            with CaptureCmdOutput() as out_second:
+                prepare_cmd(cmd.split(), 'benchopt', standalone_mode=False)
+            with CaptureCmdOutput() as out_forced:
+                prepare_cmd(
+                    f"{cmd} --force".split(), 'benchopt', standalone_mode=False
+                )
+
+        # First run: nothing cached, so prepare runs in a dispatched worker
+        # process, not in the main one.
+        prepare_pids = {
+            int(p) for p in out_first.check_output(r"#PREPARE_PID:(\d+)")
+        }
+        assert prepare_pids and main_pid not in prepare_pids, prepare_pids
+
+        # The cache check always runs on the frontal (main) process.
+        check_pids = {
+            int(p) for p in out_second.check_output(r"#CHECK_PID:(\d+)")
+        }
+        assert check_pids == {main_pid}, check_pids
+
+        # Second run: everything is cached, so _prepare_one is called
+        # directly on the frontal node instead of being dispatched to a
+        # worker, and the dataset's own prepare() is not re-run.
+        prepare_pids_second = {
+            int(p) for p in out_second.check_output(r"#PREPARE_PID:(\d+)")
+        }
+        assert prepare_pids_second == {main_pid}, prepare_pids_second
+        out_second.check_output("#PREPARED", repetition=0)
+
+        # --force must bypass the skip even when cached: the prep is dispatched
+        # to a worker (not the main process) and the dataset's prepare() runs.
+        prepare_pids_forced = {
+            int(p) for p in out_forced.check_output(r"#PREPARE_PID:(\d+)")
+        }
+        assert prepare_pids_forced and main_pid not in prepare_pids_forced, (
+            prepare_pids_forced
+        )
+        out_forced.check_output("#PREPARED", repetition=1)
+
     def test_force_flag(self, tmp_path):
         """--force re-runs preparation even when cached."""
         with temp_benchmark(datasets=self.dataset) as bench:

--- a/benchopt/cli/tests/test_cmd_prepare.py
+++ b/benchopt/cli/tests/test_cmd_prepare.py
@@ -335,6 +335,7 @@ class TestPrepareCmd:
             int(p) for p in out_first.check_output(r"#PREPARE_PID:(\d+)")
         }
         assert prepare_pids and main_pid not in prepare_pids, prepare_pids
+        out_first.check_output(r"done \(cached\)", repetition=0)
 
         # The cache check always runs on the frontal (main) process.
         check_pids = {
@@ -350,6 +351,8 @@ class TestPrepareCmd:
         }
         assert prepare_pids_second == {main_pid}, prepare_pids_second
         out_second.check_output("#PREPARED", repetition=0)
+        # ... and the cached load is reported as such in the status line.
+        out_second.check_output(r"done \(cached\)", repetition=1)
 
         # --force must bypass the skip even when cached: the prep is dispatched
         # to a worker (not the main process) and the dataset's prepare() runs.
@@ -360,6 +363,8 @@ class TestPrepareCmd:
             prepare_pids_forced
         )
         out_forced.check_output("#PREPARED", repetition=1)
+        # A forced prep recomputes, so it is not reported as cached.
+        out_forced.check_output(r"done \(cached\)", repetition=0)
 
     def test_force_flag(self, tmp_path):
         """--force re-runs preparation even when cached."""

--- a/benchopt/parallel_backends/__init__.py
+++ b/benchopt/parallel_backends/__init__.py
@@ -62,8 +62,12 @@ def _dispatch(backend, benchmark, run, run_kwargs_iter, config):
         if backend == 'dask':
             from .dask_backend import check_dask_config
             config = check_dask_config(config)
+        # `batch_size` is a `Parallel` argument, not a `parallel_config` one.
+        batch_size = config.pop('batch_size', 'auto')
         with parallel_config(backend, **config):
-            yield from Parallel(return_as="generator_unordered")(
+            yield from Parallel(
+                return_as="generator_unordered", batch_size=batch_size
+            )(
                 delayed(run)(**run_kwargs) for run_kwargs in run_kwargs_iter
             )
 

--- a/benchopt/parallel_backends/__init__.py
+++ b/benchopt/parallel_backends/__init__.py
@@ -1,4 +1,5 @@
 import yaml
+from collections import deque
 from joblib import parallel_config
 from joblib import Parallel, delayed
 
@@ -16,6 +17,57 @@ def is_distributed_frontal():
     return _DISTRIBUTED_FRONTAL
 
 
+def _tag_cached_runs(run, run_kwargs_generator, collect):
+    """Tag each run, in generation order, as one of:
+
+    - ``'cached'``: already computed, loaded here on the frontal node (cheap,
+      it does not load the data) instead of being dispatched as a job (e.g. a
+      SLURM job just to hit the cache).
+    - ``'result'``: a ready result that is not a cache hit. In ``collect``
+      mode, runs missing from the cache are reported as ``'not run yet'``
+      rather than being computed.
+    - ``'dispatch'``: a cache miss that must be run on the parallel backend.
+    """
+    check_in_cache = getattr(run, "check_call_in_cache", None)
+    for run_kwargs in run_kwargs_generator:
+        if (check_in_cache is not None
+                and not run_kwargs.get('force', False)
+                and check_in_cache(**run_kwargs)):
+            yield 'cached', run(**run_kwargs)
+        elif collect:
+            # Collect mode only gathers cached runs; flag the rest as missing.
+            meta = run_kwargs['meta']
+            key = (
+                meta['dataset_name'],
+                meta['objective_name'],
+                meta['solver_name'],
+            )
+            yield 'result', ([], key, 'not run yet', "")
+        else:
+            yield 'dispatch', run_kwargs
+
+
+def _dispatch(backend, benchmark, run, run_kwargs_iter, config):
+    """Run ``run(**kwargs)`` for each kwargs on the chosen backend, yielding
+    results as they complete.
+
+    This is the only backend-specific piece: a thin adapter turning an iterator
+    of run kwargs into an iterator of results. Backends consume the kwargs
+    lazily (loky/dask, bounded by ``pre_dispatch``) or in one batch (submitit).
+    """
+    if backend == 'submitit':
+        from .slurm_executor import run_on_slurm
+        yield from run_on_slurm(benchmark, config, run, run_kwargs_iter)
+    else:
+        if backend == 'dask':
+            from .dask_backend import check_dask_config
+            config = check_dask_config(config)
+        with parallel_config(backend, **config):
+            yield from Parallel(return_as="generator_unordered")(
+                delayed(run)(**run_kwargs) for run_kwargs in run_kwargs_iter
+            )
+
+
 def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
     config = config or {}
     backend = config.pop('backend', 'loky')
@@ -24,22 +76,30 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
     assert backend in DISTRIBUTED_BACKENDS, (
         f"Unknown backend {backend}. Valid backends: {DISTRIBUTED_BACKENDS}."
     )
-    if backend == 'submitit':
-        from .slurm_executor import run_on_slurm
-        results_generator = run_on_slurm(
-            benchmark, config, run, run_kwargs_generator
-        )
-    else:
-        if backend == 'dask':
-            from .dask_backend import check_dask_config
-            config = check_dask_config(config)
-        with parallel_config(backend, **config):
-            results_generator = Parallel(return_as="generator_unordered")(
-                delayed(run)(**run_kwargs)
-                for run_kwargs in run_kwargs_generator
-            )
 
-    return results_generator
+    # Cache hits are loaded on the frontal node and parked in `ready`; only the
+    # misses are dispatched. The dispatch stays backend-agnostic and lazy (we
+    # never hold all the runs, each carrying its loaded data, in memory): the
+    # backend pulls `_to_dispatch` on demand, and cache hits seen meanwhile are
+    # merged back into the result stream.
+    ready = deque()
+
+    def _to_dispatch():
+        for tag, item in _tag_cached_runs(run, run_kwargs_generator, collect):
+            if tag == 'dispatch':
+                yield item
+            else:
+                ready.append(((tag == 'cached'), item))
+
+    def _results():
+        for item in _dispatch(backend, benchmark, run, _to_dispatch(), config):
+            while ready:
+                yield ready.popleft()
+            yield False, item
+        while ready:
+            yield ready.popleft()
+
+    return _results()
 
 
 def check_parallel_config(parallel_config_file, n_jobs):

--- a/benchopt/parallel_backends/__init__.py
+++ b/benchopt/parallel_backends/__init__.py
@@ -17,36 +17,6 @@ def is_distributed_frontal():
     return _DISTRIBUTED_FRONTAL
 
 
-def _tag_cached_runs(run, run_kwargs_generator, collect):
-    """Tag each run, in generation order, as one of:
-
-    - ``'cached'``: already computed, loaded here on the frontal node (cheap,
-      it does not load the data) instead of being dispatched as a job (e.g. a
-      SLURM job just to hit the cache).
-    - ``'result'``: a ready result that is not a cache hit. In ``collect``
-      mode, runs missing from the cache are reported as ``'not run yet'``
-      rather than being computed.
-    - ``'dispatch'``: a cache miss that must be run on the parallel backend.
-    """
-    check_in_cache = getattr(run, "check_call_in_cache", None)
-    for run_kwargs in run_kwargs_generator:
-        if (check_in_cache is not None
-                and not run_kwargs.get('force', False)
-                and check_in_cache(**run_kwargs)):
-            yield 'cached', run(**run_kwargs)
-        elif collect:
-            # Collect mode only gathers cached runs; flag the rest as missing.
-            meta = run_kwargs['meta']
-            key = (
-                meta['dataset_name'],
-                meta['objective_name'],
-                meta['solver_name'],
-            )
-            yield 'result', ([], key, 'not run yet', "")
-        else:
-            yield 'dispatch', run_kwargs
-
-
 def _dispatch(backend, benchmark, run, run_kwargs_iter, config):
     """Run ``run(**kwargs)`` for each kwargs on the chosen backend, yielding
     results as they complete.
@@ -81,19 +51,34 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
         f"Unknown backend {backend}. Valid backends: {DISTRIBUTED_BACKENDS}."
     )
 
-    # Cache hits are loaded on the frontal node and parked in `ready`; only the
-    # misses are dispatched. The dispatch stays backend-agnostic and lazy (we
-    # never hold all the runs, each carrying its loaded data, in memory): the
-    # backend pulls `_to_dispatch` on demand, and cache hits seen meanwhile are
-    # merged back into the result stream.
+    # Cache hits (and, in `collect` mode, cache misses that are skipped) are
+    # loaded on the frontal node and parked in `ready`; only genuine misses
+    # are dispatched. The dispatch stays backend-agnostic and lazy (we never
+    # hold all the runs, each carrying its loaded data, in memory): the
+    # backend pulls `_to_dispatch` on demand, and items parked in `ready`
+    # meanwhile are merged back into the result stream.
     ready = deque()
+    check_in_cache = getattr(run, "check_call_in_cache", None)
 
     def _to_dispatch():
-        for tag, item in _tag_cached_runs(run, run_kwargs_generator, collect):
-            if tag == 'dispatch':
-                yield item
+        for run_kwargs in run_kwargs_generator:
+            if (check_in_cache is not None
+                    and not run_kwargs.get('force', False)
+                    and check_in_cache(**run_kwargs)):
+                ready.append((True, run(**run_kwargs)))
+            elif collect:
+                # Collect mode only gathers cached runs; flag the rest as
+                # missing instead of computing them (e.g. a SLURM job just
+                # to hit the cache).
+                meta = run_kwargs['meta']
+                key = (
+                    meta['dataset_name'],
+                    meta['objective_name'],
+                    meta['solver_name'],
+                )
+                ready.append((False, ([], key, 'not run yet', "")))
             else:
-                ready.append(((tag == 'cached'), item))
+                yield run_kwargs
 
     def _results():
         for item in _dispatch(backend, benchmark, run, _to_dispatch(), config):

--- a/benchopt/parallel_backends/__init__.py
+++ b/benchopt/parallel_backends/__init__.py
@@ -56,7 +56,9 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
     # are dispatched. The dispatch stays backend-agnostic and lazy (we never
     # hold all the runs, each carrying its loaded data, in memory): the
     # backend pulls `_to_dispatch` on demand, and items parked in `ready`
-    # meanwhile are merged back into the result stream.
+    # meanwhile are merged back into the result stream. `cached` is appended
+    # as the last element of each yielded tuple, so the item itself (whose
+    # shape is backend/run-specific) stays untouched.
     ready = deque()
     check_in_cache = getattr(run, "check_call_in_cache", None)
 
@@ -65,7 +67,7 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
             if (check_in_cache is not None
                     and not run_kwargs.get('force', False)
                     and check_in_cache(**run_kwargs)):
-                ready.append((True, run(**run_kwargs)))
+                ready.append((*run(**run_kwargs), True))
             elif collect:
                 # Collect mode only gathers cached runs; flag the rest as
                 # missing instead of computing them (e.g. a SLURM job just
@@ -76,7 +78,7 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
                     meta['objective_name'],
                     meta['solver_name'],
                 )
-                ready.append((False, ([], key, 'not run yet', "")))
+                ready.append(([], key, 'not run yet', "", False))
             else:
                 yield run_kwargs
 
@@ -84,7 +86,7 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
         for item in _dispatch(backend, benchmark, run, _to_dispatch(), config):
             while ready:
                 yield ready.popleft()
-            yield False, item
+            yield (*item, False)
         while ready:
             yield ready.popleft()
 

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -79,31 +79,29 @@ def test_backend_not_installed(backend):
 
 
 def test_parallel_run_dispatches_lazily():
-    # parallel_run must not consume the whole kwargs generator before yielding
-    # the first dispatched result; otherwise every run (with its loaded data)
-    # would be held in memory at once on a single node.
+    # Make sure we keep the lazy dispatching when possible (loky).
     from benchopt.parallel_backends import parallel_run
 
     n_runs = 100
-    # The generator hard-blocks its tail until `release` is set. If dispatch is
-    # lazy, the first result still comes out from the unblocked prefix; if it
-    # eagerly drained the generator, this would instead block. This makes the
-    # laziness check deterministic even on a slow (e.g. macOS) CI runner.
+    # Hard-block the generator's tail after dispatching a few tasks,
+    # so we can check that the first results are yielded before the generator
+    # is fully consumed.
     block_after = 20
     release = threading.Event()
-    pulled = []
+    pulled = 0
 
     def kwargs_gen():
+        nonlocal pulled
         for i in range(n_runs):
             if i == block_after:
                 release.wait(timeout=30)
-            pulled.append(i)
+            pulled += 1
             yield dict(i=i)
 
+    # parallel_run expect a check_call_in_cache method, and here we make sure
+    # that every run is dispatched.
     def _run(i):
-        return ([], (str(i), "obj", "solver"), "done", "")
-
-    # Nothing is cached, so every run is dispatched.
+        return i
     _run.check_call_in_cache = lambda **kwargs: False
 
     results = parallel_run(
@@ -114,7 +112,7 @@ def test_parallel_run_dispatches_lazily():
         next(results)
         # A result came out while the generator tail is still blocked, so at
         # most the unblocked prefix was pulled.
-        assert len(pulled) <= block_after
+        assert pulled <= block_after
     finally:
         release.set()
     # Drain the rest so the workers shut down cleanly.

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -106,7 +106,8 @@ def test_parallel_run_dispatches_lazily():
 
     results = parallel_run(
         benchmark=None, run=_run, run_kwargs_generator=kwargs_gen(),
-        config=dict(backend="loky", n_jobs=2),
+        # batch_size=1 avoids joblib auto-batching pulling many tasks at once.
+        config=dict(backend="loky", n_jobs=2, batch_size=1),
     )
     try:
         next(results)

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -94,7 +94,7 @@ def test_parallel_run_dispatches_lazily():
         nonlocal pulled
         for i in range(n_runs):
             if i == block_after:
-                release.wait(timeout=30)
+                release.wait(timeout=60)
             pulled += 1
             yield dict(i=i)
 

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 import pytest
 
@@ -86,7 +87,7 @@ def test_parallel_run_dispatches_lazily():
     # Hard-block the generator's tail after dispatching a few tasks,
     # so we can check that the first results are yielded before the generator
     # is fully consumed.
-    block_after = 20
+    block_after = 50
     release = threading.Event()
     pulled = 0
 
@@ -99,8 +100,14 @@ def test_parallel_run_dispatches_lazily():
             yield dict(i=i)
 
     # parallel_run expect a check_call_in_cache method, and here we make sure
-    # that every run is dispatched.
+    # that every run is dispatched. A small sleep keeps completions slower
+    # than the main thread's retrieval polling (joblib polls every 10ms), so
+    # dispatch doesn't race ahead of `next(results)` on slow/jittery workers
+    # (e.g. macOS/Windows CI, where loky's spawn-started workers are slower
+    # to come up, giving the completion-driven redispatch loop more real time
+    # to run before the first result is observed).
     def _run(i):
+        time.sleep(0.005)
         return i
     _run.check_call_in_cache = lambda **kwargs: False
 

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -76,6 +76,37 @@ def test_backend_not_installed(backend):
                 ], standalone_mode=False)
 
 
+def test_parallel_run_dispatches_lazily():
+    # parallel_run must not consume the whole kwargs generator before yielding
+    # the first dispatched result; otherwise every run (with its loaded data)
+    # would be held in memory at once on a single node.
+    from benchopt.parallel_backends import parallel_run
+
+    n_runs = 100
+    pulled = []
+
+    def kwargs_gen():
+        for i in range(n_runs):
+            pulled.append(i)
+            yield dict(i=i)
+
+    def _run(i):
+        return ([], (str(i), "obj", "solver"), "done", "")
+
+    # Nothing is cached, so every run is dispatched.
+    _run.check_call_in_cache = lambda **kwargs: False
+
+    results = parallel_run(
+        benchmark=None, run=_run, run_kwargs_generator=kwargs_gen(),
+        config=dict(backend="loky", n_jobs=2),
+    )
+    next(results)
+    # The first result comes out well before the generator is exhausted.
+    assert len(pulled) < n_runs
+    # Drain the rest so the workers shut down cleanly.
+    assert len(list(results)) == n_runs - 1
+
+
 @pytest.mark.parametrize("backend", ["submitit", "dask"])
 def test_backend_collect(backend):
     config = f"""

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -108,7 +108,7 @@ def test_parallel_run_dispatches_lazily():
     # to run before the first result is observed).
     def _run(i):
         time.sleep(0.005)
-        return i
+        return (i,)
     _run.check_call_in_cache = lambda **kwargs: False
 
     results = parallel_run(

--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 
 
@@ -83,10 +85,18 @@ def test_parallel_run_dispatches_lazily():
     from benchopt.parallel_backends import parallel_run
 
     n_runs = 100
+    # The generator hard-blocks its tail until `release` is set. If dispatch is
+    # lazy, the first result still comes out from the unblocked prefix; if it
+    # eagerly drained the generator, this would instead block. This makes the
+    # laziness check deterministic even on a slow (e.g. macOS) CI runner.
+    block_after = 20
+    release = threading.Event()
     pulled = []
 
     def kwargs_gen():
         for i in range(n_runs):
+            if i == block_after:
+                release.wait(timeout=30)
             pulled.append(i)
             yield dict(i=i)
 
@@ -100,9 +110,13 @@ def test_parallel_run_dispatches_lazily():
         benchmark=None, run=_run, run_kwargs_generator=kwargs_gen(),
         config=dict(backend="loky", n_jobs=2),
     )
-    next(results)
-    # The first result comes out well before the generator is exhausted.
-    assert len(pulled) < n_runs
+    try:
+        next(results)
+        # A result came out while the generator tail is still blocked, so at
+        # most the unblocked prefix was pulled.
+        assert len(pulled) <= block_after
+    finally:
+        release.set()
     # Drain the rest so the workers shut down cleanly.
     assert len(list(results)) == n_runs - 1
 

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -264,10 +264,6 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
     output_file : Path
         Path to the output file where the results have been saved.
     """
-    assert not (collect and benchmark.no_cache), (
-        "Cannot collect when using `--no-cache`."
-    )
-
     exit_code = 0
     terminal = TerminalOutput(n_repetitions, show_progress)
 
@@ -421,6 +417,9 @@ def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
     output_file : Path
         Path to the output file where the results have been saved.
     """
+    assert not (collect and no_cache), (
+        "Cannot collect when using `no_cache=True`."
+    )
     benchmark = Benchmark(benchmark_path, no_cache=no_cache)
     if solver_names is None:
         solver_names = []

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -316,7 +316,7 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
         config=parallel_config, collect=collect
     )
     try:
-        for cached, (result, key, status, reason) in results_generator:
+        for result, key, status, reason, cached in results_generator:
             run_statistics.extend(result)
             terminal.set(dataset=key[0], objective=key[1], solver=key[2])
             terminal.show_status(status=status, reason=reason, cached=cached)

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -264,6 +264,10 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
     output_file : Path
         Path to the output file where the results have been saved.
     """
+    assert not (collect and benchmark.no_cache), (
+        "Cannot collect when using `--no-cache`."
+    )
+
     exit_code = 0
     terminal = TerminalOutput(n_repetitions, show_progress)
 
@@ -282,7 +286,6 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
     run_one_to_cvg_cached = benchmark.cache(
         run_one_to_cvg,
         ignore=['force', 'terminal', 'run_context'],
-        collect=collect
     )
 
     def run_one_to_cvg_final(**kwargs):
@@ -298,6 +301,11 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
             )
             return ([], key, e.status, "")
 
+    # Forward the cache lookup so the parallel dispatch can skip cached runs.
+    run_one_to_cvg_final.check_call_in_cache = (
+        run_one_to_cvg_cached.check_call_in_cache
+    )
+
     total_cvg_kwargs_generator = generate_run_kwargs(
         benchmark, solvers=solvers, forced_solvers=forced_solvers,
         datasets=datasets, objectives=objectives,
@@ -312,10 +320,10 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
         config=parallel_config, collect=collect
     )
     try:
-        for result, key, status, reason in results_generator:
+        for cached, (result, key, status, reason) in results_generator:
             run_statistics.extend(result)
             terminal.set(dataset=key[0], objective=key[1], solver=key[2])
-            terminal.show_status(status=status, reason=reason)
+            terminal.show_status(status=status, reason=reason, cached=cached)
             if status == 'interrupted':
                 raise SystemExit(1)
     except KeyboardInterrupt:

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -283,10 +283,12 @@ class TestCache:
         out.check_output("#RUN_SOLVER", repetition=n_reps * 3)
 
     def test_collect_no_cache_incompatible(self, no_debug_log):
+        import click
+
         with temp_benchmark(
                 solvers=self.solver, datasets=self.dataset
         ) as bench:
-            with pytest.raises(AssertionError, match="Cannot collect"):
+            with pytest.raises(click.BadParameter, match="--collect"):
                 run(f"{bench.benchmark_dir} --no-plot --collect --no-cache"
                     .split(), standalone_mode=False)
 

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -252,6 +252,8 @@ class TestCache:
                 run(cmd.split(), standalone_mode=False)
             with CaptureCmdOutput() as out_second:
                 run(cmd.split(), standalone_mode=False)
+            with CaptureCmdOutput() as out_forced:
+                run(f"{cmd} -f test-solver".split(), standalone_mode=False)
 
         # First run: nothing cached, so the solver runs in dispatched worker
         # processes, not in the main one.
@@ -268,6 +270,15 @@ class TestCache:
         # is dispatched) and the status is displayed as cached.
         out_second.check_output(r"#RUN_PID", repetition=0)
         out_second.check_output(r"done \(cached\)", repetition=1)
+
+        # --force-solver must bypass the skip even when cached: the solver is
+        # dispatched to a worker (not the main process) and re-run, and its
+        # status is no longer reported as cached.
+        forced_pids = {
+            int(p) for p in out_forced.check_output(r"#RUN_PID:(\d+)")
+        }
+        assert forced_pids and main_pid not in forced_pids, forced_pids
+        out_forced.check_output(r"done \(cached\)", repetition=0)
 
     @pytest.mark.parametrize('n_reps', [1, 4])
     def test_no_cache(self, no_debug_log, n_reps):

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -212,6 +212,63 @@ class TestCache:
         # when using multiple repetitions
         out.check_output("#RUN_SOLVER", repetition=n_reps)
 
+    def test_cached_runs_not_dispatched(self, no_debug_log, monkeypatch):
+        # A cached run must be detected on the frontal node (the main process)
+        # and not dispatched to a worker. To tell the two apart, both the cache
+        # check and the solver report the PID of the process they run in: the
+        # check always runs on the frontal, while a dispatched solver runs in a
+        # separate worker process.
+        import os
+        from benchopt.benchmark import Benchmark
+
+        main_pid = os.getpid()
+        orig_cache = Benchmark.cache
+
+        def cache_reporting_pid(self, func, *args, **kwargs):
+            cached = orig_cache(self, func, *args, **kwargs)
+            check = cached.check_call_in_cache
+
+            def check_call_in_cache(**kw):
+                print(f"#CHECK_PID:{os.getpid()}")
+                return check(**kw)
+
+            cached.check_call_in_cache = check_call_in_cache
+            return cached
+
+        monkeypatch.setattr(Benchmark, "cache", cache_reporting_pid)
+
+        solver = """from benchopt.utils.temp_benchmark import TempSolver
+        import os
+
+        class Solver(TempSolver):
+            name = "test-solver"
+            sampling_strategy = 'run_once'
+            def run(self, _): print(f"#RUN_PID:{os.getpid()}")
+        """
+
+        with temp_benchmark(solvers=solver, datasets=self.dataset) as bench:
+            cmd = f"{bench.benchmark_dir} --no-plot -r 2 -j 2"
+            with CaptureCmdOutput() as out_first:
+                run(cmd.split(), standalone_mode=False)
+            with CaptureCmdOutput() as out_second:
+                run(cmd.split(), standalone_mode=False)
+
+        # First run: nothing cached, so the solver runs in dispatched worker
+        # processes, not in the main one.
+        run_pids = {int(p) for p in out_first.check_output(r"#RUN_PID:(\d+)")}
+        assert run_pids and main_pid not in run_pids, run_pids
+
+        # The cache check always runs on the frontal (main) process.
+        check_pids = {
+            int(p) for p in out_second.check_output(r"#CHECK_PID:(\d+)")
+        }
+        assert check_pids == {main_pid}, check_pids
+
+        # Second run: everything is cached, so the solver is not run (nothing
+        # is dispatched) and the status is displayed as cached.
+        out_second.check_output(r"#RUN_PID", repetition=0)
+        out_second.check_output(r"done \(cached\)", repetition=1)
+
     @pytest.mark.parametrize('n_reps', [1, 4])
     def test_no_cache(self, no_debug_log, n_reps):
         with temp_benchmark(
@@ -224,6 +281,14 @@ class TestCache:
 
         # Check that the run is not cached when using --no-cache
         out.check_output("#RUN_SOLVER", repetition=n_reps * 3)
+
+    def test_collect_no_cache_incompatible(self, no_debug_log):
+        with temp_benchmark(
+                solvers=self.solver, datasets=self.dataset
+        ) as bench:
+            with pytest.raises(AssertionError, match="Cannot collect"):
+                run(f"{bench.benchmark_dir} --no-plot --collect --no-cache"
+                    .split(), standalone_mode=False)
 
     def test_no_error_caching(self, no_debug_log):
 

--- a/benchopt/utils/terminal_output.py
+++ b/benchopt/utils/terminal_output.py
@@ -141,7 +141,8 @@ class TerminalOutput:
                 endline=False,  verbose=self.verbose
             )
 
-    def show_status(self, status, reason=None, dataset=False, objective=False):
+    def show_status(self, status, reason=None, dataset=False, objective=False,
+                    cached=False):
         from ..runner import SUCCESS_STATUS
 
         if dataset or objective:
@@ -172,6 +173,8 @@ class TerminalOutput:
             f"status should be in {list(STATUS)}. Got '{status}'"
         )
         status_print = colorify(*STATUS[status])
+        if cached:
+            status_print += colorify(" (cached)", CYAN)
         print_normalize(f"{tag} {status_print}")
 
         if status == 'skip' and reason is not None:

--- a/doc/user_guide/distributed_run.rst
+++ b/doc/user_guide/distributed_run.rst
@@ -83,7 +83,9 @@ Hereafter is an example of such config file:
 
 Using this backend, each configuration of ``(dataset, objective, solver)`` with
 unique parameters is launched as a separated job in a job-array on the SLURM
-cluster. The logs of each run can be found in ``./benchopt_run/``.
+cluster. The logs of each run can be found in ``./benchopt_run/``. Cache hits
+are detected on the submitting node before dispatching, so no SLURM job is
+allocated for a configuration whose result is already cached.
 
 The parameters defined in this config file should be compatible with
 the ``submitit`` library, as they are passed to the ``submitit.AutoExecutor``

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -40,7 +40,9 @@ API
 - Cache hits are now detected on the main process before dispatching, so no
   parallel job (loky, dask or SLURM/submitit) is launched for a
   ``(dataset, objective, solver)`` run whose result is already cached. Such
-  runs are reported as ``done (cached)``. By `Thomas Moreau`_ (:gh:`976`)
+  runs are reported as ``done (cached)``. The same skip and ``done (cached)``
+  reporting also apply to dataset preparation.
+  By `Thomas Moreau`_ (:gh:`976`)
 
 - Custom plot ``options`` values can now be a callable taking the results
   DataFrame as input and returning the list of possible values for the option.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,7 +10,6 @@ What's new
 Version 1.10.0 -- in development
 --------------------------------
 
-<<<<<<< ENH_agent_skills
 CLI
 ~~~
 
@@ -18,10 +17,9 @@ CLI
   standard) as package data and add ``benchopt sync-skills`` to install them
   into a project's ``.agents/skills/`` (or globally with ``--global``), with a
   ``.claude/skills/`` mirror for Claude Code. By `Thomas Moreau`_ (:gh:`959`)
-=======
+
 PLOT
 ~~~~
-
 
 - Quantile toggle is now hidden if no quantiles are available
   By `Hippolyte Verninas`_ (:gh:`964`)
@@ -29,10 +27,14 @@ PLOT
 - Improve the html report table, now rendered with `Grid.js
   <https://gridjs.io/>`_: sortable by any column, filter by solver name,
   hide/show any columns. By `Hippolyte Verninas`_ (:gh:`953`)
->>>>>>> main
 
 API
 ~~~
+
+- Cache hits are now detected on the main process before dispatching, so no
+  parallel job (loky, dask or SLURM/submitit) is launched for a
+  ``(dataset, objective, solver)`` run whose result is already cached. Such
+  runs are reported as ``done (cached)``. By `Thomas Moreau`_ (:gh:`976`)
 
 - Custom plot ``options`` values can now be a callable taking the results
   DataFrame as input and returning the list of possible values for the option.


### PR DESCRIPTION
When running with a parallel backend, benchopt dispatch jobs even for cached results. This is wasteful especially on SLURM, where job initialization can be slow. This PR detects cache hits on the submitting node, reports cached runs as `done (cached)` and schedules missing ones.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)