### PR TITLE
TST fix test_dask_backend for distributed 2026.7.0

### DIFF
--- a/benchopt/parallel_backends/tests/test_parallel_backends.py
+++ b/benchopt/parallel_backends/tests/test_parallel_backends.py
@@ -135,10 +135,13 @@ def test_dask_backend():
             ], standalone_mode=False)
 
     client = distributed.get_client()
-    workers = client._scheduler_identity.get('workers', {})
-    effective_workers = len(workers)
     assert client_name in client.id
-    assert effective_workers == n_workers
+    # Wait for the workers to register, then query the scheduler through the
+    # public `scheduler_info` (the private `_scheduler_identity` snapshot is
+    # not refreshed and reports no worker on recent distributed versions).
+    client.wait_for_workers(n_workers, timeout=30)
+    workers = client.scheduler_info().get('workers', {})
+    assert len(workers) == n_workers
     client.close()
 
     out.check_output("Distributed run with backend: dask", repetition=1)


### PR DESCRIPTION
`test_dask_backend` fails deterministically on `main` since `distributed` 2026.7.0: the private `client._scheduler_identity` snapshot is no longer refreshed and reports no worker, so the worker-count assertion sees `0 != 2`. This switches the check to the public `client.scheduler_info()` after waiting for the workers to register.

### Checks before merging PR
- [x] ~~added documentation for any new feature~~
- [x] added unit test
- [x] ~~edited the [what's new](../../whatsnew.rst)~~ (if applicable)