### PR TITLE
ENH rich progress display

### DIFF
--- a/benchopt/_generate_runs.py
+++ b/benchopt/_generate_runs.py
@@ -5,18 +5,6 @@ from .utils.parametrized_name_mixin import is_matched
 from .utils.run_context import RunContext
 
 
-def buffer_iterator(it):
-    """Buffer the output of an iterator to repeat it without recomputing."""
-    buffer = []
-
-    def buffered_it(buffer):
-        for val in it:
-            buffer.append(val)
-            yield val
-
-    return buffered_it(buffer), buffer
-
-
 def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
                   datasets=None, objectives=None, terminal=None):
     """Generator with all combinations to run for the benchmark.
@@ -49,19 +37,30 @@ def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
     """
     from .benchmark import _list_parametrized_classes
 
-    all_datasets = _list_parametrized_classes(*datasets)
-    all_solvers, solvers_buffer = buffer_iterator(
-        _list_parametrized_classes(*solvers)
+    # Listing the parametrized classes only instantiates them, the data is
+    # only loaded in `get_solver_kwargs`, so this is cheap enough to be
+    # resolved upfront to know how many runs the benchmark contains.
+    all_datasets = list(_list_parametrized_classes(*datasets))
+    all_solvers = list(_list_parametrized_classes(*solvers))
+    n_configs = (
+        sum(is_installed for _, is_installed in all_datasets)
+        * sum(is_installed for _, is_installed in all_solvers)
     )
+
     for dataset, is_installed in all_datasets:
         terminal.set(dataset=dataset)
         if not is_installed:
             terminal.show_status('not installed', dataset=True)
             continue
         terminal.display_dataset()
-        all_objectives = _list_parametrized_classes(
+        # A new objective instance is created for each dataset, as it holds
+        # the data once `_set_dataset` has been called.
+        all_objectives = list(_list_parametrized_classes(
             *objectives, check_installed=False
-        )
+        ))
+        terminal.set_n_configs(n_configs * sum(
+            is_installed for _, is_installed in all_objectives
+        ))
         for objective, is_installed in all_objectives:
             terminal.set(objective=objective)
             if not is_installed:
@@ -82,7 +81,6 @@ def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
                     dataset=dataset, objective=objective, solver=solver,
                     force=force, terminal=terminal
                 )
-            all_solvers = solvers_buffer
 
 
 def get_solver_kwargs(

--- a/benchopt/_generate_runs.py
+++ b/benchopt/_generate_runs.py
@@ -5,6 +5,18 @@ from .utils.parametrized_name_mixin import is_matched
 from .utils.run_context import RunContext
 
 
+def buffer_iterator(it):
+    """Buffer the output of an iterator to repeat it without recomputing."""
+    buffer = []
+
+    def buffered_it(buffer):
+        for val in it:
+            buffer.append(val)
+            yield val
+
+    return buffered_it(buffer), buffer
+
+
 def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
                   datasets=None, objectives=None, terminal=None):
     """Generator with all combinations to run for the benchmark.
@@ -37,30 +49,23 @@ def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
     """
     from .benchmark import _list_parametrized_classes
 
