### PR TITLE
SKILLS strengthen using-benchopt debug trigger and traps list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Agent skills in this repo
+
+This repo has its own agent-skills system, separate from any personal
+ai-skills setup you may have configured elsewhere:
+
+- `.agents/skills/benchopt-contributor/` — how to work on the benchopt
+  library itself (tests, docs, CLI, contributor gotchas).
+- `benchopt/skills/using-benchopt/` — the benchmark-*authoring* skill,
+  packaged with benchopt and distributed via `benchopt sync-skills`.
+
+**Before editing any file under either path, load the `benchopt-contributor`
+skill via the Skill tool first** — it documents how the two bundles relate
+and the "update the skill in the same PR as the code it describes" rule.
+A personal ai-skills setup is a fine complement, but it won't know this
+repo's specific conventions (packaging, `sync-skills`, version-stamping), so
+check for `benchopt-contributor` here too.

--- a/benchopt/skills/using-benchopt/SKILL.md
+++ b/benchopt/skills/using-benchopt/SKILL.md
@@ -30,6 +30,12 @@ version differs from the one above, warn the user that this skill may be out of
 date and recommend re-running `benchopt sync-skills` (add `--global` for the
 global install) to refresh it.**
 
+**Never edit this file in place** (whether synced into a benchmark repo's
+`.agents/skills/` or `.claude/skills/`, or found elsewhere on disk) — it is
+package data generated from the `benchopt` repo. Fix it at
+`benchopt/skills/using-benchopt/` upstream and open a PR there; local edits are
+silently overwritten by the next `benchopt sync-skills`.
+
 ## Before editing ANY component, open its sub-file first
 
 The conventions below are easy to get wrong from memory, so it is worth opening
@@ -42,14 +48,20 @@ the matching sub-file before editing a component rather than free-handing it:
 - **Running / caching / config?** → read [**run.md**](./run.md)
 - **Scaling to cores or a SLURM cluster?** → read [**parallel.md**](./parallel.md)
 - **Exploring, plotting, merging, publishing results?** → read [**results.md**](./results.md)
-- **Driving benchmark code from Python (no CLI)?** → read [**debug.md**](./debug.md)
+- **Driving benchmark code from Python (no CLI), or a quick interactive sanity check (e.g. "does this new parameter/split work")?** → read [**debug.md**](./debug.md)
 - **CLI subcommand reference?** → read [**cli-reference.md**](./cli-reference.md)
 
 Traps that are wrong-from-memory (authoritative details in the sub-files):
 import third-party deps at module top level and let `ImportError` propagate —
 no `try/except`, and no `safe_import_context` unless a class-body attribute
 needs the imported name; `requirements` is a literal list of strings; add a
-small `test_parameters` / `test_config`.
+small `test_parameters` / `test_config`; never instantiate `Dataset()` /
+`Objective()` / `Solver()` directly or `import` benchmark modules by hand
+(`from objective import Objective`) — constructor kwargs silently skip the
+parameter grid, and hand-imports risk shadowing `datasets/` with PyPI's
+`datasets`. Always go through `Benchmark(".").get_datasets()` /
+`.get_benchmark_objective()` + `.get_instance(**params)` — see
+[debug.md](./debug.md).
 
 ## Assets (copy-paste templates)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,7 +19,7 @@ CLI
   ``.claude/skills/`` mirror for Claude Code. The skills are consolidated into a
   single ``using-benchopt`` skill (router ``SKILL.md`` plus task sub-files and
   asset templates) and ``sync-skills`` stamps the installed version and
-  retargets doc links. By `Thomas Moreau`_ (:gh:`959`, :gh:`980`)
+  retargets doc links. By `Thomas Moreau`_ (:gh:`959`, :gh:`980`, :gh:`982`)
 
 PLOT
 ~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ ignore = [
   "continuous_integration/*",
   "Makefile",
   "roadmap.md",
+  "CLAUDE.md",
   "benchopt/version.py",
   "benchopt/tests/dummy_package/build/**",
   ".agents/**",


### PR DESCRIPTION
Follow-up to #959 / #980 (agent skills). Hardens the `using-benchopt` skill
against two mistakes an agent made from memory (hand-instantiating
`Dataset`/`Objective`/`Solver` instead of going through `Benchmark(".")`, and
routing a quick interactive sanity check to the wrong sub-file), and adds a
repo `CLAUDE.md` pointing at `benchopt-contributor` before editing skill files
in this repo.

### Checks before merging PR
- [ ] added documentation for any new feature — n/a, doc-only change to the skill files themselves
- [ ] added unit test — n/a, no code changed; `test_cmd_sync_skills.py` still passes (26 passed)
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable) — pending, will push once PR number is known