### PR TITLE
FEAT Add solver and dataset tag filters

### DIFF
--- a/benchopt/base.py
+++ b/benchopt/base.py
@@ -59,8 +59,9 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
       dependent computations, for instance in ``jax`` with different number of
       iterations in a for loop.
 
-    The ``Solver`` class also defines class attributes to specify how the
-    benchmark curve should be sampled:
+    The ``Solver`` class also defines optional class attributes:
+
+    - ``tags``: labels used to select groups of solvers from the command line.
 
     - ``sampling_strategy``: defines how the benchmark curve should be sampled.
       It should be one of the following strings: 'iteration', 'tolerance',
@@ -82,7 +83,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
       used depending on the ``sampling_strategy``.
       See :ref:`stopping_criterion` for available options.
 
-    Note that default values for these attributes can be set at the
+    Note that default values for the sampling attributes can be set at the
     ``Objective`` level so that all solvers in a benchmark share the same
     default behavior. Typically, for ML benchmarks, all solvers can be run only
     once by setting ``sampling_strategy = 'run_once'`` in the benchmark's
@@ -91,6 +92,7 @@ class BaseSolver(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
     """
 
     _base_class_name = 'Solver'
+    tags = []
     sampling_strategy = None
 
     @classproperty
@@ -335,6 +337,8 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
 
     Class attributes
     ----------------
+    tags : list of str
+        Labels used to select groups of datasets from the command line.
     prepare_cache_ignore : tuple of str or "all"
         Parameter names that do not affect the output of ``prepare()``.
         These are excluded from the prepare cache key and from job
@@ -348,6 +352,7 @@ class BaseDataset(ParametrizedNameMixin, DependenciesMixin, RunContextMixin,
 
     _base_class_name = 'Dataset'
 
+    tags = []
     prepare_cache_ignore = ()
 
     def prepare(self):

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -77,12 +77,10 @@ def _get_class_tags(cls):
 
 def _filter_classes_by_tags(all_classes, tags, name_type):
     """Return classes matching any requested tag."""
-    if tags is None:
+    if not tags:
         return set(all_classes)
     if isinstance(tags, str):
         tags = [tags]
-    if not tags:
-        return set(all_classes)
 
     class_tags = {cls: _get_class_tags(cls) for cls in all_classes}
     available_tags = set().union(*class_tags.values())

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -67,10 +67,10 @@ def _get_class_tags(cls):
         ) from exc
 
     if not isinstance(tags, list) or not all(
-            isinstance(tag, str) for tag in tags):
+            isinstance(tag, str) and ',' not in tag for tag in tags):
         raise ValueError(
             f"Invalid tags for {component} {cls.name!r}: expected a literal "
-            "list of strings."
+            "list of strings without commas."
         )
     return tags.copy()
 

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -55,6 +55,55 @@ def get_running_benchmark():
     return _RUNNING_BENCHMARK
 
 
+def _get_class_tags(cls):
+    """Return validated tags declared by a benchmark component."""
+    component = cls._base_class_name
+    try:
+        tags = cls.tags
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Could not read tags for {component} {cls.name!r}. The tags "
+            "attribute must be a literal list of strings."
+        ) from exc
+
+    if not isinstance(tags, list) or not all(
+            isinstance(tag, str) for tag in tags):
+        raise ValueError(
+            f"Invalid tags for {component} {cls.name!r}: expected a literal "
+            "list of strings."
+        )
+    return tags.copy()
+
+
+def _filter_classes_by_tags(all_classes, tags, name_type):
+    """Return classes matching any requested tag."""
+    if tags is None:
+        return set(all_classes)
+    if isinstance(tags, str):
+        tags = [tags]
+    if not tags:
+        return set(all_classes)
+
+    class_tags = {cls: _get_class_tags(cls) for cls in all_classes}
+    available_tags = {
+        tag for cls_tags in class_tags.values() for tag in cls_tags
+    }
+    invalid_tags = [tag for tag in tags if tag not in available_tags]
+    if invalid_tags:
+        available = '- ' + '\n- '.join(sorted(available_tags))
+        if not available_tags:
+            available = '(none)'
+        raise click.BadParameter(
+            f"Tags {invalid_tags} did not match any {name_type}.\n"
+            f"Available {name_type} tags are:\n{available}"
+        )
+
+    return {
+        cls for cls in all_classes
+        if any(tag in class_tags[cls] for tag in tags)
+    }
+
+
 class Benchmark:
     """Benchmark exposes all constituents of the benchmark folder.
 
@@ -216,12 +265,28 @@ class Benchmark:
         "List all available solver names for the benchmark."
         return [s.name for s in self.get_solvers()]
 
-    def check_solver_patterns(self, solver_patterns, class_only=False):
+    def check_solver_patterns(self, solver_patterns, class_only=False,
+                              tags=None):
         "Check that the patterns are valid and return selected configurations."
-        return _check_patterns(
-            self.get_solvers(), solver_patterns, name_type='solver',
-            class_only=class_only
+        all_solvers = self.get_solvers()
+        solvers = _check_patterns(
+            all_solvers, solver_patterns, name_type='solver'
         )
+        tagged_solvers = _filter_classes_by_tags(
+            all_solvers, tags, name_type='solver'
+        )
+        solvers = [
+            (solver, parameters) for solver, parameters in solvers
+            if solver in tagged_solvers
+        ]
+        has_tag_filters = bool(tags)
+        if has_tag_filters and not solvers:
+            raise click.BadParameter(
+                "No solver matches both the name and tag filters."
+            )
+        if class_only:
+            return {solver for solver, _ in solvers}
+        return solvers
 
     def get_datasets(self):
         "List all available dataset classes for the benchmark."
@@ -298,12 +363,28 @@ class Benchmark:
             names = datasets if len(datasets) == 1 else ['simulated']
         return names
 
-    def check_dataset_patterns(self, dataset_patterns, class_only=False):
+    def check_dataset_patterns(self, dataset_patterns, class_only=False,
+                               tags=None):
         "Check that the patterns are valid and return selected configurations."
-        return _check_patterns(
-            self.get_datasets(), dataset_patterns, name_type='dataset',
-            class_only=class_only
+        all_datasets = self.get_datasets()
+        datasets = _check_patterns(
+            all_datasets, dataset_patterns, name_type='dataset'
         )
+        tagged_datasets = _filter_classes_by_tags(
+            all_datasets, tags, name_type='dataset'
+        )
+        datasets = [
+            (dataset, parameters) for dataset, parameters in datasets
+            if dataset in tagged_datasets
+        ]
+        has_tag_filters = bool(tags)
+        if has_tag_filters and not datasets:
+            raise click.BadParameter(
+                "No dataset matches both the name and tag filters."
+            )
+        if class_only:
+            return {dataset for dataset, _ in datasets}
+        return datasets
 
     def _get_plots_classes(self):
         "List all available custom plot classes for the benchmark"

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -85,9 +85,7 @@ def _filter_classes_by_tags(all_classes, tags, name_type):
         return set(all_classes)
 
     class_tags = {cls: _get_class_tags(cls) for cls in all_classes}
-    available_tags = {
-        tag for cls_tags in class_tags.values() for tag in cls_tags
-    }
+    available_tags = set().union(*class_tags.values())
     invalid_tags = [tag for tag in tags if tag not in available_tags]
     if invalid_tags:
         available = '- ' + '\n- '.join(sorted(available_tags))

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -86,7 +86,9 @@ def _complete_tags(ctx, incomplete, component):
     if benchmark is None:
         return []
     classes = getattr(benchmark, f"get_{component}s")()
-    return propose_from_list(sorted(_get_tags(classes)), incomplete)
+    prefix, separator, incomplete = incomplete.rpartition(',')
+    proposals = propose_from_list(sorted(_get_tags(classes)), incomplete)
+    return [f"{prefix}{separator}{tag}" for tag in proposals]
 
 
 def complete_solver_tags(ctx, param, incomplete):

--- a/benchopt/cli/completion.py
+++ b/benchopt/cli/completion.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 from benchopt.benchmark import Benchmark
+from benchopt.benchmark import _get_class_tags
 from benchopt.utils.dynamic_modules import skip_import
 from benchopt.utils.conda_env_cmd import list_conda_envs
 
@@ -72,6 +73,30 @@ def complete_datasets(ctx, param, incomplete):
         return []
     datasets = [d.lower() for d in benchmark.get_dataset_names()]
     return propose_from_list(datasets, incomplete.lower())
+
+
+def _get_tags(classes):
+    return {tag for cls in classes for tag in _get_class_tags(cls)}
+
+
+def _complete_tags(ctx, incomplete, component):
+    "Complete tags declared on benchmark components."
+    skip_import()
+    benchmark = find_benchmark_in_args(ctx.args)
+    if benchmark is None:
+        return []
+    classes = getattr(benchmark, f"get_{component}s")()
+    return propose_from_list(sorted(_get_tags(classes)), incomplete)
+
+
+def complete_solver_tags(ctx, param, incomplete):
+    "Auto-completion for solver tags."
+    return _complete_tags(ctx, incomplete, "solver")
+
+
+def complete_dataset_tags(ctx, param, incomplete):
+    "Auto-completion for dataset tags."
+    return _complete_tags(ctx, incomplete, "dataset")
 
 
 def complete_plots(ctx, param, incomplete):

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -51,6 +51,12 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
                 ctx.get_parameter_source(var_name).name == 'DEFAULT'):
             cli_kwargs[var_name] = v
 
+    for name in ["solver_tag", "dataset_tag"]:
+        cli_kwargs[name] = [
+            tag.strip()
+            for tags in cli_kwargs[name] for tag in tags.split(',')
+        ]
+
     return_names = [
         "benchmark",
         "solver",
@@ -116,13 +122,13 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               shell_complete=complete_datasets)
 @click.option('--solver-tag', '-st',
               metavar="<tag>", multiple=True, type=str,
-              help="Only include solvers with <tag>. Repeat this option to "
-              "match any listed solver tag.",
+              help="Only include solvers with <tag>. Separate tags with "
+              "commas or repeat this option to match any listed tag.",
               shell_complete=complete_solver_tags)
 @click.option('--dataset-tag', '-dt',
               metavar="<tag>", multiple=True, type=str,
-              help="Only include datasets with <tag>. Repeat this option to "
-              "match any listed dataset tag.",
+              help="Only include datasets with <tag>. Separate tags with "
+              "commas or repeat this option to match any listed tag.",
               shell_complete=complete_dataset_tags)
 @click.option("--max-runs", "-n",
               metavar="<int>", default=100, show_default=True, type=int,

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -7,6 +7,8 @@ from benchopt.benchmark import Benchmark
 from benchopt.config import get_setting
 from benchopt.cli.completion import complete_solvers
 from benchopt.cli.completion import complete_datasets
+from benchopt.cli.completion import complete_solver_tags
+from benchopt.cli.completion import complete_dataset_tags
 from benchopt.cli.completion import complete_benchmarks
 from benchopt.cli.completion import complete_conda_envs
 from benchopt.cli.completion import complete_config_files
@@ -39,8 +41,9 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
                 "See list of valid options with `benchopt run -h`.")
 
         # parse if value is on a single line
-        if (not isinstance(v, list) and
-                var_name in ["objective", "dataset", "solver"]):
+        if (not isinstance(v, list) and var_name in [
+                "objective", "dataset", "solver", "solver_tag",
+                "dataset_tag"]):
             v = [v]
 
         # only override CLI variables if they have their default value
@@ -53,6 +56,8 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
         "solver",
         "force_solver",
         "dataset",
+        "solver_tag",
+        "dataset_tag",
         "objective",
         "max_runs",
         "n_repetitions",
@@ -109,6 +114,16 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               " with the syntax `dataset[parameter=value]`. "
               "To include multiple datasets, use multiple `-d` options.",
               shell_complete=complete_datasets)
+@click.option('--solver-tag', '-st',
+              metavar="<tag>", multiple=True, type=str,
+              help="Only include solvers with <tag>. Repeat this option to "
+              "match any listed solver tag.",
+              shell_complete=complete_solver_tags)
+@click.option('--dataset-tag', '-dt',
+              metavar="<tag>", multiple=True, type=str,
+              help="Only include datasets with <tag>. Repeat this option to "
+              "match any listed dataset tag.",
+              shell_complete=complete_dataset_tags)
 @click.option("--max-runs", "-n",
               metavar="<int>", default=100, show_default=True, type=int,
               help='Maximal number of runs for each solver. This corresponds '
@@ -206,7 +221,8 @@ def run(config_file=None, **kwargs):
 
     (
         benchmark, solver_names, forced_solvers, dataset_names,
-        objective_filters, max_runs, n_repetitions, timeout, no_timeout,
+        solver_tags, dataset_tags, objective_filters, max_runs,
+        n_repetitions, timeout, no_timeout,
         collect, plot, display, html, n_jobs, parallel_config, pdb,
         do_profile, env_name, no_cache, output, seed
     ) = _get_run_args(kwargs, config)
@@ -287,7 +303,9 @@ def run(config_file=None, **kwargs):
         objective.is_installed(raise_on_not_installed=True)
 
         # Check that the dataset/solver patterns match actual dataset
-        datasets = benchmark.check_dataset_patterns(dataset_names)
+        datasets = benchmark.check_dataset_patterns(
+            dataset_names, tags=dataset_tags
+        )
         objectives = benchmark.check_objective_filters(objective_filters)
         print(" done.")
 
@@ -297,7 +315,7 @@ def run(config_file=None, **kwargs):
         elif isinstance(solver_names, tuple):
             solver_names = list(solver_names)
         solvers = benchmark.check_solver_patterns(
-            solver_names + list(forced_solvers)
+            solver_names + list(forced_solvers), tags=solver_tags
         )
         exit_code, _ = _run_benchmark(
             benchmark, solvers, forced_solvers,
@@ -366,6 +384,12 @@ def run(config_file=None, **kwargs):
     solvers_option = " ".join([f'-s "{s}"' for s in solver_names])
     forced_solvers_option = " ".join([f'-f "{s}"' for s in forced_solvers])
     datasets_option = " ".join([f'-d "{d}"' for d in dataset_names])
+    solver_tags_option = " ".join([
+        f'--solver-tag "{tag}"' for tag in solver_tags
+    ])
+    dataset_tags_option = " ".join([
+        f'--dataset-tag "{tag}"' for tag in dataset_tags
+    ])
     objective_option = " ".join([f'-o "{o}"' for o in objective_filters])
     parallel_args = ""
     if n_jobs:
@@ -379,7 +403,8 @@ def run(config_file=None, **kwargs):
         rf"{f'--timeout {timeout} ' if timeout is not None else ''}"
         rf"{'--no-timeout ' if no_timeout else ''} "
         rf"{solvers_option} {forced_solvers_option} "
-        rf"{datasets_option} {objective_option} "
+        rf"{datasets_option} {solver_tags_option} "
+        rf"{dataset_tags_option} {objective_option} "
         rf"{'--plot' if plot else '--no-plot'} "
         rf"{'--display' if display else '--no-display'} "
         rf"{'--html' if html else '--no-html'} "

--- a/benchopt/cli/tests/test_cmd_run.py
+++ b/benchopt/cli/tests/test_cmd_run.py
@@ -185,13 +185,13 @@ class TestRunCmd:
         out.check_output("DATA#large-data")
         out.check_output("DATA#private-data", repetition=0)
 
-    def test_repeated_tag_filters_use_or(self):
+    def test_multiple_tag_filters_use_or(self):
         solvers, datasets = _tagged_components()
         with temp_benchmark(solvers=solvers, datasets=datasets) as bench, \
                 CaptureCmdOutput() as out:
             run([
-                str(bench.benchmark_dir), "--solver-tag", "cpu",
-                "--solver-tag", "gpu", "--dataset-tag", "small",
+                str(bench.benchmark_dir), "--solver-tag", "cpu, gpu",
+                "--dataset-tag", "small", "--dataset-tag", "large",
                 "-n", "1", "-r", "1", "--no-plot"
             ], "benchopt", standalone_mode=False)
 
@@ -199,8 +199,8 @@ class TestRunCmd:
         out.check_output("RUN#gpu-solver")
         out.check_output("RUN#hard-solver")
         out.check_output("DATA#small-data")
-        out.check_output("DATA#large-data", repetition=0)
-        out.check_output("DATA#private-data", repetition=0)
+        out.check_output("DATA#large-data")
+        out.check_output("DATA#private-data")
 
     def test_invalid_tag(self):
         with temp_benchmark() as bench:
@@ -541,7 +541,9 @@ class TestRunCmd:
         with temp_benchmark(solvers=solvers, datasets=datasets) as bench:
             benchmark = str(bench.benchmark_dir)
             _test_shell_completion(
-                run, [benchmark, "-st"], [("g", ["gpu"])]
+                run, [benchmark, "-st"], [
+                    ("g", ["gpu"]), ("easy,g", ["easy,gpu"])
+                ]
             )
             _test_shell_completion(
                 run, [benchmark, "-dt"], [("l", ["large"])]
@@ -638,7 +640,7 @@ class TestRunCmdConfig:
 
     def test_tag_filters_from_config(self):
         config = """
-        solver-tag: gpu
+        solver-tag: gpu, hard
         dataset-tag: large
         n-repetitions: 1
         max-runs: 1

--- a/benchopt/cli/tests/test_cmd_run.py
+++ b/benchopt/cli/tests/test_cmd_run.py
@@ -23,6 +23,56 @@ from benchopt.cli.tests.completion_cases import (  # noqa: F401
 CURRENT_DIR = Path.cwd()
 
 
+def _tagged_components():
+    solvers = [
+        """from benchopt.utils.temp_benchmark import TempSolver
+        class Solver(TempSolver):
+            name = "cpu-solver"
+            tags = ["easy", "cpu"]
+            def run(self, _): print("RUN#cpu-solver")
+        """,
+        """from benchopt.utils.temp_benchmark import TempSolver
+        class Solver(TempSolver):
+            name = "gpu-solver"
+            tags = ["easy", "gpu"]
+            def run(self, _): print("RUN#gpu-solver")
+        """,
+        """from benchopt.utils.temp_benchmark import TempSolver
+        class Solver(TempSolver):
+            name = "hard-solver"
+            tags = ["hard", "gpu"]
+            def run(self, _): print("RUN#hard-solver")
+        """,
+    ]
+    datasets = [
+        """from benchopt.utils.temp_benchmark import TempDataset
+        class Dataset(TempDataset):
+            name = "small-data"
+            tags = ["easy", "small"]
+            def get_data(self):
+                print("DATA#small-data")
+                return super().get_data()
+        """,
+        """from benchopt.utils.temp_benchmark import TempDataset
+        class Dataset(TempDataset):
+            name = "large-data"
+            tags = ["easy", "large"]
+            def get_data(self):
+                print("DATA#large-data")
+                return super().get_data()
+        """,
+        """from benchopt.utils.temp_benchmark import TempDataset
+        class Dataset(TempDataset):
+            name = "private-data"
+            tags = ["hard", "large"]
+            def get_data(self):
+                print("DATA#private-data")
+                return super().get_data()
+        """,
+    ]
+    return solvers, datasets
+
+
 class TestRunCmd:
 
     @pytest.mark.parametrize('invalid_benchmark, match', [
@@ -116,6 +166,51 @@ class TestRunCmd:
         # Make sure the results were saved in a result file
         assert len(out.result_files) == 1, out
 
+    def test_scoped_tag_filters(self):
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(solvers=solvers, datasets=datasets) as bench, \
+                CaptureCmdOutput() as out:
+            run([
+                str(bench.benchmark_dir), "-s", "cpu-solver",
+                "-s", "gpu-solver", "-st", "gpu",
+                "-d", "small-data", "-d", "large-data",
+                "-dt", "large",
+                "-n", "1", "-r", "1", "--no-plot"
+            ], "benchopt", standalone_mode=False)
+
+        out.check_output("RUN#cpu-solver", repetition=0)
+        out.check_output("RUN#gpu-solver")
+        out.check_output("RUN#hard-solver", repetition=0)
+        out.check_output("DATA#small-data", repetition=0)
+        out.check_output("DATA#large-data")
+        out.check_output("DATA#private-data", repetition=0)
+
+    def test_repeated_tag_filters_use_or(self):
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(solvers=solvers, datasets=datasets) as bench, \
+                CaptureCmdOutput() as out:
+            run([
+                str(bench.benchmark_dir), "--solver-tag", "cpu",
+                "--solver-tag", "gpu", "--dataset-tag", "small",
+                "-n", "1", "-r", "1", "--no-plot"
+            ], "benchopt", standalone_mode=False)
+
+        out.check_output("RUN#cpu-solver")
+        out.check_output("RUN#gpu-solver")
+        out.check_output("RUN#hard-solver")
+        out.check_output("DATA#small-data")
+        out.check_output("DATA#large-data", repetition=0)
+        out.check_output("DATA#private-data", repetition=0)
+
+    def test_invalid_tag(self):
+        with temp_benchmark() as bench:
+            with pytest.raises(
+                    click.BadParameter,
+                    match="Tags .*missing.* did not match any solver"):
+                run([
+                    str(bench.benchmark_dir), "--solver-tag", "missing"
+                ], "benchopt", standalone_mode=False)
+
     @pytest.mark.parametrize('cv', [True, False])
     def test_n_rep_display(self, cv):
         objective = f"""
@@ -158,6 +253,24 @@ class TestRunCmd:
 
         # Make sure the results were saved in a result file
         assert len(out.result_files) == 1, out
+
+    def test_tag_filters_in_env(self, test_env_name):
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(solvers=solvers, datasets=datasets) as bench, \
+                CaptureCmdOutput() as out:
+            run([
+                str(bench.benchmark_dir), "--env-name", test_env_name,
+                "--solver-tag", "gpu", "--dataset-tag", "large",
+                "-n", "1", "-r", "1",
+                "--no-plot"
+            ], "benchopt", standalone_mode=False)
+
+        out.check_output("RUN#cpu-solver", repetition=0)
+        out.check_output("RUN#gpu-solver")
+        out.check_output("RUN#hard-solver")
+        out.check_output("DATA#small-data", repetition=0)
+        out.check_output("DATA#large-data")
+        out.check_output("DATA#private-data")
 
     @pytest.mark.parametrize('timeout', ['10', '1m', '0.03h', '100s'])
     def test_timeout_in_env(self, test_env_name, timeout):
@@ -423,6 +536,17 @@ class TestRunCmd:
                         standalone_mode=False)
         out.check_output("not run yet", repetition=1)
 
+    def test_complete_tags(self):
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(solvers=solvers, datasets=datasets) as bench:
+            benchmark = str(bench.benchmark_dir)
+            _test_shell_completion(
+                run, [benchmark, "-st"], [("g", ["gpu"])]
+            )
+            _test_shell_completion(
+                run, [benchmark, "-dt"], [("l", ["large"])]
+            )
+
     def test_complete_bench(self, bench_completion_cases):  # noqa: F811
 
         # Completion for benchmark name
@@ -511,6 +635,64 @@ class TestRunCmdConfig:
             out.check_output(r'test-solver\[param1=27\]:', repetition=2)
             out.check_output(r'test-solver\[param1=42\]:', repetition=0)
             out.check_output(r'test-solver\[param1=0\]:', repetition=0)
+
+    def test_tag_filters_from_config(self):
+        config = """
+        solver-tag: gpu
+        dataset-tag: large
+        n-repetitions: 1
+        max-runs: 1
+        plot: false
+        """
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(
+                config=config, solvers=solvers, datasets=datasets) as bench:
+            args = [
+                str(bench.benchmark_dir), "--config",
+                str(bench.benchmark_dir / "config.yml")
+            ]
+            with CaptureCmdOutput() as out:
+                run(args, "benchopt", standalone_mode=False)
+
+            out.check_output("RUN#cpu-solver", repetition=0)
+            out.check_output("RUN#gpu-solver")
+            out.check_output("RUN#hard-solver")
+            out.check_output("DATA#small-data", repetition=0)
+            out.check_output("DATA#large-data")
+            out.check_output("DATA#private-data")
+
+            with CaptureCmdOutput() as out:
+                run([
+                    *args, "--solver-tag", "cpu", "--no-cache"
+                ], "benchopt", standalone_mode=False)
+
+            out.check_output("RUN#cpu-solver")
+            out.check_output("RUN#gpu-solver", repetition=0)
+            out.check_output("RUN#hard-solver", repetition=0)
+
+    def test_tag_filter_lists_from_config(self):
+        config = """
+        solver-tag: [cpu, hard]
+        dataset-tag: [small, large]
+        n-repetitions: 1
+        max-runs: 1
+        plot: false
+        """
+        solvers, datasets = _tagged_components()
+        with temp_benchmark(
+                config=config, solvers=solvers, datasets=datasets) as bench, \
+                CaptureCmdOutput() as out:
+            run([
+                str(bench.benchmark_dir), "--config",
+                str(bench.benchmark_dir / "config.yml")
+            ], "benchopt", standalone_mode=False)
+
+        out.check_output("RUN#cpu-solver")
+        out.check_output("RUN#gpu-solver", repetition=0)
+        out.check_output("RUN#hard-solver")
+        out.check_output("DATA#small-data")
+        out.check_output("DATA#large-data")
+        out.check_output("DATA#private-data")
 
     def test_config_file_single_line(self, no_debug_log):
         n_reps = 2

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -365,7 +365,8 @@ def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
                   n_jobs=None, parallel_config=None,
                   plot_result=True, display=True, html=True,  collect=False,
                   show_progress=True, pdb=False, no_cache=False,
-                  output_file="None"):
+                  output_file="None", solver_tags=None,
+                  dataset_tags=None):
     """Run full benchmark.
 
     Parameters
@@ -420,6 +421,10 @@ def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
     output_file : str
         Filename for the parquet output. If given, the results will
         be stored at <BENCHMARK>/outputs/<filename>.parquet.
+    solver_tags : list | None
+        Tags used to select solvers. Repeated tags are combined with OR.
+    dataset_tags : list | None
+        Tags used to select datasets. Repeated tags are combined with OR.
 
     Returns
     -------
@@ -436,9 +441,12 @@ def run_benchmark(benchmark_path, solver_names=None, forced_solvers=(),
     if solver_names is None:
         solver_names = []
     solvers = benchmark.check_solver_patterns(
-        solver_names + list(forced_solvers)
+        solver_names + list(forced_solvers),
+        tags=solver_tags
     )
-    datasets = benchmark.check_dataset_patterns(dataset_names)
+    datasets = benchmark.check_dataset_patterns(
+        dataset_names, tags=dataset_tags
+    )
     objectives = benchmark.check_objective_filters(objective_filters)
 
     parallel_config = check_parallel_config(parallel_config, n_jobs)

--- a/benchopt/tests/test_benchmark_object.py
+++ b/benchopt/tests/test_benchmark_object.py
@@ -91,7 +91,9 @@ def test_invalid_component_tag(component):
             check_patterns([], tags=["missing"])
 
 
-@pytest.mark.parametrize("tags", ["None", "('easy',)", "['easy', 1]"])
+@pytest.mark.parametrize(
+    "tags", ["None", "('easy',)", "['easy', 1]", "['easy,gpu']"]
+)
 def test_invalid_component_tags(tags):
     solver = f"""from benchopt import BaseSolver
     class Solver(BaseSolver):

--- a/benchopt/tests/test_benchmark_object.py
+++ b/benchopt/tests/test_benchmark_object.py
@@ -1,3 +1,6 @@
+import click
+import pytest
+
 from benchopt.utils.temp_benchmark import temp_benchmark
 
 
@@ -19,3 +22,102 @@ def test_dataset_name_default():
     with temp_benchmark(datasets={'only-data': only_data}) as bench:
         assert len(bench.get_dataset_names()) > 1
         assert bench.get_test_dataset_names() == ['simulated']
+
+
+def test_component_tag_filters():
+    solvers = [
+        """from benchopt import BaseSolver
+        class Solver(BaseSolver):
+            name = "cpu-solver"
+            tags = ["easy", "cpu"]
+        """,
+        """from benchopt import BaseSolver
+        class Solver(BaseSolver):
+            name = "gpu-solver"
+            tags = ["easy", "gpu"]
+        """,
+        """from benchopt import BaseSolver
+        class Solver(BaseSolver):
+            name = "untagged-solver"
+        """,
+    ]
+    datasets = [
+        """from benchopt import BaseDataset
+        class Dataset(BaseDataset):
+            name = "small-data"
+            tags = ["easy", "small"]
+        """,
+        """from benchopt import BaseDataset
+        class Dataset(BaseDataset):
+            name = "large-data"
+            tags = ["hard", "large"]
+        """,
+    ]
+
+    with temp_benchmark(solvers=solvers, datasets=datasets) as bench:
+        selected = bench.check_solver_patterns(
+            [], tags=["cpu", "gpu"]
+        )
+        assert {solver.name for solver, _ in selected} == {
+            "cpu-solver", "gpu-solver"
+        }
+
+        selected = bench.check_solver_patterns(
+            ["gpu-solver"], tags=["gpu"]
+        )
+        assert [solver.name for solver, _ in selected] == ["gpu-solver"]
+
+        selected = bench.check_dataset_patterns(
+            [], tags=["easy"]
+        )
+        assert [dataset.name for dataset, _ in selected] == ["small-data"]
+
+        assert len(bench.check_solver_patterns([])) == 3
+        assert len(bench.check_dataset_patterns([])) == 2
+
+        with pytest.raises(click.BadParameter, match="No solver matches"):
+            bench.check_solver_patterns(
+                ["cpu-solver"], tags=["gpu"]
+            )
+
+
+@pytest.mark.parametrize("component", ["solver", "dataset"])
+def test_invalid_component_tag(component):
+    with temp_benchmark() as bench:
+        check_patterns = getattr(bench, f"check_{component}_patterns")
+        with pytest.raises(
+                click.BadParameter,
+                match=f"Tags .*missing.* did not match any {component}"):
+            check_patterns([], tags=["missing"])
+
+
+@pytest.mark.parametrize("tags", ["None", "('easy',)", "['easy', 1]"])
+def test_invalid_component_tags(tags):
+    solver = f"""from benchopt import BaseSolver
+    class Solver(BaseSolver):
+        name = "invalid-tags"
+        tags = {tags}
+    """
+    with temp_benchmark(solvers=solver) as bench:
+        with pytest.raises(
+                ValueError, match="literal list of strings"):
+            bench.check_solver_patterns([], tags=["easy"])
+
+
+def test_tags_must_be_statically_readable():
+    solvers = [
+        """from benchopt import BaseSolver
+        class Solver(BaseSolver):
+            name = "valid-tags"
+            tags = ["easy"]
+        """,
+        """from benchopt import BaseSolver
+        failure
+        class Solver(BaseSolver):
+            name = "computed-tags"
+            tags = make_tags()
+        """,
+    ]
+    with temp_benchmark(solvers=solvers) as bench:
+        with pytest.raises(ValueError, match="Could not read tags"):
+            bench.check_solver_patterns([], tags=["easy"])

--- a/benchopt/tests/test_runner.py
+++ b/benchopt/tests/test_runner.py
@@ -83,6 +83,56 @@ def test_benchopt_run_script(n_jobs, no_debug_log):
     assert len(out.result_files) == 1, out.raw_output
 
 
+def test_benchopt_run_script_with_tags(no_debug_log):
+    from benchopt import run_benchmark
+
+    solvers = [
+        """from benchopt.utils.temp_benchmark import TempSolver
+        class Solver(TempSolver):
+            name = "easy-solver"
+            tags = ["easy"]
+            def run(self, _): print("RUN#easy-solver")
+        """,
+        """from benchopt.utils.temp_benchmark import TempSolver
+        class Solver(TempSolver):
+            name = "hard-solver"
+            tags = ["hard"]
+            def run(self, _): print("RUN#hard-solver")
+        """,
+    ]
+    datasets = [
+        """from benchopt.utils.temp_benchmark import TempDataset
+        class Dataset(TempDataset):
+            name = "easy-data"
+            tags = ["easy"]
+            def get_data(self):
+                print("DATA#easy-data")
+                return super().get_data()
+        """,
+        """from benchopt.utils.temp_benchmark import TempDataset
+        class Dataset(TempDataset):
+            name = "hard-data"
+            tags = ["hard"]
+            def get_data(self):
+                print("DATA#hard-data")
+                return super().get_data()
+        """,
+    ]
+
+    with temp_benchmark(solvers=solvers, datasets=datasets) as benchmark, \
+            CaptureCmdOutput() as out:
+        run_benchmark(
+            str(benchmark.benchmark_dir), solver_tags=["easy"],
+            dataset_tags=["easy"], max_runs=1,
+            n_repetitions=1, plot_result=False
+        )
+
+    out.check_output("RUN#easy-solver")
+    out.check_output("RUN#hard-solver", repetition=0)
+    out.check_output("DATA#easy-data")
+    out.check_output("DATA#hard-data", repetition=0)
+
+
 def test_prefix_with_same_parameters():
     from benchopt import run_benchmark
 

--- a/benchopt/utils/tests/test_dynamic_module.py
+++ b/benchopt/utils/tests/test_dynamic_module.py
@@ -71,6 +71,23 @@ def test_ast_replacement_no_name():
             Solver.is_installed(raise_on_not_installed=True)
 
 
+def test_ast_replacement_tags():
+    solver = """
+    from benchopt import BaseSolver
+    import benchopt_test_missing_dependency
+
+    class Solver(BaseSolver):
+        name = "tagged-solver"
+        tags = ["easy", "cpu"]
+    """
+    with temp_benchmark(solvers=solver) as bench:
+        solvers = bench.check_solver_patterns(
+            [], tags=["easy"]
+        )
+        assert [solver.name for solver, _ in solvers] == ["tagged-solver"]
+        assert solvers[0][0].tags == ["easy", "cpu"]
+
+
 def test_ast_replacement_name_undefined():
     # Test that the AST replacement works when a dynamic module is not
     # importable. In particular, this makes sure that the module filename

--- a/doc/benchmark_workflow/run_benchmark.rst
+++ b/doc/benchmark_workflow/run_benchmark.rst
@@ -89,6 +89,17 @@ For instance, the following command runs the benchmark with solvers
 The ``-s`` flag is to specify a solver whereas ``-d`` specifies a dataset.
 To include multiple datasets/solvers, use multiple ``-d``/``-s`` flags, as in the above snippet.
 
+Solvers and datasets can also be selected through their :ref:`component tags
+<component_tags>`. Use ``-st``/``--solver-tag`` and
+``-dt``/``--dataset-tag`` to filter each component independently:
+
+.. prompt:: bash $
+
+    benchopt run . --solver-tag gpu --dataset-tag large
+
+Each option is repeatable and matches any of the tags passed to it. A tag
+filter and the corresponding name selector are combined.
+
 .. note::
 
     The ``run`` command accepts other flags such as ``-j`` to run the benchmark in parallel with a given number of processes.
@@ -133,6 +144,9 @@ Using a YAML file and the ``--config`` flag, it is possible to describe all deta
 Here is the content of configuration file ``example_config.yml`` if we were to run the two previous examples into a single one.
 
 .. code-block:: yaml
+
+    solver-tag: [cpu, gpu]
+    dataset-tag: small
 
     solver:
         - solver1
@@ -180,6 +194,8 @@ It assumes that the python script is located at the same level as the benchmark 
             "dataset3",
             "dataset1[n_samples=100,n_features=20]"
         ],