-    # Listing the parametrized classes only instantiates them, the data is
-    # only loaded in `get_solver_kwargs`, so this is cheap enough to be
-    # resolved upfront to know how many runs the benchmark contains.
-    all_datasets = list(_list_parametrized_classes(*datasets))
-    all_solvers = list(_list_parametrized_classes(*solvers))
-    n_configs = (
-        sum(is_installed for _, is_installed in all_datasets)
-        * sum(is_installed for _, is_installed in all_solvers)
+    terminal.set_n_configs(
+        benchmark.get_n_configs(solvers, datasets, objectives)
     )
 
+    all_datasets = _list_parametrized_classes(*datasets)
+    all_solvers, solvers_buffer = buffer_iterator(
+        _list_parametrized_classes(*solvers)
+    )
     for dataset, is_installed in all_datasets:
         terminal.set(dataset=dataset)
         if not is_installed:
             terminal.show_status('not installed', dataset=True)
             continue
         terminal.display_dataset()
-        # A new objective instance is created for each dataset, as it holds
-        # the data once `_set_dataset` has been called.
-        all_objectives = list(_list_parametrized_classes(
+        all_objectives = _list_parametrized_classes(
             *objectives, check_installed=False
-        ))
-        terminal.set_n_configs(n_configs * sum(
-            is_installed for _, is_installed in all_objectives
-        ))
+        )
         for objective, is_installed in all_objectives:
             terminal.set(objective=objective)
             if not is_installed:
@@ -81,6 +86,8 @@ def _get_all_runs(benchmark, solvers=None, forced_solvers=None,
                     dataset=dataset, objective=objective, solver=solver,
                     force=force, terminal=terminal
                 )
+
+            all_solvers = solvers_buffer
 
 
 def get_solver_kwargs(

--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -223,6 +223,27 @@ class Benchmark:
             class_only=class_only
         )
 
+    def get_n_configs(self, solvers, datasets, objectives):
+        """Number of (dataset, objective, solver) configs that will be run.
+
+        The parameter grids are counted without instantiating the classes,
+        so that the total is known before the runs start. Classes that are
+        not installed are excluded, as they are skipped by the runner.
+        """
+        def count(classes, check_installed=True):
+            return sum(
+                sum(1 for _ in _get_used_parameters(klass, params))
+                for klass, params in classes
+                if not check_installed or klass.is_installed(
+                    raise_on_not_installed=RAISE_INSTALL_ERROR, quiet=True
+                )
+            )
+
+        return (
+            count(datasets) * count(objectives, check_installed=False)
+            * count(solvers)
+        )
+
     def get_datasets(self):
         "List all available dataset classes for the benchmark."
         return self._list_benchmark_classes(BaseDataset)

--- a/benchopt/config.py
+++ b/benchopt/config.py
@@ -35,6 +35,7 @@ DEFAULT_GLOBAL_CONFIG = {
     'cache': None,
     'default_timeout': 100,
     'warn_nonunique_files': True,
+    'no_rich': False,
     '_g_config_check': False,
     '_bench_config_check': False,
 }
@@ -66,6 +67,8 @@ particular for logging, warnings and errors. The available options are:
 * ``warn_nonunique_files``, *bool*: If set to True, raise a warning when a
   results file is about to be overwritten because a file with the same name
   already exists. Mostly useful to deactivate this warning in tests.
+* ``no_rich``, *bool*: If set to True, disable the live display of
+  ``benchopt run`` and fall back on the plain line by line output.
 """
 
 DEFAULT_BENCHMARK_CONFIG = {

--- a/benchopt/parallel_backends/__init__.py
+++ b/benchopt/parallel_backends/__init__.py
@@ -55,7 +55,12 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
     check_in_cache = getattr(run, "check_call_in_cache", None)
 
     def _to_dispatch():
+        # `terminal` is only present for benchmark runs, not for `prepare`.
+        terminal = None
         for run_kwargs in run_kwargs_generator:
+            terminal = run_kwargs.get('terminal')
+            if terminal is not None:
+                terminal.start_run(run_kwargs['meta'])
             if (check_in_cache is not None
                     and not run_kwargs.get('force', False)
                     and check_in_cache(**run_kwargs)):
@@ -71,6 +76,9 @@ def parallel_run(benchmark, run, run_kwargs_generator, config, collect=False):
                 ready.append(([], key, 'not run yet', "", False))
             else:
                 yield run_kwargs
+
+        if terminal is not None:
+            terminal.all_dispatched()
 
     for item in _dispatch(backend, benchmark, run, _to_dispatch(), config):
         while ready:

--- a/benchopt/parallel_backends/slurm_executor.py
+++ b/benchopt/parallel_backends/slurm_executor.py
@@ -86,10 +86,15 @@ def run_on_slurm(
 ):
 
     executors = {}
-    tasks = []
+    tasks, keys, terminal = [], [], None
 
     with ExitStack() as stack:
         for kwargs in run_kwargs_generator:
+            terminal = kwargs.get("terminal", terminal)
+            meta = kwargs.get("meta")
+            if meta is not None:
+                keys.append((meta["dataset_name"], meta["objective_name"],
+                             meta["solver_name"]))
             solver = kwargs.get("solver")
             if solver is not None:
                 job_slurm_config = get_solver_slurm_config(
@@ -112,6 +117,11 @@ def run_on_slurm(
                 run_one_solver, **kwargs
             )
             tasks.append(future)
+
+    if terminal is not None and len(keys) == len(tasks):
+        terminal.set_running_probe(lambda: [
+            key for key, job in zip(keys, tasks) if job.state == "RUNNING"
+        ])
 
     # Yield results as jobs finish (unordered)
     for t in as_completed(tasks):

--- a/benchopt/plotting/__init__.py
+++ b/benchopt/plotting/__init__.py
@@ -93,7 +93,7 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
     -------
     figs : list
         The matplotlib figures for convergence curve and bar chart
-        for each dataset.
+        for each dataset, or the paths of the generated pages if `html`.
     """
     benchmark = Benchmark(benchmark)
     plot_config = get_metadata(fname)
@@ -124,7 +124,7 @@ def plot_benchmark(fname, benchmark, kinds=None, display=True, plotly=False,
         _check_view(name, view, plots)
 
     if html:
-        plot_benchmark_html(fname, benchmark, plot_config, display)
+        return plot_benchmark_html(fname, benchmark, plot_config, display)
 
     else:
         # Load the results.

--- a/benchopt/plotting/generate_html.py
+++ b/benchopt/plotting/generate_html.py
@@ -364,8 +364,10 @@ def plot_benchmark_html(
     print("done")
 
     # Save the resulting page in the HTML folder
+    result_filenames = []
     for result, html in zip(results, htmls):
         result_filename = html_root / result['page']
+        result_filenames.append(result_filename)
         result_filename.parent.mkdir(exist_ok=True)
         print(f"Writing results to {result_filename}")
         with open(result_filename, "w", encoding="utf-8") as f:
@@ -386,6 +388,8 @@ def plot_benchmark_html(
     if display:
         result_filename = (html_root / results[-1]['page']).absolute()
         webbrowser.open_new_tab('file://' + quote(str(result_filename)))
+
+    return result_filenames
 
 
 def plot_benchmark_html_all(patterns=(), benchmark_paths=(), root=None,

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -6,7 +6,7 @@ from .callback import _Callback
 from .benchmark import Benchmark
 from .utils.sys_info import get_sys_info
 from .utils.pdb_helpers import exception_handler
-from .utils.terminal_output import TerminalOutput
+from .utils.rich_output import make_terminal_output
 from .parallel_backends import parallel_run
 from .parallel_backends import check_parallel_config
 from .results import save_results
@@ -15,6 +15,14 @@ from ._generate_runs import generate_run_kwargs
 
 FAILURE_STATUS = ['diverged', 'error', 'interrupted']
 SUCCESS_STATUS = ['done', 'max_runs', 'timeout']
+
+
+def _get_n_workers(parallel_config):
+    """Number of runs that can be executed concurrently, for the display."""
+    config = parallel_config or {}
+    return (
+        config.get('n_jobs') or config.get('slurm_array_parallelism') or 1
+    )
 
 
 class FailedRun(RuntimeError):
@@ -277,7 +285,10 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
         Path to the output file where the results have been saved.
     """
     exit_code = 0
-    terminal = TerminalOutput(n_repetitions, show_progress)
+    terminal = make_terminal_output(
+        n_repetitions, show_progress, pdb=pdb,
+        n_jobs=_get_n_workers(parallel_config),
+    )
 
     # Resolve the output filename stem before runs start so that
     # run_output_base is stable across all workers.
@@ -327,34 +338,52 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
         benchmark, run_one_to_cvg_final, total_cvg_kwargs_generator,
         config=parallel_config, collect=collect
     )
+    log_file = output_dir / f'{Path(output_file).stem}.log'
     try:
-        for result, key, status, reason, cached in results_generator:
-            run_statistics.extend(result)
-            terminal.set(dataset=key[0], objective=key[1], solver=key[2])
-            terminal.show_status(status=status, reason=reason, cached=cached)
-            if status == 'interrupted':
-                raise SystemExit(1)
+        # The generator drives the run enumeration, so the whole display is
+        # held while the results are consumed.
+        with terminal.live(log_file=log_file):
+            for result, key, status, reason, cached in results_generator:
+                run_statistics.extend(result)
+                terminal.set(dataset=key[0], objective=key[1], solver=key[2])
+                terminal.show_status(
+                    status=status, reason=reason, cached=cached
+                )
+                if status == 'interrupted':
+                    raise SystemExit(1)
     except KeyboardInterrupt:
         print(end='', flush=True)
-        terminal.show_status('interrupted')
+        terminal.show_interrupted()
         raise
 
     import pandas as pd
-    df = pd.DataFrame(run_statistics)
+    with terminal.step("Collecting results"):
+        df = pd.DataFrame(run_statistics)
     if df.empty:
         terminal.savefile_status()
         return 1, None
 
     # Save output in parquet file in the benchmark folder
-    output_file = save_results(df, output_dir / output_file)
+    with terminal.step("Saving results"):
+        output_file = save_results(df, output_dir / output_file)
 
+    html_files = None
     if plot_result:
         try:
             from benchopt.plotting import plot_benchmark
-            plot_benchmark(output_file, benchmark, html=html, display=display)
+            with terminal.step("Rendering results"):
+                html_files = plot_benchmark(
+                    output_file, benchmark, html=html, display=display
+                )
         except Exception as e:
             print(f"Failed to plot the benchmark results: {e}")
             exit_code = 1
+
+    terminal.show_outputs(
+        results=output_file,
+        report=html_files[0] if html_files else None,
+        log=log_file,
+    )
 
     return exit_code, output_file
 

--- a/benchopt/skills/using-benchopt/debug.md
+++ b/benchopt/skills/using-benchopt/debug.md
@@ -235,6 +235,11 @@ https://benchopt.github.io/stable/benchmark_workflow/test_benchmark.html
 - For an error *inside* a real run, `benchopt run . --pdb` drops into the
   debugger at the failing line — reach for the Benchmark object when you want to
   reproduce or probe the code outside the run loop.
+- In a terminal, `benchopt run` shows a live progress display and sends the
+  stdout, stderr and tracebacks of the run — including the ones of the parallel
+  workers — to `outputs/<run_name>.log`. That is where your `print` calls and
+  the traceback of a run marked `error` end up. `BENCHOPT_NO_RICH=1` (or piping
+  the output) falls back to plain output on the terminal.
 - Everything here uses the installed benchmark code in the current environment;
   no conda env, caching or parallelism is involved, so edits to the benchmark's
   `.py` files take effect on the next `Benchmark(".")` / re-import.

--- a/benchopt/skills/using-benchopt/debug.md
+++ b/benchopt/skills/using-benchopt/debug.md
@@ -238,8 +238,8 @@ https://benchopt.github.io/stable/benchmark_workflow/test_benchmark.html
 - In a terminal, `benchopt run` shows a live progress display and sends the
   stdout, stderr and tracebacks of the run — including the ones of the parallel
   workers — to `outputs/<run_name>.log`. That is where your `print` calls and
-  the traceback of a run marked `error` end up. `BENCHOPT_NO_RICH=1` (or piping
-  the output) falls back to plain output on the terminal.
+  the traceback of a run marked `error` end up. `BENCHOPT_NO_RICH=1`, the
+  `no_rich` config option, or piping the output falls back to plain output.
 - Everything here uses the installed benchmark code in the current environment;
   no conda env, caching or parallelism is involved, so edits to the benchmark's
   `.py` files take effect on the next `Benchmark(".")` / re-import.

--- a/benchopt/skills/using-benchopt/run.md
+++ b/benchopt/skills/using-benchopt/run.md
@@ -129,7 +129,8 @@ run expensive preprocessing once before any benchmarking run.
 - In a terminal, the run shows a live progress display (global progress bar,
   runs in flight, done/cached/skip/error counters) on the alternate screen,
   and the stdout, stderr and tracebacks go to `outputs/<run_name>.log`. Set
-  `BENCHOPT_NO_RICH=1` or pipe the output for the plain line-by-line display.
+  `BENCHOPT_NO_RICH=1` (or `no_rich: true` in the benchopt config file), or
+  pipe the output, for the plain line-by-line display.
   Once the runs are over, the screen is restored and the results, then where
   the result file, the HTML report and the log are, are printed.
 - The name of the output can be controlled with the `--output` option.

--- a/benchopt/skills/using-benchopt/run.md
+++ b/benchopt/skills/using-benchopt/run.md
@@ -126,6 +126,12 @@ run expensive preprocessing once before any benchmarking run.
 
 - Results are `.parquet` files under `./outputs/`. An HTML dashboard is
   generated unless `--no-html`; `--no-plot`/`--no-display` skip plotting.
+- In a terminal, the run shows a live progress display (global progress bar,
+  runs in flight, done/cached/skip/error counters) on the alternate screen,
+  and the stdout, stderr and tracebacks go to `outputs/<run_name>.log`. Set
+  `BENCHOPT_NO_RICH=1` or pipe the output for the plain line-by-line display.
+  Once the runs are over, the screen is restored and the results, then where
+  the result file, the HTML report and the log are, are printed.
 - The name of the output can be controlled with the `--output` option.
   If the name already exist, the new result is postfixed with `-1` or
   `-X` the X-th time.

--- a/benchopt/tests/test_benchmark_object.py
+++ b/benchopt/tests/test_benchmark_object.py
@@ -19,3 +19,36 @@ def test_dataset_name_default():
     with temp_benchmark(datasets={'only-data': only_data}) as bench:
         assert len(bench.get_dataset_names()) > 1
         assert bench.get_test_dataset_names() == ['simulated']
+
+
+def test_get_n_configs():
+    # get_n_configs counts the parametrized (dataset, objective, solver)
+    # combinations that `_get_all_runs` yields.
+    from benchopt._generate_runs import _get_all_runs
+    from benchopt.utils.terminal_output import TerminalOutput
+
+    solver = """from benchopt import BaseSolver
+    class Solver(BaseSolver):
+        name = "solver"
+        parameters = {'p': [1, 2, 3]}
+        sampling_strategy = 'run_once'
+        def set_objective(self, X, y): pass
+        def run(self, n_iter): pass
+        def get_result(self): return dict(beta=1)
+    """
+    dataset = """from benchopt import BaseDataset
+    class Dataset(BaseDataset):
+        name = "data"
+        parameters = {'n': [10, 20]}
+        def get_data(self): return dict(X=0, y=0)
+    """
+    with temp_benchmark(solvers=solver, datasets=dataset) as bench:
+        solvers = bench.check_solver_patterns(None)
+        datasets = bench.check_dataset_patterns(None)
+        objectives = bench.check_objective_filters(None)
+        n_runs = len(list(_get_all_runs(
+            bench, solvers, None, datasets, objectives,
+            terminal=TerminalOutput(1, False)
+        )))
+        assert bench.get_n_configs(solvers, datasets, objectives) == n_runs
+        assert n_runs == 6

--- a/benchopt/tests/test_rich_output.py
+++ b/benchopt/tests/test_rich_output.py
@@ -1,6 +1,7 @@
 import io
 import os
 import pickle
+import sys
 
 from rich.console import Console
 
@@ -180,9 +181,18 @@ def test_rich_output_unordered_results():
     ]
 
 
-def test_make_terminal_output():
+def test_make_terminal_output(monkeypatch):
     # stdout is captured by pytest, hence not a terminal.
     assert type(make_terminal_output(1, True)) is TerminalOutput
+
+    # The display can be turned off, from the config file or the environment.
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    assert type(make_terminal_output(1, True)) is RichOutput
+    monkeypatch.setenv("BENCHOPT_NO_RICH", "true")
+    assert type(make_terminal_output(1, True)) is TerminalOutput
+    # Unlike a bare environment variable check, `0` does not disable it.
+    monkeypatch.setenv("BENCHOPT_NO_RICH", "0")
+    assert type(make_terminal_output(1, True)) is RichOutput
 
 
 def test_rich_output_steps(tmp_path):

--- a/benchopt/tests/test_rich_output.py
+++ b/benchopt/tests/test_rich_output.py
@@ -1,0 +1,266 @@
+import io
+import os
+import pickle
+
+from rich.console import Console
+
+from benchopt.utils.terminal_output import TerminalOutput
+from benchopt.utils.rich_output import RichOutput, _redirect_fds
+from benchopt.utils.rich_output import make_terminal_output
+
+
+META = dict(
+    # Names contain brackets, which are `rich` markup and must be escaped.
+    dataset_name="simu[n_samples=10]",
+    objective_name="obj[reg=0.1]",
+    solver_name="solver[lr=1e-3]",
+)
+KEY = tuple(META.values())
+
+
+def _render_to_str(terminal):
+    "Render the live display in a string, without any terminal involved."
+    from rich.console import Console
+
+    console = Console(file=io.StringIO(), width=120, highlight=False)
+    console.print(terminal._render())
+    return console.file.getvalue()
+
+
+def test_redirect_fds(tmp_path):
+    log_file = tmp_path / "run.log"
+    # Write on the file descriptors rather than with `print`, as pytest
+    # replaces `sys.stdout` with an object that does not use fd 1.
+    with _redirect_fds(log_file):
+        os.write(1, b"from this process\n")
+        os.system("echo from subprocess")
+
+    log = log_file.read_text()
+    assert "from this process" in log
+    assert "from subprocess" in log
+
+    # The file descriptors are restored on exit.
+    os.system("echo back on stdout")
+    assert "back on stdout" not in log_file.read_text()
+
+
+def test_rich_output(tmp_path):
+    log_file = tmp_path / "run.log"
+    terminal = RichOutput(n_repetitions=2, show_progress=False, n_jobs=2)
+    terminal.set_n_configs(3)
+
+    with terminal.live(log_file=log_file):
+        terminal.set(dataset=KEY[0], objective=KEY[1], solver=KEY[2])
+
+        # Two repetitions of the same run are stacked on a single line.
+        terminal.start_run(META)
+        terminal.start_run(META)
+        assert terminal.n_dispatched == 2
+        assert terminal._total() == 6
+
+        # The runs are displayed as a dataset > objective > solver tree.
+        display = _render_to_str(terminal)
+        assert display.count("simu[n_samples=10]") == 1
+        assert "Running" in display and "Total" in display
+        assert "solver[lr=1e-3] — 2 reps running (0/2 done)" in display
+
+        # Only `n_jobs` runs hold a worker, the ones dispatched after wait.
+        terminal.start_run(META)
+        display = _render_to_str(terminal)
+        assert "2 reps running" in display
+        assert "+1 queued" in display
+
+        # In the workers, the display falls back to the plain output.
+        worker_terminal = pickle.loads(pickle.dumps(terminal))
+        assert worker_terminal._worker
+        assert worker_terminal.console is None
+
+        for _ in range(3):
+            terminal.show_status(status='done')
+        assert len(terminal.in_flight) == 0
+        assert terminal.n_finished == 3
+        assert terminal.counts['done'] == 3
+
+        # Once everything is dispatched, the total is exact.
+        terminal.all_dispatched()
+        assert terminal._total() == 3
+
+        os.system("echo output of the run")
+
+    assert "output of the run" in log_file.read_text()
+
+
+def test_rich_output_result_tree():
+    from rich.console import Console
+
+    terminal = RichOutput(n_repetitions=1, show_progress=False)
+    terminal.console = Console(file=io.StringIO(), width=120,
+                               highlight=False)
+
+    runs = [
+        ("data[n=1]", "obj[p=1]", "s1", 'done', False),
+        ("data[n=1]", "obj[p=1]", "s2", 'max_runs', True),
+        ("data[n=1]", "obj[p=2]", "s1", 'error', False),
+        ("data[n=2]", "obj[p=1]", "s1", 'skip', True),
+    ]
+    for data, obj, solver, status, cached in runs:
+        terminal.set(dataset=data, objective=obj, solver=solver)
+        terminal.show_status(status=status, cached=cached, reason="a reason")
+    terminal.show_status(status='interrupted')
+
+    # The results are only printed once the display is over.
+    assert terminal.console.file.getvalue() == ""
+    for markup in terminal._lines():
+        terminal.console.print(markup)
+    display = terminal.console.file.getvalue()
+    assert display == (
+        "data[n=1]\n"
+        "├── obj[p=1]\n"
+        "│   ├── ✓ s1 done\n"
+        # A cached result is reported as done, whatever stopped the run.
+        "│   ├── ✓ s2 done (cached)\n"
+        "├── obj[p=2]\n"
+        "│   ├── ✗ s1 error (traceback in the log)\n"
+        "data[n=2]\n"
+        "├── obj[p=1]\n"
+        # A skipped run has no cached result to report.
+        "│   ├── » s1 skip\n"
+        "│   │   Reason: a reason\n"
+        # A run interrupted mid-way is reported as any other status.
+        "│   ├── ! s1 interrupted\n"
+    )
+    assert terminal.counts == {
+        'done': 1, 'cached': 1, 'error': 1, 'skip': 1, 'interrupted': 1
+    }
+
+
+def test_rich_output_interrupted():
+    from rich.console import Console
+
+    terminal = RichOutput(n_repetitions=1, show_progress=False, n_jobs=2)
+    terminal.console = Console(file=io.StringIO(), width=120,
+                               highlight=False)
+
+    terminal.start_run(META)
+    terminal.set(dataset=KEY[0], objective=KEY[1], solver=KEY[2])
+    terminal.show_status(status='done')
+
+    # A keyboard interruption does not report anything: the runs that were
+    # still going produced no result.
+    terminal.show_interrupted()
+    assert "interrupted" not in terminal.console.file.getvalue()
+
+
+def test_rich_output_unordered_results():
+    from rich.console import Console
+
+    terminal = RichOutput(n_repetitions=1, show_progress=False, n_jobs=2)
+    terminal.console = Console(file=io.StringIO(), width=120, highlight=False)
+
+    runs = [
+        ("data[n=1]", "obj", "fast"),
+        ("data[n=2]", "obj", "fast"),
+        # A slow run of the first dataset finishes after the second one.
+        ("data[n=1]", "obj", "slow"),
+    ]
+    for data, obj, solver in runs:
+        terminal.set(dataset=data, objective=obj, solver=solver)
+        terminal.show_status(status='done')
+
+    # The late result is grouped with the runs sharing its dataset, and no
+    # dataset is displayed twice.
+    assert list(terminal._lines()) == [
+        "[bold]data\\[n=1][/]",
+        "[dim]├── [/][bold]obj[/]",
+        "[dim]│   [/][dim]├── [/][green]✓[/] fast [green]done[/]",
+        "[dim]│   [/][dim]├── [/][green]✓[/] slow [green]done[/]",
+        "[bold]data\\[n=2][/]",
+        "[dim]├── [/][bold]obj[/]",
+        "[dim]│   [/][dim]├── [/][green]✓[/] fast [green]done[/]",
+    ]
+
+
+def test_make_terminal_output():
+    # stdout is captured by pytest, hence not a terminal.
+    assert type(make_terminal_output(1, True)) is TerminalOutput
+
+
+def test_rich_output_steps(tmp_path):
+    log_file = tmp_path / "run.log"
+    terminal = RichOutput(n_repetitions=1, show_progress=False)
+    terminal.log_file = log_file
+    log_file.write_text("run output\n")
+
+    # The output of a step goes to the log, not on top of the spinner.
+    with terminal.step("Saving results"):
+        os.write(1, b"from the step\n")
+    assert "from the step" in log_file.read_text()
+    # The log is not overwritten by the step.
+    assert "run output" in log_file.read_text()
+
+    terminal.console = Console(file=io.StringIO(), width=120, highlight=False)
+    terminal.show_outputs(results="res.parquet", report=None, log=log_file)
+    display = terminal.console.file.getvalue()
+    assert "res.parquet" in display and str(log_file) in display
+    # Only the outputs that were produced are reported.
+    assert "report" not in display
+
+
+def test_rich_output_fits_the_screen():
+    terminal = RichOutput(n_repetitions=1, show_progress=False, n_jobs=20)
+    terminal.console = Console(file=io.StringIO(), width=80, height=20,
+                               highlight=False)
+    for i in range(20):
+        terminal.start_run(dict(dataset_name=f"data{i}",
+                                objective_name="obj", solver_name="s"))
+    for i in range(30):
+        terminal.set(dataset="data", objective="obj", solver=f"s{i}")
+        terminal.show_status(status='done')
+
+    display = _render_to_str(terminal).splitlines()
+    # The display never overflows the screen, whatever the number of runs.
+    assert len(display) <= 20
+    # The counters are always visible, the sections are cropped instead.
+    assert "done 30" in display[-1]
+    assert any("more" in line for line in display)
+    assert "Running" in "".join(display)
+
+
+def test_rich_output_long_names_wrap_under_the_name():
+    terminal = RichOutput(n_repetitions=1, show_progress=False)
+    terminal.console = Console(file=io.StringIO(), width=80, highlight=False)
+    terminal.set(dataset="data", objective="obj",
+                 solver=f"gd[path={'x' * 200}]")
+    terminal.show_status(status='done')
+
+    terminal._print_results()
+    lines = terminal.console.file.getvalue().splitlines()
+    # The name is shown whole, wrapped past the guides instead of over them.
+    assert all(len(line) <= 80 for line in lines)
+    assert 'x' * 200 in "".join(line.strip("│├─ ") for line in lines)
+    assert lines[-2].startswith("│   │     ")
+
+
+def test_rich_output_running_probe():
+    terminal = RichOutput(n_repetitions=1, show_progress=False, n_jobs=1)
+    terminal.console = Console(file=io.StringIO(), width=120, height=20,
+                               highlight=False)
+    other = dict(META, solver_name="other[lr=1]")
+    terminal.start_run(META)
+    terminal.start_run(other)
+
+    # A backend that knows which runs left the queue overrides the guess
+    # based on the dispatch order.
+    terminal.set_running_probe(lambda: [tuple(other.values())])
+    display = _render_to_str(terminal)
+    assert "other[lr=1]" in display
+    assert "solver[lr=1e-3]" not in display
+
+    # A probe that fails is dropped, rather than taking the run down.
+    def _raise():
+        raise RuntimeError("no scheduler here")
+
+    terminal.set_running_probe(_raise)
+    display = _render_to_str(terminal)
+    assert "solver[lr=1e-3]" in display
+    assert terminal._probe is None

--- a/benchopt/utils/rich_output.py
+++ b/benchopt/utils/rich_output.py
@@ -93,7 +93,7 @@ def _redirect_fds(log_file, mode="w"):
     """
     sys.stdout.flush()
     sys.stderr.flush()
-    tty = os.fdopen(os.dup(1), "w")
+    tty = os.fdopen(os.dup(1), "w", encoding="utf-8", errors="replace")
     saved_out, saved_err = os.dup(1), os.dup(2)
     log = open(log_file, mode)
     os.dup2(log.fileno(), 1)

--- a/benchopt/utils/rich_output.py
+++ b/benchopt/utils/rich_output.py
@@ -1,0 +1,530 @@
+"Live progress display for `benchopt run`, based on `rich`."
+import os
+import sys
+import threading
+from time import time
+from collections import Counter, deque
+from itertools import islice
+from contextlib import contextmanager
+
+from .terminal_output import STATUS, TerminalOutput
+
+
+# Guides for the result tree. The last child of a node is unknown while the
+# results stream in, so every entry uses a "more to come" branch.
+GUIDE = "[dim]\u2502   [/]"
+BRANCH = "[dim]\u251c\u2500\u2500 [/]"
+
+# Asking a scheduler which runs are running spawns a process, so keep it
+# way slower than the refresh rate of the display.
+PROBE_PERIOD = 30
+
+# (style, glyph) for each benchopt status. The human readable label is
+# reused from `STATUS` in terminal_output.
+RICH_STATUS = {
+    'error': ("red", "✗"),
+    'diverged': ("red", "✗"),
+    'not installed': ("red", "✗"),
+    'interrupted': ("yellow", "!"),
+    'not run yet': ("yellow", "·"),
+    'skip': ("yellow", "»"),
+    'timeout': ("yellow", "✓"),
+    'max_runs': ("yellow", "✓"),
+    'done': ("green", "✓"),
+}
+
+
+def _is_cached(status, cached):
+    """Whether a result was loaded from the cache instead of being run.
+
+    A run that was skipped has no cached result to speak of, so it is
+    reported as a skip.
+    """
+    from ..runner import SUCCESS_STATUS
+    return cached and status in SUCCESS_STATUS
+
+
+def _guides(level):
+    """Tree guides leading to a node at `level`, as in the running section."""
+    return GUIDE * (level - 1) + BRANCH if level else ""
+
+
+def _ellipsis(name, width):
+    """Shorten `name` to `width` characters, marking the cut."""
+    return name if len(name) <= width else name[:max(width - 3, 0)] + "..."
+
+
+def _line(markup):
+    """A single display line, cropped rather than wrapped.
+
+    Keeping the live display at a fixed number of lines is what makes it
+    survive a terminal resize, as `rich` erases the previous frame based on
+    the number of lines it printed.
+    """
+    from rich.text import Text
+    text = Text.from_markup(markup, overflow="ellipsis")
+    text.no_wrap = True
+    return text
+
+
+def _crop(lines, n, tail=False):
+    """Keep `n` lines, reporting how many are left out on an extra one."""
+    if len(lines) <= n:
+        return lines
+    left_out = f"[dim]+{len(lines) - n + 1} more[/]"
+    if tail:
+        return [left_out] + lines[len(lines) - max(0, n - 1):]
+    return lines[:max(0, n - 1)] + [left_out]
+
+
+def _rule(title):
+    """Section separator in the live display."""
+    from rich.rule import Rule
+    return Rule(f"[bold]{title}[/]", style="dim")
+
+
+@contextmanager
+def _redirect_fds(log_file, mode="w"):
+    """Send fd 1 and 2 to `log_file`, yielding a file on the original stdout.
+
+    The redirection is done at the file descriptor level rather than with
+    `contextlib.redirect_stdout` so that worker processes, which inherit the
+    file descriptors, also write to the log instead of on top of the display.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    tty = os.fdopen(os.dup(1), "w")
+    saved_out, saved_err = os.dup(1), os.dup(2)
+    log = open(log_file, mode)
+    os.dup2(log.fileno(), 1)
+    os.dup2(log.fileno(), 2)
+    try:
+        yield tty
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        log.close()
+        tty.close()
+
+
+class RichOutput(TerminalOutput):
+    """Live display of the benchmark progress, in the main process.
+
+    The `terminal` object is pickled to the workers, which cannot share the
+    live display. The pickled copy sets `_worker` and falls back to the plain
+    `TerminalOutput` behavior, writing to the redirected stdout, i.e. the log
+    file.
+    """
+
+    def __init__(self, n_repetitions=None, show_progress=None, n_jobs=1):
+        super().__init__(n_repetitions, show_progress)
+        self._worker = False
+        self.log_file = None
+        self.n_jobs = n_jobs
+
+        self.counts = Counter()
+        # Dispatched runs that are not finished yet, in dispatch order. Only
+        # the first `n_jobs` of them are actually running, the others are
+        # waiting for a free worker.
+        self.in_flight = deque()
+        self.n_configs = None
+        # Set by a backend that knows which runs are actually running.
+        self._probe = None
+        self._probe_keys, self._probe_time = [], 0
+        self._probe_lock = threading.Lock()
+        # Result tree: dataset -> objective -> lines of its finished runs,
+        # in the order they first appeared.
+        self._tree = {}
+        self._labels = {}
+        self.n_dispatched = 0
+        self.n_finished = 0
+        self._all_dispatched = False
+
+        self.console = None
+        self._tty_fd = None
+        self._width = None
+        self._live = None
+        self._progress = None
+        self._task = None
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        for k in ['console', '_tty_fd', '_live', '_progress',
+                  '_task', '_probe', '_probe_lock']:
+            state[k] = None
+        state['_worker'] = True
+        state['show_progress'] = False
+        return state
+
+    # Display life cycle ####################################################
+
+    @contextmanager
+    def live(self, log_file=None):
+        from rich.console import Console
+        from rich.live import Live
+        from rich.progress import (
+            BarColumn, MofNCompleteColumn, Progress, SpinnerColumn,
+            TextColumn, TimeElapsedColumn
+        )
+
+        self.log_file = log_file
+        try:
+            with _redirect_fds(log_file) as tty:
+                self._tty_fd = tty.fileno()
+                self.console = Console(file=tty, highlight=False)
+                self._progress = Progress(
+                    SpinnerColumn(), TextColumn("[bold]Runs"), BarColumn(),
+                    MofNCompleteColumn(), TimeElapsedColumn(),
+                    console=self.console,
+                )
+                self._task = self._progress.add_task("runs", total=None)
+                try:
+                    # The display runs on the alternate screen, so that the
+                    # terminal redraws it on a resize and the output of the
+                    # run is left untouched. `redirect_stdout` would re-print
+                    # the main process output on the console: everything goes
+                    # to the log instead.
+                    with Live(get_renderable=self._render,
+                              console=self.console, screen=True,
+                              refresh_per_second=8, redirect_stdout=False,
+                              redirect_stderr=False) as live:
+                        self._live = live
+                        yield
+                finally:
+                    self._live = None
+                    # The alternate screen is gone: print the results, that
+                    # were only visible in the display, on the terminal.
+                    self._print_results()
+        finally:
+            # The file descriptors are restored: keep a console on the real
+            # stdout so that trailing output, e.g. an interrupted status,
+            # stays in the same style.
+            self.console = Console(highlight=False)
+
+    @contextmanager
+    def step(self, label):
+        """Run a post-run step under a spinner, its output going to the log."""
+        if self._worker or self.log_file is None:
+            yield
+            return
+
+        from rich.console import Console
+        from rich.live import Live
+        from rich.spinner import Spinner
+
+        with _redirect_fds(self.log_file, mode="a") as tty:
+            console = Console(file=tty, highlight=False)
+            # `console.status` would capture stdout and print it on the
+            # console: the output of the step goes to the log instead.
+            with Live(Spinner("dots", f"[bold]{label}[/]"), console=console,
+                      refresh_per_second=8, redirect_stdout=False,
+                      redirect_stderr=False, transient=True):
+                yield
+            console.print(f"[green]\u2713[/] {label}")
+
+    def show_outputs(self, **files):
+        """Report where the outputs of the run are available."""
+        if self._worker or self.console is None:
+            return
+
+        files = {k: v for k, v in files.items() if v is not None}
+        if not files:
+            return
+        self.console.print(_rule("Outputs"))
+        width = max(len(name) for name in files)
+        for name, path in files.items():
+            self.console.print(
+                f"[bold]{name:{width}}[/]  [cyan]{path}[/]"
+            )
+
+    def _render(self):
+        from rich.console import Group
+
+        # `rich` looks up the size on fd 0, 1 and 2, which are redirected, so
+        # read it on the terminal itself to follow a resize.
+        try:
+            # A pseudo-terminal can report 0, which would render nothing.
+            size = os.get_terminal_size(self._tty_fd)
+            if size.columns and size.lines:
+                self.console.size = size
+                if size.columns != self._width:
+                    # The frames are drawn from the top of the screen: on a
+                    # resize, wipe what is left of the previous ones. The
+                    # first frame is skipped, as the alternate screen is not
+                    # up yet and clearing scrolls the terminal.
+                    first, self._width = self._width is None, size.columns
+                    if not first:
+                        self.console.clear()
+        except (OSError, TypeError):
+            pass
+
+        totals = [_rule("Total")]
+        if self._progress is not None:
+            totals.append(self._progress)
+        totals.append(_line(self._counters()))
+
+        # The screen does not scroll, so the sections share what is left
+        # once the two titles and the totals, which always fit, are placed.
+        # The results are all printed on the terminal once the run is over.
+        results = list(self._lines())
+        free = max(0, self.console.height - len(totals) - 2)
+        # The runs in flight get half of the space when the results fill it.
+        # With a scheduler, thousands of runs can be in flight, so the lines
+        # that do not fit are not built at all.
+        running = self._running_lines(max(free - len(results), free // 2))
+        results = _crop(results, free - len(running), tail=True)
+
+        return Group(_rule("Results"), *map(_line, results),
+                     _rule("Running"), *map(_line, running), *totals)
+
+    def _running_lines(self, max_lines=None):
+        """One line per dataset, objective and solver of the runs in flight."""
+        from rich.markup import escape
+        from rich.text import Text
+
+        running = Counter(self._running_keys())
+        if not running:
+            return ["[dim]waiting for runs...[/]"]
+
+        # Group the runs by dataset and objective, as their names are long
+        # and shared by several solvers.
+        lines, seen, n_shown = [], set(), 0
+        for key, n in sorted(running.items()):
+            # A run adds up to 3 lines, plus the one counting the hidden
+            # ones: stop early rather than let `_crop` miscount them.
+            if max_lines is not None and len(lines) + 4 > max_lines:
+                break
+            n_shown += n
+            data, obj, solver = key
+            for level, node in enumerate([(data,), (data, obj)]):
+                if node not in seen:
+                    seen.add(node)
+                    lines.append(
+                        f"{_guides(level)}[bold]{escape(node[-1])}[/]"
+                    )
+            reps = f"{n} reps" if n > 1 else "1 rep"
+            suffix = (f" \u2014 [magenta]{reps}[/] running "
+                      f"({self.rep[key]}/{self.n_repetitions} done)")
+            # A solver with many parameters would push the counters out of
+            # the line, so it is the name that gets cropped instead.
+            width = self.console.width - 8 - len(Text.from_markup(suffix))
+            lines.append(
+                f"{_guides(2)}[cyan]{escape(_ellipsis(solver, width))}[/]"
+                f"{suffix}"
+            )
+
+        n_hidden = len(self.in_flight) - n_shown
+        if n_hidden > 0:
+            # The hidden runs are queued ones, plus the ones left out above.
+            label = "queued" if n_shown == sum(running.values()) else "more"
+            lines.append(f"[dim]+{n_hidden} {label}[/]")
+        return lines
+
+    def _running_keys(self):
+        """The runs holding a worker, as told by the backend or guessed."""
+        with self._probe_lock:
+            if self._probe is not None and time() - self._probe_time > (
+                    PROBE_PERIOD):
+                self._probe_time = time()
+                try:
+                    self._probe_keys = list(self._probe())
+                except Exception:
+                    # The display is never worth taking the run down for.
+                    self._probe = None
+            if self._probe is not None:
+                return self._probe_keys
+
+        # Without a probe, the runs are dispatched in order, so the oldest
+        # unfinished ones are the ones actually holding a worker.
+        return list(islice(self.in_flight, self.n_jobs))
+
+    def _lines(self):
+        """The whole result tree, as one markup line per node."""
+        from rich.markup import escape
+
+        for data, objectives in self._tree.items():
+            yield from self._labels.get(
+                (data,), [f"[bold]{escape(data)}[/]"]
+            )
+            for obj, lines in objectives.items():
+                yield from self._labels.get(
+                    (data, obj), [f"{_guides(1)}[bold]{escape(obj)}[/]"]
+                )
+                yield from lines
+
+    def _print_results(self):
+        """Print the whole result tree, once the display is over."""
+        self.console.print(_rule("Results"))
+        for markup in self._lines():
+            self._print(markup)
+        self._print(self._counters())
+
+    def _print(self, markup):
+        """Print one result line, wrapped under the name of the run."""
+        from rich.text import Text
+
+        text = Text.from_markup(markup)
+        # Long names, e.g. a solver with many parameters, have to wrap: keep
+        # the tree readable by indenting past the guides and the status glyph.
+        plain = text.plain
+        level = (len(plain) - len(plain.lstrip("│├─ "))) // 4
+        indent = min(4 * level + 2, max(self.console.width - 8, 0))
+        lines = text[indent:].wrap(self.console, self.console.width - indent)
+        # The wrapped lines carry on the guides of the nodes above them.
+        pad = Text.from_markup(GUIDE * level + "  ")
+        self.console.print(Text("\n").join(
+            [text[:indent] + line for line in lines[:1]]
+            + [pad + line for line in lines[1:]]
+        ))
+
+    def _total(self):
+        """Number of runs to display in the progress bar.
+
+        `n_configs` is only an upper bound, as some runs are skipped, so
+        fall back on the exact count once everything has been dispatched.
+        """
+        if self._all_dispatched or self.n_configs is None:
+            return self.n_dispatched
+        return max(self.n_configs * (self.n_repetitions or 1),
+                   self.n_dispatched)
+
+    def _counters(self):
+        done = sum(self.counts[s] for s in ['done', 'timeout', 'max_runs'])
+        errors = sum(
+            self.counts[s] for s in ['error', 'diverged', 'not installed']
+        )
+        return (
+            f"[green]done {done}[/] · [cyan]cached "
+            f"{self.counts['cached']}[/] · [yellow]skip "
+            f"{self.counts['skip']}[/] · [red]error {errors}[/]"
+        )
+
+    # TerminalOutput interface ##############################################
+
+    def show_interrupted(self):
+        # Nothing to report: the interrupted runs produced no result, and
+        # they are already accounted for in the progress bar.
+        if self._worker:
+            super().show_interrupted()
+
+    def start_run(self, meta):
+        if self._worker:
+            return
+        key = (
+            meta['dataset_name'], meta['objective_name'], meta['solver_name']
+        )
+        self.in_flight.append(key)
+        self.n_dispatched += 1
+        self._refresh()
+
+    def set_n_configs(self, n_configs):
+        self.n_configs = n_configs
+        self._refresh()
+
+    def all_dispatched(self):
+        self._all_dispatched = True
+        self._refresh()
+
+    def set_running_probe(self, probe):
+        """Register a callable listing the runs that are actually running.
+
+        A scheduler, e.g. SLURM, knows which of the dispatched runs left the
+        queue. Without a probe, the oldest dispatched ones are assumed to be
+        the running ones.
+        """
+        if not self._worker:
+            self._probe, self._probe_time = probe, 0
+
+    def show_status(self, status, reason=None, dataset=False, objective=False,
+                    cached=False):
+        if self._worker:
+            return super().show_status(status, reason, dataset, objective,
+                                       cached)
+
+        if not (dataset or objective):
+            key = (str(self.dataset), str(self.objective), str(self.solver))
+            self.n_finished += 1
+            bucket = 'cached' if _is_cached(status, cached) else status
+            self.counts[bucket] += 1
+            if key in self.in_flight:
+                self.in_flight.remove(key)
+
+        super().show_status(status, reason, dataset, objective, cached)
+        self._refresh()
+
+    def _emit_status(self, status, reason, dataset, objective, cached):
+        if self._worker or self.console is None:
+            return super()._emit_status(status, reason, dataset, objective,
+                                        cached)
+
+        from rich.markup import escape
+
+        if _is_cached(status, cached):
+            style, glyph = RICH_STATUS['done']
+            result = "[green]done[/] [cyan](cached)[/]"
+        else:
+            style, glyph = RICH_STATUS[status]
+            result = f"[{style}]{STATUS[status][0]}[/]"
+            if status in ['error', 'diverged']:
+                result += " [dim](traceback in the log)[/]"
+
+        level = 0 if dataset else 1 if objective else 2
+        name = str([self.dataset, self.objective, self.solver][level])
+        lines = [
+            f"{_guides(level)}[{style}]{glyph}[/] {escape(name)} {result}"
+        ]
+        if status == 'skip' and reason is not None:
+            lines.append(
+                f"{GUIDE * level}[dim]Reason: {escape(str(reason))}[/]"
+            )
+
+        data, obj = str(self.dataset), str(self.objective)
+        objectives = self._tree.setdefault(data, {})
+        if level == 0:
+            self._labels[data, ] = lines
+        elif level == 1:
+            objectives.setdefault(obj, [])
+            self._labels[data, obj] = lines
+        else:
+            objectives.setdefault(obj, []).extend(lines)
+
+    def _refresh(self):
+        if self._live is not None:
+            self._progress.update(
+                self._task, completed=self.n_finished, total=self._total()
+            )
+            self._live.refresh()
+
+    # In the main process, these are subsumed by the live display. In the
+    # workers, they keep printing to the log file.
+    def progress(self, progress, key):
+        if self._worker:
+            super().progress(progress, key)
+
+    def debug(self, msg):
+        if self._worker:
+            super().debug(msg)
+
+    def display_dataset(self):
+        if self._worker:
+            super().display_dataset()
+
+    def display_objective(self):
+        if self._worker:
+            super().display_objective()
+
+
+def make_terminal_output(n_repetitions=None, show_progress=None, pdb=False,
+                         n_jobs=1):
+    """Rich live display if running in an interactive terminal, plain else."""
+    if pdb or os.environ.get('BENCHOPT_NO_RICH') or not sys.stdout.isatty():
+        return TerminalOutput(n_repetitions, show_progress)
+    try:
+        import rich  # noqa: F401
+    except ImportError:
+        return TerminalOutput(n_repetitions, show_progress)
+    return RichOutput(n_repetitions, show_progress, n_jobs=n_jobs)

--- a/benchopt/utils/rich_output.py
+++ b/benchopt/utils/rich_output.py
@@ -521,7 +521,8 @@ class RichOutput(TerminalOutput):
 def make_terminal_output(n_repetitions=None, show_progress=None, pdb=False,
                          n_jobs=1):
     """Rich live display if running in an interactive terminal, plain else."""
-    if pdb or os.environ.get('BENCHOPT_NO_RICH') or not sys.stdout.isatty():
+    from ..config import get_setting
+    if pdb or get_setting('no_rich') or not sys.stdout.isatty():
         return TerminalOutput(n_repetitions, show_progress)
     try:
         import rich  # noqa: F401

--- a/benchopt/utils/rich_output.py
+++ b/benchopt/utils/rich_output.py
@@ -524,8 +524,4 @@ def make_terminal_output(n_repetitions=None, show_progress=None, pdb=False,
     from ..config import get_setting
     if pdb or get_setting('no_rich') or not sys.stdout.isatty():
         return TerminalOutput(n_repetitions, show_progress)
-    try:
-        import rich  # noqa: F401
-    except ImportError:
-        return TerminalOutput(n_repetitions, show_progress)
     return RichOutput(n_repetitions, show_progress, n_jobs=n_jobs)

--- a/benchopt/utils/terminal_output.py
+++ b/benchopt/utils/terminal_output.py
@@ -4,6 +4,7 @@ import ctypes
 import platform
 import sys
 from collections import defaultdict
+from contextlib import contextmanager
 
 if sys.platform == 'win32':
     sys.stdout.reconfigure(encoding='utf-8')
@@ -165,12 +166,16 @@ class TerminalOutput:
             self.status[key] = status
 
         status = self.status[key]
+        assert status in STATUS, (
+            f"status should be in {list(STATUS)}. Got '{status}'"
+        )
+        self._emit_status(status, reason, dataset, objective, cached)
+
+    def _emit_status(self, status, reason, dataset, objective, cached):
+        """Display the final status of a run. Overridden by `RichOutput`."""
         tag = (
             self.dataset_tag if dataset else
             self.objective_tag if objective else self.solver_tag
-        )
-        assert status in STATUS, (
-            f"status should be in {list(STATUS)}. Got '{status}'"
         )
         status_print = colorify(*STATUS[status])
         if cached:
@@ -180,6 +185,35 @@ class TerminalOutput:
         if status == 'skip' and reason is not None:
             indent = ' ' * (2 if objective else 4)
             print(f'{indent}Reason: {reason}')
+
+    def show_interrupted(self):
+        """Report the runs stopped by a keyboard interruption."""
+        self.show_status('interrupted')
+
+    def start_run(self, meta):
+        """Called when a run is dispatched. Only used by `RichOutput`."""
+
+    def set_n_configs(self, n_configs):
+        """Number of (dataset, objective, solver) to run, skips included."""
+
+    def all_dispatched(self):
+        """Called once every run has been dispatched."""
+
+    def set_running_probe(self, probe):
+        """Register a probe for the running runs. Only used by `RichOutput`."""
+
+    @contextmanager
+    def live(self, log_file=None):
+        """Context manager wrapping the run. Only used by `RichOutput`."""
+        yield
+
+    @contextmanager
+    def step(self, label):
+        """Wrap a post-run step, e.g. saving. Only used by `RichOutput`."""
+        yield
+
+    def show_outputs(self, **files):
+        """Report where the outputs are. Only used by `RichOutput`."""
 
     def debug(self, msg):
         if DEBUG:

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,6 +17,9 @@ Version 1.10.0 -- in development
 CLI
 ~~~
 
+- ``benchopt run`` now displays a live ``rich`` interface
+  By `Hippolyte Verninas`_
+
 - Add ``benchopt info -f <result_file>`` (repeatable, or ``-f all``) to
   summarize result file(s) instead of listing benchmark solvers/datasets;
   plain ``benchopt info`` now also lists available result files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "pyyaml",
   "click>=8.0",
   "pygithub",
+  "rich",
   # Runner deps
   "psutil",
   "line-profiler",


### PR DESCRIPTION
I tried creating a new progress display with rich when using `benchopt run`. It has better support for parallelised runs and is overall a bit more pretty then what we had before. Using the old progress bar is still possible with `BENCHOPT_NO_RICH=1` (useful for tests since the stdout and stderr are now redirected to a log file).

I would greatly appreciate any feedback :)

### Checks before merging PR
- [X] ~~added documentation for any new feature~~
- [X] added unit test
- [ ] edited the [what's new](../../whatsnew.rst) (if applicable)
