### PR TITLE
VIZ format table cells with markers

### DIFF
--- a/benchopt/plotting/html/static/result.js
+++ b/benchopt/plotting/html/static/result.js
@@ -1211,6 +1211,74 @@ const valueToFixed = (value) => {
   return value;
 }
 
+/*
+ * Inline markup for table cells: `**bold**`, `*italic*` and `__underlined__`.
+ * They are rendered as HTML in the report and converted to the matching LaTeX
+ * commands on export. A cell whose text is a single number, e.g. `**1.234**`,
+ * is still handled as a number by the float precision control and the sorting.
+ */
+const CELL_MARKUP = [
+  [/\*\*([^*]+)\*\*/g, 'b'],
+  [/__([^_]+)__/g, 'u'],
+  [/\*([^*]+)\*/g, 'i'],
+];
+const LATEX_COMMANDS = {B: 'textbf', I: 'textit', U: 'underline'};
+
+const escapeHtml = (value) => value.replace(
+  /[&<>]/g, c => ({'&': '&amp;', '<': '&lt;', '>': '&gt;'}[c])
+);
+
+// `\*` and `\_` give a literal marker: hide them behind a placeholder while
+// the markup is converted, then put them back.
+const PLACEHOLDERS = {'*': '\u0000', '_': '\u0001'};
+const LITERALS = {'\u0000': '*', '\u0001': '_'};
+
+// Escape the cell content first: only our own markup produces HTML tags.
+const markupToHtml = (value) => CELL_MARKUP.reduce(
+  (html, [regexp, tag]) => html.replace(regexp, `<${tag}>$1</${tag}>`),
+  escapeHtml(value).replace(/\\([*_])/g, (match, c) => PLACEHOLDERS[c])
+).replace(/[\u0000\u0001]/g, c => LITERALS[c]);
+
+// Cell text without its markup, used to sort and to format a wrapped number.
+const stripMarkup = (value) => CELL_MARKUP.reduce(
+  (text, [regexp]) => text.replace(regexp, '$1'),
+  String(value).replace(/\\([*_])/g, (match, c) => PLACEHOLDERS[c])
+).replace(/[\u0000\u0001]/g, c => LITERALS[c]);
+
+// Numeric value of a cell, or null if its text is not a single number.
+const cellNumber = (value) => {
+  if (typeof value === 'number') return value;
+  const text = typeof value === 'string' ? stripMarkup(value).trim() : '';
+  return text !== '' && !isNaN(text) ? Number(text) : null;
+};
+
+/**
+ * Render a cell, applying the float precision to numbers, markup or not.
+ */
+const formatCell = (value) => {
+  if (typeof value !== 'string') return valueToFixed(value);
+  const number = cellNumber(value);
+  const text = number === null ? value
+    : value.replace(stripMarkup(value).trim(), valueToFixed(number));
+  return gridjs.html(markupToHtml(text));
+};
+
+const escapeLatex = (value) => value.replace(/([&%$#_{}])/g, '\\$1');
+
+// Recurse: Grid.js wraps formatted cells in a <span>, and markup can be
+// nested (`**__text__**`).
+const nodeToLatex = (node) => {
+  if (node.nodeType === Node.TEXT_NODE) return escapeLatex(node.textContent);
+  const content = Array.from(node.childNodes, nodeToLatex).join('');
+  const command = LATEX_COMMANDS[node.nodeName];
+  return command ? `\\${command}{${content}}` : content;
+};
+
+/**
+ * Convert a rendered cell (or header) to LaTeX, keeping its formatting.
+ */
+const elementToLatex = (element) => nodeToLatex(element).trim();
+
 /**
  * Compare two cell values, handling both numbers and strings.
  *
@@ -1219,10 +1287,11 @@ const valueToFixed = (value) => {
  * would make all close numbers compare as equal.
  */
 const compareCells = (a, b) => {
-  if (typeof a === 'number' && typeof b === 'number') {
-    return a > b ? 1 : a < b ? -1 : 0;
+  const [numA, numB] = [cellNumber(a), cellNumber(b)];
+  if (numA !== null && numB !== null) {
+    return numA > numB ? 1 : numA < numB ? -1 : 0;
   }
-  return String(a).localeCompare(String(b));
+  return stripMarkup(a).localeCompare(stripMarkup(b));
 }
 
 const sortRows = (plotData, column, ascending) =>
@@ -1344,7 +1413,7 @@ function renderTable() {
     name,
     hidden: tableHiddenColumns.has(name),
     sort: { compare: compareCells },
-    formatter: (value) => valueToFixed(value),
+    formatter: formatCell,
   }));
 
   tableGrid = new gridjs.Grid({
@@ -1488,18 +1557,18 @@ async function exportTable() {
   // float precision.
   const displayedColumns = Array.from(
     document.querySelectorAll('#table_container .gridjs-th-content'),
-    el => el.textContent.trim()
+    elementToLatex
   );
   const displayedRows = Array.from(
     document.querySelectorAll('#table_container .gridjs-table tbody tr')
-  ).map(tr => Array.from(tr.querySelectorAll('td'), td => td.innerText));
+  ).map(tr => Array.from(tr.querySelectorAll('td'), elementToLatex));
 
   const title = (getPlotData() || {}).title;
   let value = "";
   if (title) {
     // Caption above the table, kept on a single line.
     value += "\\begin{table}[h]\n\\centering\n\\caption{";
-    value += title.replace(/<br\s*\/?>/g, ", ").replaceAll('_', '\\_');
+    value += escapeLatex(title.replace(/<br\s*\/?>/g, ", "));
     value += "}\n";
   }
   value += "\\begin{tabular}{l";
@@ -1507,16 +1576,16 @@ async function exportTable() {
   value += "}\n";
   value += "\\hline\n";
 
-  value += displayedColumns[0].replace('_', '\\_');
-  displayedColumns.slice(1).forEach(metric => value += ` & ${metric.replace('_', '\\_')}`);
+  value += displayedColumns[0];
+  displayedColumns.slice(1).forEach(metric => value += ` & ${metric}`);
 
   value += " \\\\\n";
   value += "\\hline\n";
 
   displayedRows.forEach(rowData => {
-    value += rowData[0].replace('_', '\\_');
+    value += rowData[0];
     rowData.slice(1).forEach(cell => {
-      value += ` & ${cell.replace('_', '\\_')}`;
+      value += ` & ${cell}`;
     });
     value += " \\\\\n";
   });

--- a/benchopt/skills/using-benchopt/results.md
+++ b/benchopt/skills/using-benchopt/results.md
@@ -167,7 +167,9 @@ set `name` and `type` (`scatter`/`bar_chart`/`boxplot`/`table`/`image`),
 implement `plot(df, **options)` (returns data shaped by `type`) and
 `get_metadata` (title/labels/scale), and use `self.get_style(label)` for a
 consistent color/marker per solver. The `name` then appears in the HTML menu and
-works as a `plot_kind` in `plot_configs` (above). For the per-type return schema
+works as a `plot_kind` in `plot_configs` (above). Table cells accept
+`**bold**`, `*italic*` and `__underlined__` markers, rendered in the HTML
+report and in the LaTeX export; escape a literal marker with `r"a \* b"`. For the per-type return schema
 and a full example, see the custom-plot doc:
 https://benchopt.github.io/stable/user_guide/add_custom_plot.html
 

--- a/doc/user_guide/add_custom_plot.rst
+++ b/doc/user_guide/add_custom_plot.rst
@@ -259,6 +259,10 @@ The metadata dictionary returned by :code:`get_metadata` should contain:
 - :code:`default_order_ascending` (optional, default=True): Whether the default
   ordering is in increasing order.
 
+String cells can carry simple formatting with :code:`**bold**`,
+:code:`*italic*` and :code:`__underlined__` markers. A literal marker is
+escaped with a backslash, as in :code:`r"a \* b"`.
+
 In the html report, each column header can be clicked to sort on that column,
 and the arrow next to it can be toggled to switch between increasing and
 decreasing order. A search bar allows filtering the rows, and each column can
@@ -274,7 +278,7 @@ be shown or hidden with the checkboxes below the table.
         for solver, df_solver in df.groupby('solver_name'):
             # Example: table with solver name and mean time
             # when using `sampling_strategy = 'run_once'`
-            rows.append([solver, df_solver['time'].mean()])
+            rows.append([f"**{solver}**", df_solver['time'].mean()])
         return rows
 
     def get_metadata(self, df, dataset, objective, **kwargs):

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -30,7 +30,7 @@ PLOT
 
 - Table cells can be formatted with ``**bold**``, ``*italic*`` and
   ``__underlined__`` markers.
-  By `Hippolyte Verninas`_
+  By `Hippolyte Verninas`_ (:gh:`993`)
 
 - Change the plotly style to make it more like matplotlib.
   By `Hippolyte Verninas`_ (:gh:`966`)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -28,6 +28,10 @@ CLI
 PLOT
 ~~~~
 
+- Table cells can be formatted with ``**bold**``, ``*italic*`` and
+  ``__underlined__`` markers.
+  By `Hippolyte Verninas`_
+
 - Change the plotly style to make it more like matplotlib.
   By `Hippolyte Verninas`_ (:gh:`966`)
 


### PR DESCRIPTION
Table cells can now be formatted with some simple markers (bold, italic and underlines), works with text and numbers. This is useful when we want to highlight the best results in a table for example.

### Checks before merging PR
- [X] added documentation for any new feature
- [X] ~~added unit test~~
- [X] edited the [what's new](../../whatsnew.rst) (if applicable)
