### PR TITLE
ENH accept .py file paths for -s/-d and a filesystem path for --output

### DIFF
--- a/benchopt/benchmark.py
+++ b/benchopt/benchmark.py
@@ -18,6 +18,7 @@ from .utils.dynamic_modules import _load_class_from_module
 from .utils.parametrized_name_mixin import sanitize
 from .utils.parametrized_name_mixin import _get_used_parameters
 from .utils.parametrized_name_mixin import _check_patterns
+from .utils.parametrized_name_mixin import _extract_options, is_file_selector
 
 from .utils.terminal_output import colorify
 from .utils.terminal_output import GREEN, YELLOW
@@ -218,8 +219,11 @@ class Benchmark:
 
     def check_solver_patterns(self, solver_patterns, class_only=False):
         "Check that the patterns are valid and return selected configurations."
+        all_solvers = self._add_file_classes(
+            self.get_solvers(), solver_patterns, "Solver"
+        )
         return _check_patterns(
-            self.get_solvers(), solver_patterns, name_type='solver',
+            all_solvers, solver_patterns, name_type='solver',
             class_only=class_only
         )
 
@@ -300,10 +304,37 @@ class Benchmark:
 
     def check_dataset_patterns(self, dataset_patterns, class_only=False):
         "Check that the patterns are valid and return selected configurations."
+        all_datasets = self._add_file_classes(
+            self.get_datasets(), dataset_patterns, "Dataset"
+        )
         return _check_patterns(
-            self.get_datasets(), dataset_patterns, name_type='dataset',
+            all_datasets, dataset_patterns, name_type='dataset',
             class_only=class_only
         )
+
+    def _add_file_classes(self, all_classes, patterns, class_name):
+        """Load classes for selector tokens that point to a ``.py`` file.
+
+        A token ending in ``.py`` (optionally with a ``file.py[param=value]``
+        bracket) loads the class directly from that file, even outside the
+        benchmark's ``solvers/`` / ``datasets/`` folders. Its ``name`` is set
+        to the selector token so it is matched exactly by ``_check_patterns``
+        — sidestepping name collisions and glob characters in a name.
+        """
+        if patterns is not None and not isinstance(patterns, (list, tuple)):
+            patterns = [patterns]
+        extra = []
+        for pattern in (patterns or []):
+            if not is_file_selector(pattern):
+                continue
+            filename = _extract_options(pattern)[0]
+            path = Path(filename)
+            if not path.is_file():
+                raise click.BadParameter(f"Could not find file: {path}")
+            cls = _load_class_from_module(self.benchmark_dir, path, class_name)
+            cls.name = filename
+            extra.append(cls)
+        return all_classes + extra
 
     def _get_plots_classes(self):
         "List all available custom plot classes for the benchmark"