+        solver_tags=["cpu", "gpu"],
+        dataset_tags=["small"],
     )
 
 .. note::

--- a/doc/user_guide/class_customization.rst
+++ b/doc/user_guide/class_customization.rst
@@ -132,6 +132,35 @@ Once declared, the choices enable two things:
 - **Discovering the values** through ``benchopt info -v``, which lists them
   (with a total count) alongside the default grid.
 
+.. _component_tags:
+
+Tagging solvers and datasets
+----------------------------
+
+Solvers and datasets can declare optional class-level ``tags`` to group
+related components:
+
+.. code-block:: python
+
+   class Solver(BaseSolver):
+       name = "my-solver"
+       tags = ["easy", "cpu"]
+
+Tags apply to every parameterization of the class. They can be used to select
+solvers and datasets independently:
+
+.. prompt:: bash $
+
+   benchopt run . --solver-tag cpu --dataset-tag small
+
+The ``tags`` attribute defaults to an empty list. Define it as a literal
+list of strings so Benchopt can read it even when a component's
+requirements are not installed. Tags are matched exactly and are
+case-sensitive. Repeating one tag option matches any of its values.
+Name selectors and tag filters are combined, so a component must satisfy
+both filters.
+
+
 .. _managing_dependencies:
 
 Managing dependencies


### PR DESCRIPTION
I think it is a good idea for solvers and datasets to have tags and use them to select components when running a benchmark.

Solvers and datasets declare tags as class-level lists:

```python
class Solver(BaseSolver):
    tags = ["gpu", "transformer"]
```
Components can then be selected with:
```
$ benchopt run . -st gpu -dt easy
```
The long forms versions are `--solver-tag` and `--dataset-tag`.

I see this being used for example in benchmarks of foundation models where you want to evaluate on task-specific datasets, instead of selecting each dataset by hand.

(I'll add the what's new if this is accepted)

### AI use : 

I was assisted by Codex for this PR.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)