--- a/benchopt/cli/helpers.py
+++ b/benchopt/cli/helpers.py
@@ -401,9 +401,14 @@ def info(benchmark, solver_names, dataset_names, result_filenames=(),
     benchmark.check_dataset_patterns(dataset_names)
     benchmark.check_solver_patterns(solver_names)
 
-    # get solvers and datasets in the benchmark
-    all_solvers = benchmark.get_solvers()
-    all_datasets = benchmark.get_datasets()
+    # get solvers and datasets in the benchmark, including any selected from a
+    # file path so `info -s /path/to/solver.py` lists that component too.
+    all_solvers = benchmark._add_file_classes(
+        benchmark.get_solvers(), solver_names, "Solver"
+    )
+    all_datasets = benchmark._add_file_classes(
+        benchmark.get_datasets(), dataset_names, "Dataset"
+    )
     # enable verbosity if any environment was provided
     if env_name is not None and env_name != 'False':
         verbose = True

--- a/benchopt/cli/main.py
+++ b/benchopt/cli/main.py
@@ -92,7 +92,9 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               help="Include <solver_name> in the benchmark. By default, all "
               "solvers are included. When `-s` is used, only listed solvers"
               " are included. Note that <solver_name> can include parameters,"
-              " with the syntax `solver[parameter=value]`. "
+              " with the syntax `solver[parameter=value]`. A path to a `.py` "
+              "file loads the Solver directly from that file, even outside "
+              "the benchmark's `solvers/` folder. "
               "To include multiple solvers, use multiple `-s` options.",
               shell_complete=complete_solvers)
 @click.option('--force-solver', '-f',
@@ -106,7 +108,9 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               help="Run the benchmark on <dataset_name>. By default, all "
               "datasets are included. When `-d` is used, only listed datasets"
               " are included. Note that <dataset_name> can include parameters,"
-              " with the syntax `dataset[parameter=value]`. "
+              " with the syntax `dataset[parameter=value]`. A path to a `.py` "
+              "file loads the Dataset directly from that file, even outside "
+              "the benchmark's `datasets/` folder. "
               "To include multiple datasets, use multiple `-d` options.",
               shell_complete=complete_datasets)
 @click.option("--max-runs", "-n",
@@ -183,13 +187,17 @@ def _get_run_args(cli_kwargs, config_file_kwargs):
               help='If set, disable the cache on disk for the run. Note that '
               'this makes the run less tolerant to errors, use with caution.')
 @click.option("--output", default="None", type=str,
-              help="Filename for the result output. "
-              "If given, the results will "
-              "be stored at <BENCHMARK>/outputs/<filename>.parquet, "
-              "if another result file has the same name, a number is happened "
+              help="Name or path for the result output. "
+              "A bare name is stored at "
+              "<BENCHMARK>/outputs/<name>.parquet; "
+              "if another result file has the same name, a number is appended "
               "to distinguish them "
-              "(ex: <BENCHMARK>/outputs/<filename>_1.parquet)."
-              " If not provided, the output will be saved as "
+              "(ex: <BENCHMARK>/outputs/<name>_1.parquet). "
+              "A value containing a path separator (e.g. "
+              "`out/results.parquet` or an absolute path) is treated as an "
+              "explicit path and written exactly there, leaving the benchmark "
+              "folder untouched. "
+              "If not provided, the output will be saved as "
               "<BENCHMARK>/outputs/benchopt_run_<timestamp>.parquet."
               )
 @click.option('--seed',

--- a/benchopt/cli/tests/test_cmd_run.py
+++ b/benchopt/cli/tests/test_cmd_run.py
@@ -357,6 +357,87 @@ class TestRunCmd:
         exts = [Path(result_file).suffix for result_file in out.result_files]
         assert exts[0] == expected_ext and exts[1] == expected_ext, out
 
+    def test_output_explicit_path(self, tmp_path):
+        # A value with a path separator is written verbatim, leaving the
+        # benchmark folder untouched (no outputs/ dir created).
+        out_path = tmp_path / "nested" / "results.parquet"
+        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+            run([str(bench.benchmark_dir),
+                 *"-d test-dataset -n 1 -r 1 --no-plot".split(),
+                 "--output", str(out_path)],
+                'benchopt', standalone_mode=False)
+
+            assert out_path.exists(), out
+            assert not (Path(bench.benchmark_dir) / "outputs").exists(), out
+        assert out.result_files == [str(out_path)], out
+
+    # A path to a .py file loads the Solver/Dataset directly from that file,
+    # even outside the benchmark's solvers/ or datasets/ folder.
+    EXT_SOLVER = """from benchopt import BaseSolver
+
+class Solver(BaseSolver):
+    name = 'ext-solver'
+    sampling_strategy = 'run_once'
+    parameters = {'scale': [1, 10]}
+    def set_objective(self, X, y, lmbd): pass
+    def run(self, n_iter): pass
+    def get_result(self): return dict(beta=None)
+"""
+
+    EXT_DATASET = """from benchopt import BaseDataset
+
+class Dataset(BaseDataset):
+    name = 'ext-dataset'
+    def get_data(self): return dict(X=None, y=None)
+"""
+
+    def test_solver_from_file(self, tmp_path):
+        solver_file = tmp_path / "ext_solver.py"
+        solver_file.write_text(self.EXT_SOLVER)
+        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+            run([str(bench.benchmark_dir),
+                 *"-d test-dataset -n 1 -r 1 --no-plot".split(),
+                 "-s", str(solver_file)],
+                'benchopt', standalone_mode=False)
+
+        # The file-selected solver is added to the run set (both params run),
+        # and reported under the selector token.
+        out.check_output(re.escape(str(solver_file)) + r'\[scale=1\]:')
+        out.check_output(re.escape(str(solver_file)) + r'\[scale=10\]:')
+
+    def test_solver_from_file_with_params(self, tmp_path):
+        solver_file = tmp_path / "ext_solver.py"
+        solver_file.write_text(self.EXT_SOLVER)
+        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+            run([str(bench.benchmark_dir),
+                 *"-d test-dataset -n 1 -r 1 --no-plot".split(),
+                 "-s", f"{solver_file}[scale=10]"],
+                'benchopt', standalone_mode=False)
+
+        # Only the selected parameter value is run.
+        out.check_output(re.escape(str(solver_file)) + r'\[scale=10\]:')
+        out.check_output(re.escape(str(solver_file)) + r'\[scale=1\]:',
+                         repetition=0)
+
+    def test_dataset_from_file(self, tmp_path):
+        dataset_file = tmp_path / "ext_dataset.py"
+        dataset_file.write_text(self.EXT_DATASET)
+        with temp_benchmark() as bench, CaptureCmdOutput() as out:
+            run([str(bench.benchmark_dir),
+                 *"-n 1 -r 1 --no-plot".split(),
+                 "-d", str(dataset_file)],
+                'benchopt', standalone_mode=False)
+
+        out.check_output(re.escape(str(dataset_file)), repetition=1)
+
+    def test_solver_from_missing_file(self):
+        with temp_benchmark() as bench:
+            missing = str(Path(bench.benchmark_dir) / "no_such_solver.py")
+            match = "Could not find file"
+            with pytest.raises(click.BadParameter, match=match):
+                run([str(bench.benchmark_dir), "--no-plot", "-s", missing],
+                    'benchopt', standalone_mode=False)
+
     def test_handle_class_init_error(self):
         # dataset with a wrong param name
         dataset = """from benchopt.utils.temp_benchmark import TempDataset

--- a/benchopt/runner.py
+++ b/benchopt/runner.py
@@ -1,3 +1,4 @@
+import os
 import time
 from datetime import datetime
 from pathlib import Path
@@ -265,8 +266,10 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
     pdb : bool
         If pdb is set to True, open a debugger on error.
     output_file : str
-        Filename for the parquet output. If given, the results will
-        be stored at <BENCHMARK>/outputs/<filename>.parquet.
+        Name or path for the result output. A bare name is stored at
+        <BENCHMARK>/outputs/<name>.parquet. A value containing a path separator
+        is treated as an explicit path and written exactly there, leaving the
+        benchmark folder untouched.
 
     Returns
     -------
@@ -279,16 +282,27 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
     exit_code = 0
     terminal = TerminalOutput(n_repetitions, show_progress)
 
-    # Resolve the output filename stem before runs start so that
-    # run_output_base is stable across all workers.
-    output_dir = benchmark.get_output_folder()
+    # Resolve the output path before runs start so that run_output_base is
+    # stable across all workers. A value containing a path separator is an
+    # explicit path, written exactly as given; a bare name lands in
+    # <BENCHMARK>/outputs/. Only touch the benchmark outputs folder when it is
+    # actually used, to keep the benchmark directory read-only for explicit
+    # output paths.
     if output_file == "None":
         timestamp = datetime.now().strftime('%Y-%m-%d_%Hh%Mm%S')
-        output_file = f'benchopt_run_{timestamp}.parquet'
+        output_path = (
+            benchmark.get_output_folder()
+            / f'benchopt_run_{timestamp}.parquet'
+        )
+    elif os.sep in output_file or (os.altsep and os.altsep in output_file):
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = benchmark.get_output_folder() / output_file
     from .utils.run_context import RunContext
     base_run_context = RunContext(
         pdb=pdb,
-        run_output_base=output_dir / Path(output_file).stem,
+        run_output_base=output_path.parent / output_path.stem,
     )
 
     run_one_to_cvg_cached = benchmark.cache(
@@ -345,8 +359,8 @@ def _run_benchmark(benchmark, solvers=None, forced_solvers=None,
         terminal.savefile_status()
         return 1, None
 
-    # Save output in parquet file in the benchmark folder
-    output_file = save_results(df, output_dir / output_file)
+    # Save output in parquet file at the resolved output path.
+    output_file = save_results(df, output_path)
 
     if plot_result:
         try:

--- a/benchopt/skills/using-benchopt/assets/dataset.py
+++ b/benchopt/skills/using-benchopt/assets/dataset.py
@@ -3,7 +3,7 @@ from benchopt import BaseDataset
 
 
 class Dataset(BaseDataset):
-    name = "simulated"
+    name = "simulated"  # display/CLI identifier; must not contain "/"
     requirements = []
     parameters = {
         "n_samples": [100, 1000],

--- a/benchopt/skills/using-benchopt/assets/solver.py
+++ b/benchopt/skills/using-benchopt/assets/solver.py
@@ -2,7 +2,7 @@ from benchopt import BaseSolver
 
 
 class Solver(BaseSolver):
-    name = "my-solver"
+    name = "my-solver"  # display/CLI identifier; must not contain "/"
     requirements = []
     parameters = {}
     # Fast config for `benchopt test` — solver params as top-level keys, with

--- a/benchopt/skills/using-benchopt/cli-reference.md
+++ b/benchopt/skills/using-benchopt/cli-reference.md
@@ -10,6 +10,7 @@ Run a benchmark. See [run.md](./run.md) for full usage.
 
 ```bash
 benchopt run . -s my-solver -d Simulated -n 5 -r 3 --timeout 60
+benchopt run . -s /path/to/solver.py            # load a solver from a file
 benchopt run . --config config.yml
 ```
 

--- a/benchopt/skills/using-benchopt/run.md
+++ b/benchopt/skills/using-benchopt/run.md
@@ -14,6 +14,10 @@ benchopt run . \
 
 - `-o/--objective`, `-d/--dataset`, `-s/--solver` filter by **name** (repeatable).
   Omit a filter to run all of that kind.
+- `-d`/`-s` also accept a path to a `.py` file: the `Dataset`/`Solver` is loaded
+  directly from that file (even outside `datasets/`/`solvers/`) and added to the
+  run, e.g. `-s /path/to/my_solver.py`. Bracket params still work:
+  `-s "/path/to/my_solver.py[lr=0.1]"`. The file can still `import benchmark_utils`.
 - Override parameters inline with `name[param=value]`. Values use Python literal
   syntax: `reg=0.1`, `use_acceleration=True`, lists `n_features=[20,50]`, and
   grouped params `'n_samples, n_features'=[(100,20),(1000,50)]`. Only the
@@ -70,7 +74,9 @@ repetition)` cell, so a long run does **not** need manual chunking:
 
 Gotchas that break cache matching or surprise you:
 
-- `--output` takes a **name**, not a path (results always land in `outputs/`).
+- `--output` takes a **name** (lands in `outputs/`) *or* a path with a
+  separator, e.g. `--output /tmp/results.parquet`, written verbatim without
+  touching the benchmark folder.
 - `-o` is the **objective** filter, not output.
 - Keep `-s`/`-d`/params **identical** across runs — any change alters the cache
   keys, so cells won't be recognised as already done.
@@ -126,7 +132,9 @@ run expensive preprocessing once before any benchmarking run.
 
 - Results are `.parquet` files under `./outputs/`. An HTML dashboard is
   generated unless `--no-html`; `--no-plot`/`--no-display` skip plotting.
-- The name of the output can be controlled with the `--output` option.
+- The name (or full path) of the output can be controlled with the `--output`
+  option: a bare name lands in `./outputs/`, a value with a path separator is
+  written verbatim.
   If the name already exist, the new result is postfixed with `-1` or
   `-X` the X-th time.
 - `benchopt plot <result.parquet>` regenerates figures; custom plots are
@@ -179,7 +187,8 @@ what you expect.
 - `--seed N`: fix the base seed for reproducibility.
 - `--profile`: profile solvers (line-level timing).
 - `--pdb`: drop into a debugger on error.
-- `--output NAME`: name the output files.
+- `--output NAME_OR_PATH`: name the output file (in `outputs/`), or give a path
+  with a separator to write it verbatim.
 
 ## Doc links
 

--- a/benchopt/tests/test_benchmarks.py
+++ b/benchopt/tests/test_benchmarks.py
@@ -17,6 +17,11 @@ def test_dataset_class(benchmark, dataset_class):
     assert hasattr(dataset_class, 'name'), "All dataset should expose a name"
     assert isinstance(dataset_class.name, str), (
         "The dataset's name should be a string")
+    assert '/' not in dataset_class.name, (
+        f"The dataset's name should not contain '/' (got "
+        f"'{dataset_class.name}'). A '/' makes the name ambiguous with a "
+        "`-d path/to/dataset.py` file selector."
+    )
 
     # Ensure that the dataset exposes a `get_data` function
     # that is callable
@@ -140,6 +145,11 @@ def test_solver_class(benchmark, solver_class):
     assert hasattr(solver_class, 'name'), "All solver should expose a name"
     assert isinstance(solver_class.name, str), (
         "The solver's name should be a string"
+    )
+    assert '/' not in solver_class.name, (
+        f"The solver's name should not contain '/' (got "
+        f"'{solver_class.name}'). A '/' makes the name ambiguous with a "
+        "`-s path/to/solver.py` file selector."
     )
 
     # Check that the solver_class uses a valid sampling_strategy

--- a/benchopt/utils/dynamic_modules.py
+++ b/benchopt/utils/dynamic_modules.py
@@ -108,20 +108,37 @@ class _FailedImportMixin:
         return False
 
 
-def _get_module_from_file(module_filename, benchmark_dir=None):
+def _get_module_from_file(module_filename, benchmark_dir=None, subpkg=None):
     """Load a module from the name of the file"""
     module_filename = Path(module_filename)
     if benchmark_dir is not None:
         # Use a package name derived from the benchmark root folder.
         module_filename = module_filename.resolve()
-        benchmark_dir = Path(benchmark_dir).resolve().parent
-        package_name = module_filename.relative_to(benchmark_dir)
-        package_name = package_name.with_suffix('').parts
+        bench_root = Path(benchmark_dir).resolve()
+        try:
+            package_name = module_filename.relative_to(bench_root.parent)
+            package_name = package_name.with_suffix('').parts
+        except ValueError:
+            # File selected from outside the benchmark tree (e.g. `-s
+            # /path/to/solver.py`): attach it to the benchmark's semantic
+            # module (benchmark.solvers.xxx / benchmark.datasets.xxx) so it
+            # shares the same namespace as in-repo components.
+            parts = (bench_root.name, subpkg, module_filename.stem)
+            package_name = tuple(p for p in parts if p is not None)
     else:
         package_name = module_filename.with_suffix('').parts[-3:]
     if package_name[-1] == '__init__':
         package_name = package_name[:-1]
     package_name = '.'.join(['benchopt_benchmarks', *package_name])
+
+    # Guard against a stem collision with a different file already loaded under
+    # the same semantic name (e.g. an external solver whose filename matches an
+    # in-repo one): disambiguate with a short hash of the file path.
+    cached = sys.modules.get(package_name, None)
+    cached_file = getattr(cached, "__file__", None)
+    if cached_file and Path(cached_file).resolve() != module_filename:
+        suffix = hashlib.md5(str(module_filename).encode()).hexdigest()[:8]
+        package_name = f"{package_name}_{suffix}"
 
     module = sys.modules.get(package_name, None)
     if module is None:
@@ -162,7 +179,9 @@ def _load_class_from_module(benchmark_dir, module_filename, class_name):
     module_filename = Path(module_filename)
     try:
         assert not SKIP_IMPORT  # go directly to except to skip import
-        module = _get_module_from_file(module_filename, benchmark_dir)
+        module = _get_module_from_file(
+            module_filename, benchmark_dir, subpkg=f"{class_name.lower()}s"
+        )
         klass = getattr(module, class_name)
         klass._import_ctx = _get_import_context(module)
         if klass._import_ctx.failed_import:

--- a/benchopt/utils/parametrized_name_mixin.py
+++ b/benchopt/utils/parametrized_name_mixin.py
@@ -383,6 +383,18 @@ def _extract_options(name):
             )
 
 
+def is_file_selector(pattern):
+    """Return True if a selector token points to a ``.py`` file.
+
+    The bracketed parameter part (``file.py[param=value]``) is ignored: only
+    the basename is inspected, so a selector resolves to a file as soon as its
+    name part ends with ``.py``.
+    """
+    if not isinstance(pattern, str):
+        return False
+    return _extract_options(pattern)[0].endswith(".py")
+
+
 def is_matched(name, include_patterns=None, default=True):
     """Check if a certain name is matched by any pattern in include_patterns.
 

--- a/doc/benchmark_workflow/manage_benchmark_results.rst
+++ b/doc/benchmark_workflow/manage_benchmark_results.rst
@@ -15,6 +15,9 @@ directory, with a ``.parquet`` file.
 By default, the name of the file include the date and time of the run,
 as ``benchopt_run_<date>_<time>.parquet`` but a custom name can be given using
 the :option:`--output` option of ``benchopt run``.
+A bare name is stored in ``./outputs``, while a value containing a path
+separator (e.g. ``--output /tmp/results.parquet``) is treated as an explicit
+path and written exactly there, leaving the benchmark directory untouched.
 The DataFrame contains the following columns:
 
 - ``objective_name|solver_name|dataset_name``: the names of the different benchopt

--- a/doc/benchmark_workflow/run_benchmark.rst
+++ b/doc/benchmark_workflow/run_benchmark.rst
@@ -118,6 +118,25 @@ This dataset has parameters ``n_samples`` and ``n_features`` that we set to ``10
 
     If a parameter of a solver/dataset is not explicitly set via CLI, benchopt uses all its values specified in the code.
 
+Selecting a solver or dataset from a file
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``-s`` and ``-d`` also accept a path to a ``.py`` file. The ``Solver`` /
+``Dataset`` class is then loaded directly from that file and added to the run,
+even if the file lives outside the benchmark's ``solvers/`` / ``datasets/``
+folders. This is handy to run a solver that is not part of the benchmark
+repository, e.g. a submission file, without copying it into the benchmark.
+
+.. prompt:: bash $
+
+    benchopt run . -s /path/to/my_solver.py -d /path/to/my_dataset.py
+
+The file is loaded with the benchmark on ``sys.path``, so it can still
+``import benchmark_utils``. Parameter sub-selection works as usual with the
+bracket syntax, e.g. ``-s "/path/to/my_solver.py[p1=1]"``. Because the file is
+matched exactly, this also avoids name collisions or glob characters that can
+occur with name-based selection.
+
 .. _run_with_config_file:
 
 Using a configuration file

--- a/doc/benchmark_workflow/write_benchmark.rst
+++ b/doc/benchmark_workflow/write_benchmark.rst
@@ -74,7 +74,8 @@ structure between the different components:
 All three component classes share the following features:
 
 - ``name``: human-readable identifier used to filter them in the CLI and to
-  identify the results in tables and plots.
+  identify the results in tables and plots. It must not contain a ``/``, which
+  would make it ambiguous with a ``-s``/``-d`` file selector.
 - ``requirements``: declare package dependencies for a component.
   See :ref:`specify_requirements`.
 - ``parameters``: run the same class with multiple configurations

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -17,6 +17,16 @@ Version 1.10.0 -- in development
 CLI
 ~~~
 
+- ``-s`` / ``-d`` now accept a path to a ``.py`` file, loading the
+  ``Solver`` / ``Dataset`` directly from that file (even outside the
+  benchmark's ``solvers/`` / ``datasets/`` folders), with optional
+  ``file.py[param=value]`` sub-selection. By `Thomas Moreau`_ (:gh:`1002`)
+
+- ``--output`` now accepts a path: a value containing a path separator is
+  written verbatim (leaving the benchmark folder untouched), while a bare
+  name still lands in ``<BENCHMARK>/outputs/``.
+  By `Thomas Moreau`_ (:gh:`1002`)
+
 - Add ``benchopt info -f <result_file>`` (repeatable, or ``-f all``) to
   summarize result file(s) instead of listing benchmark solvers/datasets;
   plain ``benchopt info`` now also lists available result files.

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -20,12 +20,12 @@ CLI
 - ``-s`` / ``-d`` now accept a path to a ``.py`` file, loading the
   ``Solver`` / ``Dataset`` directly from that file (even outside the
   benchmark's ``solvers/`` / ``datasets/`` folders), with optional
-  ``file.py[param=value]`` sub-selection. By `Thomas Moreau`_ (:gh:`1002`)
+  ``file.py[param=value]`` sub-selection. By `Thomas Moreau`_ (:gh:`1003`)
 
 - ``--output`` now accepts a path: a value containing a path separator is
   written verbatim (leaving the benchmark folder untouched), while a bare
   name still lands in ``<BENCHMARK>/outputs/``.
-  By `Thomas Moreau`_ (:gh:`1002`)
+  By `Thomas Moreau`_ (:gh:`1003`)
 
 - Add ``benchopt info -f <result_file>`` (repeatable, or ``-f all``) to
   summarize result file(s) instead of listing benchmark solvers/datasets;


### PR DESCRIPTION
When running competition or quick test, being able to run solver/dataset from different path can be helpful.
This PR implement this.

Also allow to output results somewhere else than in output.

### Checks before merging PR
- [x] added documentation for any new feature
- [x] added unit test
- [x] edited the [what's new](../../whatsnew.rst) (if applicable)
